### PR TITLE
SQL log - need to create queries.log - fix

### DIFF
--- a/oc-includes/osclass/Logger/LogDatabase.php
+++ b/oc-includes/osclass/Logger/LogDatabase.php
@@ -129,11 +129,7 @@
         {
             $filename = CONTENT_PATH . 'queries.log';
 
-            if( !file_exists($filename) || !is_writable($filename) ) {
-                return false;
-            }
-
-	        $fp = fopen( $filename , 'ab' );
+	    $fp = fopen( $filename , 'ab' );
 
             if( $fp == false ) {
                 return false;


### PR DESCRIPTION
Instead of manually creating queries.log every time, create it automatically when SQL debugging is enabled.

P.S. sorry for making a small mess with those pull requests, still new to GitHub, but I think I got it fixed.