### PR TITLE
Extra column added in item table

### DIFF
--- a/oc-includes/osclass/installer/struct.sql
+++ b/oc-includes/osclass/installer/struct.sql
@@ -215,6 +215,7 @@ CREATE TABLE /*TABLE_PREFIX*/t_item (
     dt_mod_date DATETIME NULL,
     f_price FLOAT NULL,
     i_price BIGINT(20) NULL,
+    s_post_type VARCHAR(100) NULL,
     fk_c_currency_code CHAR(3) NULL,
     s_contact_name VARCHAR(100) NULL,
     s_contact_email VARCHAR(140) NOT NULL,


### PR DESCRIPTION
Extra column added in item table which will extend the post type.
it will help to store/filter an item as a blog post, or custom posts,
@navjottomer i know it will list all posts, do we need to set the default as post " s_post_type VARCHAR(100) post,"?