### PR TITLE
Old link replace. with simple find, replace

### DIFF
--- a/oc-admin/login.php
+++ b/oc-admin/login.php
@@ -185,7 +185,7 @@
         function doView($file)
         {
             $login_admin_title = osc_apply_filter('login_admin_title', 'Osclass');
-            $login_admin_url   = osc_apply_filter('login_admin_url', 'http://osclass.org/');
+            $login_admin_url   = osc_apply_filter('login_admin_url', 'https://github.com/navjottomer/osclass/');
             $login_admin_image = osc_apply_filter('login_admin_image', osc_admin_base_url() . 'images/osclass-logo.gif');
 
             View::newInstance()->_exportVariableToView('login_admin_title', $login_admin_title);

--- a/oc-admin/themes/modern/functions.php
+++ b/oc-admin/themes/modern/functions.php
@@ -60,7 +60,7 @@ osc_add_hook('admin_header', 'admin_header_favicons');
 function admin_footer_html() { ?>
     <div class="float-left">
         <?php printf(__('Thank you for using <a href="%s" target="_blank">Osclass</a>'), 'https://github.com/navjottomer/Osclass/'); ?> -
-        <a title="<?php _e('Forums'); ?>" href="https://forums.osclasscommunity.com/" target="_blank"><?php _e('Forums'); ?></a> &middot;
+        <a title="<?php _e('Forums'); ?>" href="https://osclass.discourse.group" target="_blank"><?php _e('Forums'); ?></a> &middot;
         <a title="<?php _e('Report Issue'); ?>" href="https://github.com/navjottomer/Osclass/issues/" target="_blank"><?php _e('Report Issue'); ?></a>
     </div>
     <div class="float-right">

--- a/oc-admin/themes/modern/tools/upgrade.php
+++ b/oc-admin/themes/modern/tools/upgrade.php
@@ -41,7 +41,7 @@
                 var fileToUnzip = '';
                 steps.innerHTML += '<?php echo osc_esc_js( sprintf( __('Checking for updates (Current version %s)'), osc_version() )); ?> ';
 
-                $.getJSON("https://osclass.org/latest_version_v1.php?callback=?", function(data) {
+                $.getJSON("https://example.org/latest_version_v1.php?callback=?", function(data) {
                     if(data.version <= version) {
                         steps.innerHTML += '<?php echo osc_esc_js( __('Congratulations! Your Osclass installation is up to date!')); ?>';
                     } else {
@@ -105,7 +105,7 @@
                                 <div class="tools upgrade">
                                 <?php if( $ok ) { ?>
                                     <p class="text">
-                                        <?php printf( __('Your Osclass installation can be auto-upgraded. Please, back up your database and the folder oc-content before attempting to upgrade your Osclass installation. You can also upgrade Osclass manually, more information in the %s'), '<a href="http://doc.osclass.org/">Wiki</a>'); ?>
+                                        <?php printf( __('Your Osclass installation can be auto-upgraded. Please, back up your database and the folder oc-content before attempting to upgrade your Osclass installation. You can also upgrade Osclass manually, more information in the %s'), '<a href="https://osclass.gitbook.io/osclass-docs//">Wiki</a>'); ?>
                                     </p>
                                 <?php } else { ?>
                                     <p class="text">

--- a/oc-content/languages/ar_SY/core.po
+++ b/oc-content/languages/ar_SY/core.po
@@ -3256,8 +3256,8 @@ msgid "Your Osclass installation at %s is up and running. You can access the adm
 msgstr "تركيب Osclass الخاص بك على %s كامل ويعمل يمكنك الوصول إلى لوحة الإدارة بهذه التفاصيل:"
 
 #: oc-includes/osclass/install-location.php:105
-msgid "The <a href=\"http://osclass.org/\">Osclass</a> team"
-msgstr "فريق <a href=\"http://osclass.org/\">Osclass</a>"
+msgid "The <a href=\"https://github.com/navjottomer/osclass/\">Osclass</a> team"
+msgstr "فريق <a href=\"https://github.com/navjottomer/osclass/\">Osclass</a>"
 
 #: oc-includes/osclass/install.php:88
 msgid "Looks like you've already installed Osclass. To reinstall please clear your old database tables first."
@@ -3316,8 +3316,8 @@ msgid "We've encountered some problems while updating the database structure. Th
 msgstr "لقد واجهنا بعض المشاكل أثناء تحديث بنية قاعدة البيانات. الاستعلامات التالية فشلت:"
 
 #: oc-includes/osclass/upgrade-funcs.php:47
-msgid "These errors could be false-positive errors. If you're sure that is the case, you can <a href=\"%s\">continue with the upgrade</a>, or <a href=\"http://forums.osclass.org/\">ask in our forums</a>."
-msgstr "هذه الأخطاء يمكن أن تكون أخطاء إيجابية كاذبة. إذا كنت على يقين من هذه الحالة, تستطيع <a href=\"%s\">الاستمرار بالترقية</a>, او <a href=\"http://forums.osclass.org/\">طرح سؤال في المنتديات</a>."
+msgid "These errors could be false-positive errors. If you're sure that is the case, you can <a href=\"%s\">continue with the upgrade</a>, or <a href=\"https://osclass.discourse.group/\">ask in our forums</a>."
+msgstr "هذه الأخطاء يمكن أن تكون أخطاء إيجابية كاذبة. إذا كنت على يقين من هذه الحالة, تستطيع <a href=\"%s\">الاستمرار بالترقية</a>, او <a href=\"https://osclass.discourse.group/\">طرح سؤال في المنتديات</a>."
 
 #: oc-includes/osclass/upgrade-funcs.php:287
 msgid "You need to calculate location stats, please go to admin panel, tools, recalculate location stats or click"
@@ -3328,8 +3328,8 @@ msgid "Osclass &raquo; Updated correctly"
 msgstr "Osclass &raquo; تم تحديثه بشكل صحيح"
 
 #: oc-includes/osclass/upgrade-funcs.php:465
-msgid "Osclass has been updated successfully. <a href=\"http://forums.osclass.org/\">Need more help?</a>"
-msgstr "تم تحديث Osclass بنجاح . <a href=\"http://forums.osclass.org/\">تحتاج مساعدة?</a>"
+msgid "Osclass has been updated successfully. <a href=\"https://osclass.discourse.group/\">Need more help?</a>"
+msgstr "تم تحديث Osclass بنجاح . <a href=\"https://osclass.discourse.group/\">تحتاج مساعدة?</a>"
 
 #: oc-load.php:206
 msgid "The website is currently undergoing maintenance"

--- a/oc-content/languages/ar_SY/index.php
+++ b/oc-content/languages/ar_SY/index.php
@@ -26,7 +26,7 @@ function locale_ar_SY_info() {
         ,'description'     => 'Arabic translation'
         ,'version'         => '3.3.00'
         ,'author_name'     => 'Osclass'
-        ,'author_url'      => 'http://osclass.org/'
+        ,'author_url'      => 'https://github.com/navjottomer/osclass/'
         ,'currency_format' => '{NUMBER} {CURRENCY}'
         ,'date_format'     => 'm/d/Y'
         ,'stop_words'      => ''

--- a/oc-content/languages/ar_SY/messages.po
+++ b/oc-content/languages/ar_SY/messages.po
@@ -55,8 +55,8 @@ msgid "Your email has been sent properly."
 msgstr "تم ارسال رسالتك بالايميل بشكل سليم"
 
 #: oc-includes/osclass/upgrade-funcs.php:460
-msgid "Osclass has been updated successfully. <a href=\"http://forums.osclass.org/\">Need more help?</a>"
-msgstr "تم تحديث Osclass  بنجاح. <a href=\"http://forums.osclass.org/\">لمزيد من المساعدة</a>"
+msgid "Osclass has been updated successfully. <a href=\"https://osclass.discourse.group/\">Need more help?</a>"
+msgstr "تم تحديث Osclass  بنجاح. <a href=\"https://osclass.discourse.group/\">لمزيد من المساعدة</a>"
 
 #: oc-includes/osclass/controller/ajax.php:115
 #: oc-includes/osclass/controller/item.php:320

--- a/oc-content/languages/ar_SY/theme.po
+++ b/oc-content/languages/ar_SY/theme.po
@@ -30,8 +30,8 @@ msgstr "%1$d - %2$d من %3$d اعلانات"
 msgid "Premium listings"
 msgstr "اعلانات مميزة"
 
-msgid "http://osclass.org/"
-msgstr "http://osclass.org/"
+msgid "https://github.com/navjottomer/osclass/"
+msgstr "https://github.com/navjottomer/osclass/"
 
 msgid "Bender theme"
 msgstr "بندر ثيم"
@@ -148,12 +148,12 @@ msgid "Footer link"
 msgstr "رابط التذييل"
 
 #: admin/settings.php:45
-msgid "I want to help Osclass by linking to <a href=\"http://osclass.org/\" target=\"_blank\">osclass.org</a> from my site with the following text:"
-msgstr "اود مساعدة Osclass بربط <a href=\"http://osclass.org/\" target=\"_blank\">osclass.org</a>من موقعي بالنص التالي:"
+msgid "I want to help Osclass by linking to <a href=\"https://github.com/navjottomer/osclass/\" target=\"_blank\">osclass.org</a> from my site with the following text:"
+msgstr "اود مساعدة Osclass بربط <a href=\"https://github.com/navjottomer/osclass/\" target=\"_blank\">osclass.org</a>من موقعي بالنص التالي:"
 
 #: admin/settings.php:46
-msgid "This website is proudly using the <a title=\"Osclass web\" href=\"http://osclass.org/\">classifieds scripts</a> software <strong>Osclass</strong>"
-msgstr "هذا الموقع يستخدم بفخر <a title=\"Osclass web\" href=\"http://osclass.org/\">سكربت اعلانات مبوبة</a> برنامج <strong>Osclass</strong>"
+msgid "This website is proudly using the <a title=\"Osclass web\" href=\"https://github.com/navjottomer/osclass/\">classifieds scripts</a> software <strong>Osclass</strong>"
+msgstr "هذا الموقع يستخدم بفخر <a title=\"Osclass web\" href=\"https://github.com/navjottomer/osclass/\">سكربت اعلانات مبوبة</a> برنامج <strong>Osclass</strong>"
 
 #: admin/settings.php:50
 msgid "Save changes"

--- a/oc-content/languages/ca_ES/core.po
+++ b/oc-content/languages/ca_ES/core.po
@@ -1677,8 +1677,8 @@ msgid "Your Osclass installation at %s is up and running. You can access the adm
 msgstr "La teva instal·lació Osclass a %s funciona perfectament. Pots accedir al panell d'administració amb les següents dades: "
 
 #: oc-includes/osclass/install-location.php:107
-msgid "The <a href=\"http://osclass.org/\">Osclass</a> team"
-msgstr "L'equip d'<a href=\"http://osclass.org/\">Osclass</a> "
+msgid "The <a href=\"https://github.com/navjottomer/osclass/\">Osclass</a> team"
+msgstr "L'equip d'<a href=\"https://github.com/navjottomer/osclass/\">Osclass</a> "
 
 #: oc-includes/osclass/install.php:89
 msgid "Looks like you've already installed Osclass. To reinstall please clear your old database tables first."
@@ -1737,8 +1737,8 @@ msgid "We've encountered some problems while updating the database structure. Th
 msgstr "Hem trobat alguns problemes al actualitzar l'estructura de la base de dades. Han fallat les següents consultes:"
 
 #: oc-includes/osclass/upgrade-funcs.php:46
-msgid "These errors could be false-positive errors. If you're sure that is the case, you can <a href=\"%s\">continue with the upgrade</a>, or <a href=\"http://forums.osclass.org/\">ask in our forums</a>."
-msgstr "Aquests errors podrien ser falsos positius. Si no estàs segur, pots  <a href=\"%s\">continuar amb l'actualització</a>, o <a href=\"http://forums.osclass.org/\">preguntar als nostres forums</a>."
+msgid "These errors could be false-positive errors. If you're sure that is the case, you can <a href=\"%s\">continue with the upgrade</a>, or <a href=\"https://osclass.discourse.group/\">ask in our forums</a>."
+msgstr "Aquests errors podrien ser falsos positius. Si no estàs segur, pots  <a href=\"%s\">continuar amb l'actualització</a>, o <a href=\"https://osclass.discourse.group/\">preguntar als nostres forums</a>."
 
 #: oc-includes/osclass/upgrade-funcs.php:286
 msgid "You need to calculate location stats, please go to admin panel, tools, recalculate location stats or click"
@@ -1749,8 +1749,8 @@ msgid "Osclass &raquo; Updated correctly"
 msgstr "Osclass &raquo; actualitzat correctament"
 
 #: oc-includes/osclass/upgrade-funcs.php:521
-msgid "Osclass has been updated successfully. <a href=\"http://forums.osclass.org/\">Need more help?</a>"
-msgstr "Osclass s'ha actulitzat amb èxit. <a href=\"http://forums.osclass.org/\">Necessites ajuda?</a>"
+msgid "Osclass has been updated successfully. <a href=\"https://osclass.discourse.group/\">Need more help?</a>"
+msgstr "Osclass s'ha actulitzat amb èxit. <a href=\"https://osclass.discourse.group/\">Necessites ajuda?</a>"
 
 #: oc-load.php:214
 msgid "The website is currently undergoing maintenance"

--- a/oc-content/languages/ca_ES/index.php
+++ b/oc-content/languages/ca_ES/index.php
@@ -26,7 +26,7 @@ function locale_ca_ES_info() {
         ,'description'     => 'Catalan translation'
         ,'version'         => 'Osclass 3.5.0'
         ,'author_name'     => 'Osclass'
-        ,'author_url'      => 'http://osclass.org/'
+        ,'author_url'      => 'https://github.com/navjottomer/osclass/'
         ,'currency_format' => '{NUMBER} {CURRENCY}'
         ,'date_format'     => 'm/d/Y'
         ,'stop_words'      => ''

--- a/oc-content/languages/ca_ES/messages.po
+++ b/oc-content/languages/ca_ES/messages.po
@@ -1689,8 +1689,8 @@ msgid "Your email has been sent properly."
 msgstr "El teu email s'ha enviat correctament."
 
 #: oc-includes/osclass/upgrade-funcs.php:516
-msgid "Osclass has been updated successfully. <a href=\"http://forums.osclass.org/\">Need more help?</a>"
-msgstr "Osclass s'ha actualitzat amb èxit. <a href=\"http://forums.osclass.org/\">Necessites més ajuda?</a> "
+msgid "Osclass has been updated successfully. <a href=\"https://osclass.discourse.group/\">Need more help?</a>"
+msgstr "Osclass s'ha actualitzat amb èxit. <a href=\"https://osclass.discourse.group/\">Necessites més ajuda?</a> "
 
 #: oc-admin/plugins.php:231
 msgid "The files were deleted"

--- a/oc-content/languages/ca_ES/theme.po
+++ b/oc-content/languages/ca_ES/theme.po
@@ -119,12 +119,12 @@ msgid "Footer link"
 msgstr "Enllaç del peu"
 
 #: admin/settings.php:67
-msgid "I want to help Osclass by linking to <a href=\"http://osclass.org/\" target=\"_blank\">osclass.org</a> from my site with the following text:"
-msgstr "Vull ajudar a Osclass enllaçant a <a href=\"http://osclass.org/\" target=\"_blank\">osclass.org</a> des del meu lloc web amb aquest text:"
+msgid "I want to help Osclass by linking to <a href=\"https://github.com/navjottomer/osclass/\" target=\"_blank\">osclass.org</a> from my site with the following text:"
+msgstr "Vull ajudar a Osclass enllaçant a <a href=\"https://github.com/navjottomer/osclass/\" target=\"_blank\">osclass.org</a> des del meu lloc web amb aquest text:"
 
 #: admin/settings.php:68
-msgid "This website is proudly using the <a title=\"Osclass web\" href=\"http://osclass.org/\">classifieds scripts</a> software <strong>Osclass</strong>"
-msgstr "Aquesta web està fent servir el programari d'<a title=\"Osclass web\" href=\"http://osclass.org/\">anuncis classificats </a><strong>Osclass</strong>"
+msgid "This website is proudly using the <a title=\"Osclass web\" href=\"https://github.com/navjottomer/osclass/\">classifieds scripts</a> software <strong>Osclass</strong>"
+msgstr "Aquesta web està fent servir el programari d'<a title=\"Osclass web\" href=\"https://github.com/navjottomer/osclass/\">anuncis classificats </a><strong>Osclass</strong>"
 
 #: admin/settings.php:124
 msgid "Save changes"
@@ -798,8 +798,8 @@ msgstr "%1$d - %2$d of %3$d anuncis"
 msgid "Premium listings"
 msgstr "Anuncis Premium"
 
-msgid "http://osclass.org/"
-msgstr "http://osclass.org/"
+msgid "https://github.com/navjottomer/osclass/"
+msgstr "https://github.com/navjottomer/osclass/"
 
 msgid "Bender theme"
 msgstr "Tema Bender"

--- a/oc-content/languages/cs_CZ/core.po
+++ b/oc-content/languages/cs_CZ/core.po
@@ -3253,8 +3253,8 @@ msgid "Your Osclass installation at %s is up and running. You can access the adm
 msgstr "Vaše Osclass instalace %s běži. Do administračního panelu se dostanete použitím těchto informací:"
 
 #: oc-includes/osclass/install-location.php:105
-msgid "The <a href=\"http://osclass.org/\">Osclass</a> team"
-msgstr "<a href=\"http://osclass.org/\">Osclass</a> tým"
+msgid "The <a href=\"https://github.com/navjottomer/osclass/\">Osclass</a> team"
+msgstr "<a href=\"https://github.com/navjottomer/osclass/\">Osclass</a> tým"
 
 #: oc-includes/osclass/install.php:88
 msgid "Looks like you've already installed Osclass. To reinstall please clear your old database tables first."
@@ -3313,8 +3313,8 @@ msgid "We've encountered some problems while updating the database structure. Th
 msgstr "Vyskytl se problém během aktualizace databáze. Následující dotazy selhaly:"
 
 #: oc-includes/osclass/upgrade-funcs.php:47
-msgid "These errors could be false-positive errors. If you're sure that is the case, you can <a href=\"%s\">continue with the upgrade</a>, or <a href=\"http://forums.osclass.org/\">ask in our forums</a>."
-msgstr "Tyto chyby by mohly být falešně pozitivní chyby. Pokud jste si jisti, že je tomu tak, můžete <a href=\"%s\"> pokračovat s upgradem </a> nebo <a href=\"http://forums.osclass.org/\"> se zeptat v naše fórum </a>."
+msgid "These errors could be false-positive errors. If you're sure that is the case, you can <a href=\"%s\">continue with the upgrade</a>, or <a href=\"https://osclass.discourse.group/\">ask in our forums</a>."
+msgstr "Tyto chyby by mohly být falešně pozitivní chyby. Pokud jste si jisti, že je tomu tak, můžete <a href=\"%s\"> pokračovat s upgradem </a> nebo <a href=\"https://osclass.discourse.group/\"> se zeptat v naše fórum </a>."
 
 #: oc-includes/osclass/upgrade-funcs.php:287
 msgid "You need to calculate location stats, please go to admin panel, tools, recalculate location stats or click"
@@ -3325,8 +3325,8 @@ msgid "Osclass &raquo; Updated correctly"
 msgstr "Osclass &raquo; Úspěšně aktualizován"
 
 #: oc-includes/osclass/upgrade-funcs.php:465
-msgid "Osclass has been updated successfully. <a href=\"http://forums.osclass.org/\">Need more help?</a>"
-msgstr "Osclass byl úspěšně aktualizován. <a href=\"http://forums.osclass.org/\"> Potřebujete další pomoc? </a>"
+msgid "Osclass has been updated successfully. <a href=\"https://osclass.discourse.group/\">Need more help?</a>"
+msgstr "Osclass byl úspěšně aktualizován. <a href=\"https://osclass.discourse.group/\"> Potřebujete další pomoc? </a>"
 
 #: oc-load.php:206
 msgid "The website is currently undergoing maintenance"

--- a/oc-content/languages/cs_CZ/index.php
+++ b/oc-content/languages/cs_CZ/index.php
@@ -26,7 +26,7 @@ function locale_cs_CZ_info() {
         ,'description'     => 'Czech translation'
         ,'version'         => '3.3.00'
         ,'author_name'     => 'Osclass'
-        ,'author_url'      => 'http://osclass.org/'
+        ,'author_url'      => 'https://github.com/navjottomer/osclass/'
         ,'currency_format' => '{NUMBER} {CURRENCY}'
         ,'date_format'     => 'm/d/Y'
         ,'stop_words'      => ''

--- a/oc-content/languages/cs_CZ/messages.po
+++ b/oc-content/languages/cs_CZ/messages.po
@@ -55,8 +55,8 @@ msgid "Your email has been sent properly."
 msgstr "Váš e-mail byl řádně odeslán."
 
 #: oc-includes/osclass/upgrade-funcs.php:460
-msgid "Osclass has been updated successfully. <a href=\"http://forums.osclass.org/\">Need more help?</a>"
-msgstr "Osclass byl úspěšně aktualizován. <a href=\"http://forums.osclass.org/\"> Potřebujete další pomoc? </a>"
+msgid "Osclass has been updated successfully. <a href=\"https://osclass.discourse.group/\">Need more help?</a>"
+msgstr "Osclass byl úspěšně aktualizován. <a href=\"https://osclass.discourse.group/\"> Potřebujete další pomoc? </a>"
 
 #: oc-includes/osclass/controller/ajax.php:115
 #: oc-includes/osclass/controller/item.php:320

--- a/oc-content/languages/cs_CZ/theme.po
+++ b/oc-content/languages/cs_CZ/theme.po
@@ -30,8 +30,8 @@ msgstr "%1$d - %2$d of %3$d inzerátů"
 msgid "Premium listings"
 msgstr "Prémiové inzeráty"
 
-msgid "http://osclass.org/"
-msgstr "http://osclass.org/"
+msgid "https://github.com/navjottomer/osclass/"
+msgstr "https://github.com/navjottomer/osclass/"
 
 msgid "Bender theme"
 msgstr "Bender motiv"
@@ -148,12 +148,12 @@ msgid "Footer link"
 msgstr "Odkaz patičky"
 
 #: admin/settings.php:45
-msgid "I want to help Osclass by linking to <a href=\"http://osclass.org/\" target=\"_blank\">osclass.org</a> from my site with the following text:"
-msgstr "Chci pomoct Osclass umístěním odkazu <a href=\"http://osclass.org/\" target=\"_blank\">osclass.org</a> na můj web s následujícím textem:"
+msgid "I want to help Osclass by linking to <a href=\"https://github.com/navjottomer/osclass/\" target=\"_blank\">osclass.org</a> from my site with the following text:"
+msgstr "Chci pomoct Osclass umístěním odkazu <a href=\"https://github.com/navjottomer/osclass/\" target=\"_blank\">osclass.org</a> na můj web s následujícím textem:"
 
 #: admin/settings.php:46
-msgid "This website is proudly using the <a title=\"Osclass web\" href=\"http://osclass.org/\">classifieds scripts</a> software <strong>Osclass</strong>"
-msgstr "Tato webová stránka hrdě používá  <a title=\"Osclass web\" href=\"http://osclass.org/\">classifieds scripts</a> software <strong>Osclass</strong>"
+msgid "This website is proudly using the <a title=\"Osclass web\" href=\"https://github.com/navjottomer/osclass/\">classifieds scripts</a> software <strong>Osclass</strong>"
+msgstr "Tato webová stránka hrdě používá  <a title=\"Osclass web\" href=\"https://github.com/navjottomer/osclass/\">classifieds scripts</a> software <strong>Osclass</strong>"
 
 #: admin/settings.php:50
 msgid "Save changes"

--- a/oc-content/languages/da_DK/core.po
+++ b/oc-content/languages/da_DK/core.po
@@ -1677,8 +1677,8 @@ msgid "Your Osclass installation at %s is up and running. You can access the adm
 msgstr "Osclass installationen  %s  virker nu. For adgang til kontrolpanelet, brug disse oplysninger."
 
 #: oc-includes/osclass/install-location.php:107
-msgid "The <a href=\"http://osclass.org/\">Osclass</a> team"
-msgstr " The <a href=\"http://osclass.org/\">Osclass</a> Team"
+msgid "The <a href=\"https://github.com/navjottomer/osclass/\">Osclass</a> team"
+msgstr " The <a href=\"https://github.com/navjottomer/osclass/\">Osclass</a> Team"
 
 #: oc-includes/osclass/install.php:89
 msgid "Looks like you've already installed Osclass. To reinstall please clear your old database tables first."
@@ -1737,8 +1737,8 @@ msgid "We've encountered some problems while updating the database structure. Th
 msgstr "Der opstod problemer under DataBase opdateringen. Følgende forespørgsler mislykkedes:"
 
 #: oc-includes/osclass/upgrade-funcs.php:46
-msgid "These errors could be false-positive errors. If you're sure that is the case, you can <a href=\"%s\">continue with the upgrade</a>, or <a href=\"http://forums.osclass.org/\">ask in our forums</a>."
-msgstr "Disse fejl kan være urigtige, er du sikker på det er tilfældet, kan du <a href=\"%s\">fortsætte med at opdatere</a>, og eller <a href=\"http://forums.osclass.org/\"> finde svar eller spørge i vores forum</a>. "
+msgid "These errors could be false-positive errors. If you're sure that is the case, you can <a href=\"%s\">continue with the upgrade</a>, or <a href=\"https://osclass.discourse.group/\">ask in our forums</a>."
+msgstr "Disse fejl kan være urigtige, er du sikker på det er tilfældet, kan du <a href=\"%s\">fortsætte med at opdatere</a>, og eller <a href=\"https://osclass.discourse.group/\"> finde svar eller spørge i vores forum</a>. "
 
 #: oc-includes/osclass/upgrade-funcs.php:286
 msgid "You need to calculate location stats, please go to admin panel, tools, recalculate location stats or click"
@@ -1749,8 +1749,8 @@ msgid "Osclass &raquo; Updated correctly"
 msgstr "Osclass &raquo; er opdateret korrekt"
 
 #: oc-includes/osclass/upgrade-funcs.php:521
-msgid "Osclass has been updated successfully. <a href=\"http://forums.osclass.org/\">Need more help?</a>"
-msgstr "Osclass blev opdateret korrekt. <a href=\"http://forums.osclass.org/\">BRUG: forums for mere selv hjælp</a>"
+msgid "Osclass has been updated successfully. <a href=\"https://osclass.discourse.group/\">Need more help?</a>"
+msgstr "Osclass blev opdateret korrekt. <a href=\"https://osclass.discourse.group/\">BRUG: forums for mere selv hjælp</a>"
 
 #: oc-load.php:214
 msgid "The website is currently undergoing maintenance"

--- a/oc-content/languages/da_DK/index.php
+++ b/oc-content/languages/da_DK/index.php
@@ -26,7 +26,7 @@ function locale_da_DK_info() {
         ,'description'     => 'Danish translation'
         ,'version'         => 'Osclass 3.5.0'
         ,'author_name'     => 'Osclass'
-        ,'author_url'      => 'http://osclass.org/'
+        ,'author_url'      => 'https://github.com/navjottomer/osclass/'
         ,'currency_format' => '{NUMBER} {CURRENCY}'
         ,'date_format'     => 'm/d/Y'
         ,'stop_words'      => ''

--- a/oc-content/languages/da_DK/messages.po
+++ b/oc-content/languages/da_DK/messages.po
@@ -1689,8 +1689,8 @@ msgid "Your email has been sent properly."
 msgstr "Din E.Mail er afsendt korrekt"
 
 #: oc-includes/osclass/upgrade-funcs.php:516
-msgid "Osclass has been updated successfully. <a href=\"http://forums.osclass.org/\">Need more help?</a>"
-msgstr "Osclass blev opdateret korrekt. <a href=\"http://forums.osclass.org/\">BRUG: forums for mere selv hjælp</a>"
+msgid "Osclass has been updated successfully. <a href=\"https://osclass.discourse.group/\">Need more help?</a>"
+msgstr "Osclass blev opdateret korrekt. <a href=\"https://osclass.discourse.group/\">BRUG: forums for mere selv hjælp</a>"
 
 #: oc-admin/plugins.php:231
 msgid "The files were deleted"

--- a/oc-content/languages/da_DK/theme.po
+++ b/oc-content/languages/da_DK/theme.po
@@ -119,12 +119,12 @@ msgid "Footer link"
 msgstr "Footer link"
 
 #: admin/settings.php:67
-msgid "I want to help Osclass by linking to <a href=\"http://osclass.org/\" target=\"_blank\">osclass.org</a> from my site with the following text:"
-msgstr "Jeg ønsker at hjælpe med et link til <a href=\"http://osclass.org/\" target=\"_blank\">osclass.org</a> fra min side med teksten:"
+msgid "I want to help Osclass by linking to <a href=\"https://github.com/navjottomer/osclass/\" target=\"_blank\">osclass.org</a> from my site with the following text:"
+msgstr "Jeg ønsker at hjælpe med et link til <a href=\"https://github.com/navjottomer/osclass/\" target=\"_blank\">osclass.org</a> fra min side med teksten:"
 
 #: admin/settings.php:68
-msgid "This website is proudly using the <a title=\"Osclass web\" href=\"http://osclass.org/\">classifieds scripts</a> software <strong>Osclass</strong>"
-msgstr "Denne websides lynhurtige kode motor bruger: <a title=\"Osclass web\" href=\"http://osclass.org/\">Osclass software</a>"
+msgid "This website is proudly using the <a title=\"Osclass web\" href=\"https://github.com/navjottomer/osclass/\">classifieds scripts</a> software <strong>Osclass</strong>"
+msgstr "Denne websides lynhurtige kode motor bruger: <a title=\"Osclass web\" href=\"https://github.com/navjottomer/osclass/\">Osclass software</a>"
 
 #: admin/settings.php:124
 msgid "Save changes"
@@ -798,7 +798,7 @@ msgstr "%1$d til %2$d af %3$d annoncer"
 msgid "Premium listings"
 msgstr "Premium annoncer"
 
-msgid "http://osclass.org/"
+msgid "https://github.com/navjottomer/osclass/"
 msgstr "http://www.osclass.com/"
 
 msgid "Bender theme"

--- a/oc-content/languages/de_DE/core.po
+++ b/oc-content/languages/de_DE/core.po
@@ -5349,8 +5349,8 @@ msgid "Your Osclass installation at %s is up and running. You can access the adm
 msgstr "Ihre Osclass-Installation auf %s wurde erfolgreich eingerichtet. Sie können auf die Adminkonsole mit diesen Daten zugreifen:"
 
 #: oc-includes/osclass/install-location.php:107
-msgid "The <a href=\"http://osclass.org/\">Osclass</a> team"
-msgstr "Das <a href=\"http://osclass.org/\">Osclass</a> Team"
+msgid "The <a href=\"https://github.com/navjottomer/osclass/\">Osclass</a> team"
+msgstr "Das <a href=\"https://github.com/navjottomer/osclass/\">Osclass</a> Team"
 
 #: oc-includes/osclass/install.php:89
 msgid "Looks like you've already installed Osclass. To reinstall please clear your old database tables first."
@@ -5409,8 +5409,8 @@ msgid "We've encountered some problems while updating the database structure. Th
 msgstr "Es sind Probleme beim Aktualisieren der Datenbankstruktur aufgetreten. Die folgenden Abfragen sind fehlgeschlagen:"
 
 #: oc-includes/osclass/upgrade-funcs.php:46
-msgid "These errors could be false-positive errors. If you're sure that is the case, you can <a href=\"%s\">continue with the upgrade</a>, or <a href=\"http://forums.osclass.org/\">ask in our forums</a>."
-msgstr "Diese Fehler können eine Falschmeldung sein. Wenn Sie sich sicher sind, dass dies der Fall ist, können Sie <a href=\"%s\">mit dem Upgrade fortfahren</a>, oder <a href=\"http://forums.osclass.org/\">in unserem Forum nachfragen</a>."
+msgid "These errors could be false-positive errors. If you're sure that is the case, you can <a href=\"%s\">continue with the upgrade</a>, or <a href=\"https://osclass.discourse.group/\">ask in our forums</a>."
+msgstr "Diese Fehler können eine Falschmeldung sein. Wenn Sie sich sicher sind, dass dies der Fall ist, können Sie <a href=\"%s\">mit dem Upgrade fortfahren</a>, oder <a href=\"https://osclass.discourse.group/\">in unserem Forum nachfragen</a>."
 
 #: oc-includes/osclass/upgrade-funcs.php:286
 msgid "You need to calculate location stats, please go to admin panel, tools, recalculate location stats or click"
@@ -5421,8 +5421,8 @@ msgid "Osclass &raquo; Updated correctly"
 msgstr "Osclass &raquo; erfolgreich aktualisiert"
 
 #: oc-includes/osclass/upgrade-funcs.php:475
-msgid "Osclass has been updated successfully. <a href=\"http://forums.osclass.org/\">Need more help?</a>"
-msgstr "Osclass wurde erfolgreich aktualisiert. <a href=\"http://forums.osclass.org/\">Weitere Hilfe nötig?</a>"
+msgid "Osclass has been updated successfully. <a href=\"https://osclass.discourse.group/\">Need more help?</a>"
+msgstr "Osclass wurde erfolgreich aktualisiert. <a href=\"https://osclass.discourse.group/\">Weitere Hilfe nötig?</a>"
 
 #: oc-load.php:210
 msgid "The website is currently undergoing maintenance"

--- a/oc-content/languages/de_DE/index.php
+++ b/oc-content/languages/de_DE/index.php
@@ -26,7 +26,7 @@ function locale_de_DE_info() {
         ,'description'     => 'German translation'
         ,'version'         => 'Osclass 3.4.0'
         ,'author_name'     => 'Osclass'
-        ,'author_url'      => 'http://osclass.org/'
+        ,'author_url'      => 'https://github.com/navjottomer/osclass/'
         ,'currency_format' => '{NUMBER} {CURRENCY}'
         ,'date_format'     => 'm/d/Y'
         ,'stop_words'      => ''

--- a/oc-content/languages/de_DE/messages.po
+++ b/oc-content/languages/de_DE/messages.po
@@ -1696,8 +1696,8 @@ msgid "Your email has been sent properly."
 msgstr "Ihre Mail wurde erfolgreich gesendet."
 
 #: oc-includes/osclass/upgrade-funcs.php:470
-msgid "Osclass has been updated successfully. <a href=\"http://forums.osclass.org/\">Need more help?</a>"
-msgstr "Osclass wurde erfolgreich aktualisiert. <a href=\"http://forums.osclass.org/\">Benötigen Sie Hilfe?</a>"
+msgid "Osclass has been updated successfully. <a href=\"https://osclass.discourse.group/\">Need more help?</a>"
+msgstr "Osclass wurde erfolgreich aktualisiert. <a href=\"https://osclass.discourse.group/\">Benötigen Sie Hilfe?</a>"
 
 #: oc-admin/plugins.php:231
 msgid "The files were deleted"

--- a/oc-content/languages/de_DE/theme.po
+++ b/oc-content/languages/de_DE/theme.po
@@ -119,12 +119,12 @@ msgid "Footer link"
 msgstr "Link in der Fußzeile"
 
 #: admin/settings.php:67
-msgid "I want to help Osclass by linking to <a href=\"http://osclass.org/\" target=\"_blank\">osclass.org</a> from my site with the following text:"
-msgstr "I möchte Osclass helfen, indem ich einen Link <a href=\"http://osclass.org/\" target=\"_blank\">osclass.org</a> auf meiner Seite mit folgendem Text anzeige:"
+msgid "I want to help Osclass by linking to <a href=\"https://github.com/navjottomer/osclass/\" target=\"_blank\">osclass.org</a> from my site with the following text:"
+msgstr "I möchte Osclass helfen, indem ich einen Link <a href=\"https://github.com/navjottomer/osclass/\" target=\"_blank\">osclass.org</a> auf meiner Seite mit folgendem Text anzeige:"
 
 #: admin/settings.php:68
-msgid "This website is proudly using the <a title=\"Osclass web\" href=\"http://osclass.org/\">classifieds scripts</a> software <strong>Osclass</strong>"
-msgstr "Diese Website ist stolz darauf, basierend auf der Software von <a title=\"Osclass web\" href=\"http://osclass.org/\">classifieds scripts</a><strong></strong> zu laufen."
+msgid "This website is proudly using the <a title=\"Osclass web\" href=\"https://github.com/navjottomer/osclass/\">classifieds scripts</a> software <strong>Osclass</strong>"
+msgstr "Diese Website ist stolz darauf, basierend auf der Software von <a title=\"Osclass web\" href=\"https://github.com/navjottomer/osclass/\">classifieds scripts</a><strong></strong> zu laufen."
 
 #: admin/settings.php:72
 msgid "Save changes"
@@ -801,8 +801,8 @@ msgstr "%1$d - %2$d von %3$d Anzeigen"
 msgid "Premium listings"
 msgstr "Premium-Anzeigen"
 
-msgid "http://osclass.org/"
-msgstr "http://osclass.org/"
+msgid "https://github.com/navjottomer/osclass/"
+msgstr "https://github.com/navjottomer/osclass/"
 
 msgid "Bender theme"
 msgstr "&quot;Bender&quot;-Thema"

--- a/oc-content/languages/el_GR/core.po
+++ b/oc-content/languages/el_GR/core.po
@@ -5267,8 +5267,8 @@ msgid "Your Osclass installation at %s is up and running. You can access the adm
 msgstr "Εγκατάσταση Osclass σας στο %s είναι έτοιμη και λειτουργεί. Μπορείτε να αποκτήσετε πρόσβαση στο πίνακα διαχείρισης με αυτές τις λεπτομέρειες:"
 
 #: oc-includes/osclass/install-location.php:105
-msgid "The <a href=\"http://osclass.org/\">Osclass</a> team"
-msgstr "The <a href=\"http://osclass.org/\">Osclass</a> team"
+msgid "The <a href=\"https://github.com/navjottomer/osclass/\">Osclass</a> team"
+msgstr "The <a href=\"https://github.com/navjottomer/osclass/\">Osclass</a> team"
 
 #: oc-includes/osclass/install.php:88
 msgid "Looks like you've already installed Osclass. To reinstall please clear your old database tables first."
@@ -5327,8 +5327,8 @@ msgid "We've encountered some problems while updating the database structure. Th
 msgstr "Έχουμε αντιμετωπίσει κάποια προβλήματα κατά την ενημέρωση της δομής της βάσης. Τα ακόλουθα ερωτήματα απέτυχε:"
 
 #: oc-includes/osclass/upgrade-funcs.php:47
-msgid "These errors could be false-positive errors. If you're sure that is the case, you can <a href=\"%s\">continue with the upgrade</a>, or <a href=\"http://forums.osclass.org/\">ask in our forums</a>."
-msgstr "Αυτά τα λάθη θα μπορούσε να δώσει ψευδώς θετικά λάθη. Εάν είστε βέβαιοι ότι είναι η περίπτωση, μπορείτε να <a href=\"%s\">continue with the upgrade</a>, or <a href=\"http://forums.osclass.org/\">ask in our forums</a>."
+msgid "These errors could be false-positive errors. If you're sure that is the case, you can <a href=\"%s\">continue with the upgrade</a>, or <a href=\"https://osclass.discourse.group/\">ask in our forums</a>."
+msgstr "Αυτά τα λάθη θα μπορούσε να δώσει ψευδώς θετικά λάθη. Εάν είστε βέβαιοι ότι είναι η περίπτωση, μπορείτε να <a href=\"%s\">continue with the upgrade</a>, or <a href=\"https://osclass.discourse.group/\">ask in our forums</a>."
 
 #: oc-includes/osclass/upgrade-funcs.php:287
 msgid "You need to calculate location stats, please go to admin panel, tools, recalculate location stats or click"
@@ -5339,8 +5339,8 @@ msgid "Osclass &raquo; Updated correctly"
 msgstr "Osclass &raquo; Έχουν αναβαθμιστεί σωστά"
 
 #: oc-includes/osclass/upgrade-funcs.php:447
-msgid "Osclass has been updated successfully. <a href=\"http://forums.osclass.org/\">Need more help?</a>"
-msgstr "Osclass έχει ενημερωθεί με επιτυχία.<a href=\"http://forums.osclass.org/\">Need more help?</a>"
+msgid "Osclass has been updated successfully. <a href=\"https://osclass.discourse.group/\">Need more help?</a>"
+msgstr "Osclass έχει ενημερωθεί με επιτυχία.<a href=\"https://osclass.discourse.group/\">Need more help?</a>"
 
 #: oc-load.php:206
 msgid "The website is currently undergoing maintenance"

--- a/oc-content/languages/el_GR/index.php
+++ b/oc-content/languages/el_GR/index.php
@@ -26,7 +26,7 @@ function locale_el_GR_info() {
         ,'description'     => 'Greek translation'
         ,'version'         => 'Dev version'
         ,'author_name'     => 'Osclass'
-        ,'author_url'      => 'http://osclass.org/'
+        ,'author_url'      => 'https://github.com/navjottomer/osclass/'
         ,'currency_format' => '{NUMBER} {CURRENCY}'
         ,'date_format'     => 'm/d/Y'
         ,'stop_words'      => ''

--- a/oc-content/languages/el_GR/theme.po
+++ b/oc-content/languages/el_GR/theme.po
@@ -119,12 +119,12 @@ msgid "Footer link"
 msgstr "Σύνδεσμος στο footer(Υποσέλιδο)"
 
 #: admin/settings.php:45
-msgid "I want to help Osclass by linking to <a href=\"http://osclass.org/\" target=\"_blank\">osclass.org</a> from my site with the following text:"
-msgstr "Θέλω να βοηθήσω το Osclass λινκ-άρωντας  στο <a href=\"http://osclass.org/\" target=\"_blank\">osclass.org</a>απο την σελίδα μου με το παρακάτω κείμενοt:"
+msgid "I want to help Osclass by linking to <a href=\"https://github.com/navjottomer/osclass/\" target=\"_blank\">osclass.org</a> from my site with the following text:"
+msgstr "Θέλω να βοηθήσω το Osclass λινκ-άρωντας  στο <a href=\"https://github.com/navjottomer/osclass/\" target=\"_blank\">osclass.org</a>απο την σελίδα μου με το παρακάτω κείμενοt:"
 
 #: admin/settings.php:46
-msgid "This website is proudly using the <a title=\"Osclass web\" href=\"http://osclass.org/\">classifieds scripts</a> software <strong>Osclass</strong>"
-msgstr "Αυτή η ιστοσελίδα χρησιμοποιεί με υπερηφάνεια το <a title=\"Osclass web\" href=\"http://osclass.org/\">classifieds scripts</a> software <strong>Osclass</strong>"
+msgid "This website is proudly using the <a title=\"Osclass web\" href=\"https://github.com/navjottomer/osclass/\">classifieds scripts</a> software <strong>Osclass</strong>"
+msgstr "Αυτή η ιστοσελίδα χρησιμοποιεί με υπερηφάνεια το <a title=\"Osclass web\" href=\"https://github.com/navjottomer/osclass/\">classifieds scripts</a> software <strong>Osclass</strong>"
 
 #: admin/settings.php:50
 msgid "Save changes"

--- a/oc-content/languages/en_US/core.po
+++ b/oc-content/languages/en_US/core.po
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Osclass\n"
-"Report-Msgid-Bugs-To: http://osclass.org/\n"
+"Report-Msgid-Bugs-To: https://github.com/navjottomer/osclass/\n"
 "POT-Creation-Date: 2016-12-12 15:46:28+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -6260,7 +6260,7 @@ msgstr ""
 
 #: oc-includes/osclass/install-functions.php:834
 msgid ""
-"(You agree to our <a href=\"https://osclass.org/page/legal-note\">Terms & "
+"(You agree to our <a href=\"https://example.org/page/legal-note\">Terms & "
 "Conditions</a>)"
 msgstr ""
 
@@ -6397,7 +6397,7 @@ msgid "Cheers,"
 msgstr ""
 
 #: oc-includes/osclass/install-location.php:121
-msgid "The <a href=\"http://osclass.org/\">Osclass</a> team"
+msgid "The <a href=\"https://github.com/navjottomer/osclass/\">Osclass</a> team"
 msgstr ""
 
 #: oc-includes/osclass/install.php:89
@@ -6902,7 +6902,7 @@ msgstr ""
 msgid ""
 "These errors could be false-positive errors. If you're sure that is the "
 "case, you can <a href=\"%s\">continue with the upgrade</a>, or <a href="
-"\"http://forums.osclass.org/\">ask in our forums</a>."
+"\"https://osclass.discourse.group/\">ask in our forums</a>."
 msgstr ""
 
 #: oc-includes/osclass/upgrade-funcs.php:286
@@ -6921,7 +6921,7 @@ msgstr ""
 
 #: oc-includes/osclass/upgrade-funcs.php:533
 msgid ""
-"Osclass has been updated successfully. <a href=\"http://forums.osclass.org/"
+"Osclass has been updated successfully. <a href=\"https://osclass.discourse.group/"
 "\">Need more help?</a>"
 msgstr ""
 

--- a/oc-content/languages/en_US/index.php
+++ b/oc-content/languages/en_US/index.php
@@ -22,7 +22,7 @@ function locale_en_US_info() {
         ,'description'     => 'American english translation'
         ,'version'         => 2.3
         ,'author_name'     => 'Osclass'
-        ,'author_url'      => 'http://osclass.org/'
+        ,'author_url'      => 'https://github.com/navjottomer/osclass/'
         ,'currency_format' => '{NUMBER} {CURRENCY}'
         ,'date_format'     => 'm/d/Y'
         ,'stop_words'      => 'i,a,about,an,are,as,at,be,by,com,for,from,how,in,is,it,of,on,or,that,the,this,to,was,what,when,where,who,will,with,the'

--- a/oc-content/languages/en_US/messages.po
+++ b/oc-content/languages/en_US/messages.po
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Osclass\n"
-"Report-Msgid-Bugs-To: http://osclass.org/\n"
+"Report-Msgid-Bugs-To: https://github.com/navjottomer/osclass/\n"
 "POT-Creation-Date: 2017-04-24 06:56:42+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1787,6 +1787,6 @@ msgstr ""
 
 #: oc-includes/osclass/upgrade-funcs.php:532
 msgid ""
-"Osclass has been updated successfully. <a href=\"http://forums.osclass.org/"
+"Osclass has been updated successfully. <a href=\"https://osclass.discourse.group/"
 "\">Need more help?</a>"
 msgstr ""

--- a/oc-content/languages/en_US/theme.po
+++ b/oc-content/languages/en_US/theme.po
@@ -128,7 +128,7 @@ msgstr ""
 
 #: admin/settings.php:68
 msgid ""
-"I want to help Osclass by linking to <a href=\"http://osclass.org/\" target="
+"I want to help Osclass by linking to <a href=\"https://github.com/navjottomer/osclass/\" target="
 "\"_blank\">osclass.org</a> from my site with the following text:"
 msgstr ""
 

--- a/oc-content/languages/es_ES/core.po
+++ b/oc-content/languages/es_ES/core.po
@@ -1677,8 +1677,8 @@ msgid "Your Osclass installation at %s is up and running. You can access the adm
 msgstr "Tu instalación Osclass en %s está en marcha. Puedes acceder el panel de administración con los datos siguientes:"
 
 #: oc-includes/osclass/install-location.php:107
-msgid "The <a href=\"http://osclass.org/\">Osclass</a> team"
-msgstr "Equipo <a href=\"http://osclass.org/\">Osclass</a>"
+msgid "The <a href=\"https://github.com/navjottomer/osclass/\">Osclass</a> team"
+msgstr "Equipo <a href=\"https://github.com/navjottomer/osclass/\">Osclass</a>"
 
 #: oc-includes/osclass/install.php:89
 msgid "Looks like you've already installed Osclass. To reinstall please clear your old database tables first."
@@ -1737,8 +1737,8 @@ msgid "We've encountered some problems while updating the database structure. Th
 msgstr "Hemos encontrado algunos problemas al actualizar la estructura de la base de datos. Las siguientes consultas han fallado:"
 
 #: oc-includes/osclass/upgrade-funcs.php:46
-msgid "These errors could be false-positive errors. If you're sure that is the case, you can <a href=\"%s\">continue with the upgrade</a>, or <a href=\"http://forums.osclass.org/\">ask in our forums</a>."
-msgstr "Estos errores podrían ser falso-positivo. Si estás seguro que es así, puedes <a href=\"%s\">continuar con la actualización</a> o <a href=\"http://forums.osclass.org/\">consultarlo en el foro</a>."
+msgid "These errors could be false-positive errors. If you're sure that is the case, you can <a href=\"%s\">continue with the upgrade</a>, or <a href=\"https://osclass.discourse.group/\">ask in our forums</a>."
+msgstr "Estos errores podrían ser falso-positivo. Si estás seguro que es así, puedes <a href=\"%s\">continuar con la actualización</a> o <a href=\"https://osclass.discourse.group/\">consultarlo en el foro</a>."
 
 #: oc-includes/osclass/upgrade-funcs.php:286
 msgid "You need to calculate location stats, please go to admin panel, tools, recalculate location stats or click"
@@ -1749,8 +1749,8 @@ msgid "Osclass &raquo; Updated correctly"
 msgstr "Osclass &raquo; Actualizado correctamente."
 
 #: oc-includes/osclass/upgrade-funcs.php:521
-msgid "Osclass has been updated successfully. <a href=\"http://forums.osclass.org/\">Need more help?</a>"
-msgstr "Osclass ha sido actualizado con éxito. <a href=\"http://forums.osclass.org/\">¿Necesitas más ayuda?</a>"
+msgid "Osclass has been updated successfully. <a href=\"https://osclass.discourse.group/\">Need more help?</a>"
+msgstr "Osclass ha sido actualizado con éxito. <a href=\"https://osclass.discourse.group/\">¿Necesitas más ayuda?</a>"
 
 #: oc-load.php:214
 msgid "The website is currently undergoing maintenance"

--- a/oc-content/languages/es_ES/index.php
+++ b/oc-content/languages/es_ES/index.php
@@ -26,7 +26,7 @@ function locale_es_ES_info() {
         ,'description'     => 'Spanish (Spain) translation'
         ,'version'         => 'Osclass 3.5.0'
         ,'author_name'     => 'Osclass'
-        ,'author_url'      => 'http://osclass.org/'
+        ,'author_url'      => 'https://github.com/navjottomer/osclass/'
         ,'currency_format' => '{NUMBER} {CURRENCY}'
         ,'date_format'     => 'm/d/Y'
         ,'stop_words'      => ''

--- a/oc-content/languages/es_ES/messages.po
+++ b/oc-content/languages/es_ES/messages.po
@@ -1689,8 +1689,8 @@ msgid "Your email has been sent properly."
 msgstr "Tu email ha sido enviado con éxito."
 
 #: oc-includes/osclass/upgrade-funcs.php:516
-msgid "Osclass has been updated successfully. <a href=\"http://forums.osclass.org/\">Need more help?</a>"
-msgstr "Osclass ha sido actualizado con éxito. <a href=\"http://forums.osclass.org/\">¿Necesitas más ayuda?</a>"
+msgid "Osclass has been updated successfully. <a href=\"https://osclass.discourse.group/\">Need more help?</a>"
+msgstr "Osclass ha sido actualizado con éxito. <a href=\"https://osclass.discourse.group/\">¿Necesitas más ayuda?</a>"
 
 #: oc-admin/plugins.php:231
 msgid "The files were deleted"

--- a/oc-content/languages/es_ES/theme.po
+++ b/oc-content/languages/es_ES/theme.po
@@ -119,12 +119,12 @@ msgid "Footer link"
 msgstr "Enlace del footer"
 
 #: admin/settings.php:67
-msgid "I want to help Osclass by linking to <a href=\"http://osclass.org/\" target=\"_blank\">osclass.org</a> from my site with the following text:"
-msgstr "Quiero ayudar a Osclass, mostrando el enlace a <a href=\"http://osclass.org/\" target=\"_blank\">osclass.org</a> desde mi página web con el siguiente texto:"
+msgid "I want to help Osclass by linking to <a href=\"https://github.com/navjottomer/osclass/\" target=\"_blank\">osclass.org</a> from my site with the following text:"
+msgstr "Quiero ayudar a Osclass, mostrando el enlace a <a href=\"https://github.com/navjottomer/osclass/\" target=\"_blank\">osclass.org</a> desde mi página web con el siguiente texto:"
 
 #: admin/settings.php:68
-msgid "This website is proudly using the <a title=\"Osclass web\" href=\"http://osclass.org/\">classifieds scripts</a> software <strong>Osclass</strong>"
-msgstr "Este sitio web utiliza <a title=\"Osclass web\" href=\"http://osclass.org/\">el script de clasificados</a> <strong>Osclass</strong>"
+msgid "This website is proudly using the <a title=\"Osclass web\" href=\"https://github.com/navjottomer/osclass/\">classifieds scripts</a> software <strong>Osclass</strong>"
+msgstr "Este sitio web utiliza <a title=\"Osclass web\" href=\"https://github.com/navjottomer/osclass/\">el script de clasificados</a> <strong>Osclass</strong>"
 
 #: admin/settings.php:124
 msgid "Save changes"
@@ -798,8 +798,8 @@ msgstr "%1$d - %2$d of %3$d anuncios"
 msgid "Premium listings"
 msgstr "Anuncios premium"
 
-msgid "http://osclass.org/"
-msgstr "http://osclass.org/"
+msgid "https://github.com/navjottomer/osclass/"
+msgstr "https://github.com/navjottomer/osclass/"
 
 msgid "Bender theme"
 msgstr "Tema Bender"

--- a/oc-content/languages/fa_IR/core.po
+++ b/oc-content/languages/fa_IR/core.po
@@ -5265,8 +5265,8 @@ msgid "Your Osclass installation at %s is up and running. You can access the adm
 msgstr "نصب او اس کلاس شما در %s بالا و در حال اجرا است. شما می توانید با جزئیات زیر به پنل مدیریت دسترسی داشته باشید:"
 
 #: oc-includes/osclass/install-location.php:105
-msgid "The <a href=\"http://osclass.org/\">Osclass</a> team"
-msgstr "تیم <a href=\"http://osclass.org/\">او اس کلاس</a>"
+msgid "The <a href=\"https://github.com/navjottomer/osclass/\">Osclass</a> team"
+msgstr "تیم <a href=\"https://github.com/navjottomer/osclass/\">او اس کلاس</a>"
 
 #: oc-includes/osclass/install.php:88
 msgid "Looks like you've already installed Osclass. To reinstall please clear your old database tables first."
@@ -5325,7 +5325,7 @@ msgid "We've encountered some problems while updating the database structure. Th
 msgstr "در حین بروز رسانی ساختار پایگاه داده با برخی مشکلات روبرو شدیم. نمایش اعمال ناموفق در زیر:"
 
 #: oc-includes/osclass/upgrade-funcs.php:47
-msgid "These errors could be false-positive errors. If you're sure that is the case, you can <a href=\"%s\">continue with the upgrade</a>, or <a href=\"http://forums.osclass.org/\">ask in our forums</a>."
+msgid "These errors could be false-positive errors. If you're sure that is the case, you can <a href=\"%s\">continue with the upgrade</a>, or <a href=\"https://osclass.discourse.group/\">ask in our forums</a>."
 msgstr "اين خطاها مي تواند خطای درست و غلط باشد. اگر شما مطمئن هستید در این مورد، شما میتوانید <a href=\"%s\">ادامه دهید به کار ارتقا</a>، يا <a href=\"http://forum.faosclass.com/\">در انجمن های گفتگو بپرسید</a>."
 
 #: oc-includes/osclass/upgrade-funcs.php:287
@@ -5337,8 +5337,8 @@ msgid "Osclass &raquo; Updated correctly"
 msgstr "او اس کلاس &raquo; به درستی به روز شده"
 
 #: oc-includes/osclass/upgrade-funcs.php:447
-msgid "Osclass has been updated successfully. <a href=\"http://forums.osclass.org/\">Need more help?</a>"
-msgstr "او اس کلاس با موفقیت ارتقا یافت. <a href=\"http://forums.osclass.org/\">کمک بیشتری نیاز دارید؟</a>"
+msgid "Osclass has been updated successfully. <a href=\"https://osclass.discourse.group/\">Need more help?</a>"
+msgstr "او اس کلاس با موفقیت ارتقا یافت. <a href=\"https://osclass.discourse.group/\">کمک بیشتری نیاز دارید؟</a>"
 
 #: oc-load.php:206
 msgid "The website is currently undergoing maintenance"

--- a/oc-content/languages/fa_IR/index.php
+++ b/oc-content/languages/fa_IR/index.php
@@ -26,7 +26,7 @@ function locale_fa_IR_info() {
         ,'description'     => 'Persian translation'
         ,'version'         => 'Dev version'
         ,'author_name'     => 'Osclass'
-        ,'author_url'      => 'http://osclass.org/'
+        ,'author_url'      => 'https://github.com/navjottomer/osclass/'
         ,'currency_format' => '{NUMBER} {CURRENCY}'
         ,'date_format'     => 'm/d/Y'
         ,'stop_words'      => ''

--- a/oc-content/languages/fa_IR/theme.po
+++ b/oc-content/languages/fa_IR/theme.po
@@ -119,11 +119,11 @@ msgid "Footer link"
 msgstr "لینک فوتر"
 
 #: admin/settings.php:45
-msgid "I want to help Osclass by linking to <a href=\"http://osclass.org/\" target=\"_blank\">osclass.org</a> from my site with the following text:"
+msgid "I want to help Osclass by linking to <a href=\"https://github.com/navjottomer/osclass/\" target=\"_blank\">osclass.org</a> from my site with the following text:"
 msgstr "من می خواهم برای کمک به faosclass با لینک دادن به <a href=\"http://faosclass.com/\" target=\"_blank\"> faosclass.com </a> در سایتم با متن زیر حمایت کنم:"
 
 #: admin/settings.php:46
-msgid "This website is proudly using the <a title=\"Osclass web\" href=\"http://osclass.org/\">classifieds scripts</a> software <strong>Osclass</strong>"
+msgid "This website is proudly using the <a title=\"Osclass web\" href=\"https://github.com/navjottomer/osclass/\">classifieds scripts</a> software <strong>Osclass</strong>"
 msgstr "این وب سایت با افتخار با استفاده از <a title=\"faosclass web\" href=\"http://faosclass.org/\">اسکریپت آگهی</a> <strong>او اس کلاس فارسی</strong> ساخته شده است."
 
 #: admin/settings.php:50

--- a/oc-content/languages/fr_FR/core.po
+++ b/oc-content/languages/fr_FR/core.po
@@ -3252,8 +3252,8 @@ msgid "Your Osclass installation at %s is up and running. You can access the adm
 msgstr "Votre installation d'OSClass est prête sur %s. Vous pouvez accéder au tableau de bord avec ces identifiants:"
 
 #: oc-includes/osclass/install-location.php:105
-msgid "The <a href=\"http://osclass.org/\">Osclass</a> team"
-msgstr "L'équipe d'<a href=\"http://osclass.org/\">OSClass</a>"
+msgid "The <a href=\"https://github.com/navjottomer/osclass/\">Osclass</a> team"
+msgstr "L'équipe d'<a href=\"https://github.com/navjottomer/osclass/\">OSClass</a>"
 
 #: oc-includes/osclass/install.php:88
 msgid "Looks like you've already installed Osclass. To reinstall please clear your old database tables first."
@@ -3312,8 +3312,8 @@ msgid "We've encountered some problems while updating the database structure. Th
 msgstr "Quelques problèmes sont survenus au cours de la mise à jour de la structure de la base de données. Les requêtes suivantes ont échoué:"
 
 #: oc-includes/osclass/upgrade-funcs.php:47
-msgid "These errors could be false-positive errors. If you're sure that is the case, you can <a href=\"%s\">continue with the upgrade</a>, or <a href=\"http://forums.osclass.org/\">ask in our forums</a>."
-msgstr "Ces erreurs peuvent être des erreurs fausse-positives. Si vous êtes sûr que c'est le cas, vous pouvez <a href=\"%s\">continuer l'actualisation</a>, ou <a href=\"http://forums.osclass.org/\">poser la question sur nos forums</a>."
+msgid "These errors could be false-positive errors. If you're sure that is the case, you can <a href=\"%s\">continue with the upgrade</a>, or <a href=\"https://osclass.discourse.group/\">ask in our forums</a>."
+msgstr "Ces erreurs peuvent être des erreurs fausse-positives. Si vous êtes sûr que c'est le cas, vous pouvez <a href=\"%s\">continuer l'actualisation</a>, ou <a href=\"https://osclass.discourse.group/\">poser la question sur nos forums</a>."
 
 #: oc-includes/osclass/upgrade-funcs.php:287
 msgid "You need to calculate location stats, please go to admin panel, tools, recalculate location stats or click"
@@ -3324,8 +3324,8 @@ msgid "Osclass &raquo; Updated correctly"
 msgstr "OSClass &raquo; Correctement mis à jour"
 
 #: oc-includes/osclass/upgrade-funcs.php:465
-msgid "Osclass has been updated successfully. <a href=\"http://forums.osclass.org/\">Need more help?</a>"
-msgstr "Votre installation OSClass a été correctement mise à jour. <a href=\"http://forums.osclass.org/\">Encore besoin d'aide?</a>"
+msgid "Osclass has been updated successfully. <a href=\"https://osclass.discourse.group/\">Need more help?</a>"
+msgstr "Votre installation OSClass a été correctement mise à jour. <a href=\"https://osclass.discourse.group/\">Encore besoin d'aide?</a>"
 
 #: oc-load.php:206
 msgid "The website is currently undergoing maintenance"

--- a/oc-content/languages/fr_FR/index.php
+++ b/oc-content/languages/fr_FR/index.php
@@ -26,7 +26,7 @@ function locale_fr_FR_info() {
         ,'description'     => 'French (France) translation'
         ,'version'         => '3.3.00'
         ,'author_name'     => 'Osclass'
-        ,'author_url'      => 'http://osclass.org/'
+        ,'author_url'      => 'https://github.com/navjottomer/osclass/'
         ,'currency_format' => '{NUMBER} {CURRENCY}'
         ,'date_format'     => 'm/d/Y'
         ,'stop_words'      => ''

--- a/oc-content/languages/fr_FR/messages.po
+++ b/oc-content/languages/fr_FR/messages.po
@@ -55,8 +55,8 @@ msgid "Your email has been sent properly."
 msgstr "Votre email a bien été envoyé."
 
 #: oc-includes/osclass/upgrade-funcs.php:460
-msgid "Osclass has been updated successfully. <a href=\"http://forums.osclass.org/\">Need more help?</a>"
-msgstr "Osclass a bien été mis à jour. <a href=\"http://forums.osclass.org/\">Besoin d'aide supplémentaire?</a>"
+msgid "Osclass has been updated successfully. <a href=\"https://osclass.discourse.group/\">Need more help?</a>"
+msgstr "Osclass a bien été mis à jour. <a href=\"https://osclass.discourse.group/\">Besoin d'aide supplémentaire?</a>"
 
 #: oc-includes/osclass/controller/ajax.php:115
 #: oc-includes/osclass/controller/item.php:320

--- a/oc-content/languages/fr_FR/theme.po
+++ b/oc-content/languages/fr_FR/theme.po
@@ -30,8 +30,8 @@ msgstr "%1$d - %2$d sur %3$d annonces"
 msgid "Premium listings"
 msgstr "Annonces Premium"
 
-msgid "http://osclass.org/"
-msgstr "http://osclass.org/"
+msgid "https://github.com/navjottomer/osclass/"
+msgstr "https://github.com/navjottomer/osclass/"
 
 msgid "Bender theme"
 msgstr "Thème Bender"
@@ -148,12 +148,12 @@ msgid "Footer link"
 msgstr "Lien dans le pied de page"
 
 #: admin/settings.php:45
-msgid "I want to help Osclass by linking to <a href=\"http://osclass.org/\" target=\"_blank\">osclass.org</a> from my site with the following text:"
-msgstr "Je veux aider OSClass en ajoutant le lien <a href=\"http://osclass.org/\" target=\"_blank\">osclass.org</a> sur mon site avec le texte suivant:"
+msgid "I want to help Osclass by linking to <a href=\"https://github.com/navjottomer/osclass/\" target=\"_blank\">osclass.org</a> from my site with the following text:"
+msgstr "Je veux aider OSClass en ajoutant le lien <a href=\"https://github.com/navjottomer/osclass/\" target=\"_blank\">osclass.org</a> sur mon site avec le texte suivant:"
 
 #: admin/settings.php:46
-msgid "This website is proudly using the <a title=\"Osclass web\" href=\"http://osclass.org/\">classifieds scripts</a> software <strong>Osclass</strong>"
-msgstr "Ce site est fièrement propulsé par <a title=\"OSClass Web\" href=\"http://osclass.org/\">le moteur de petites annonces</a> <strong>OSClass</strong>"
+msgid "This website is proudly using the <a title=\"Osclass web\" href=\"https://github.com/navjottomer/osclass/\">classifieds scripts</a> software <strong>Osclass</strong>"
+msgstr "Ce site est fièrement propulsé par <a title=\"OSClass Web\" href=\"https://github.com/navjottomer/osclass/\">le moteur de petites annonces</a> <strong>OSClass</strong>"
 
 #: admin/settings.php:50
 msgid "Save changes"

--- a/oc-content/languages/he_HE/core.po
+++ b/oc-content/languages/he_HE/core.po
@@ -4214,8 +4214,8 @@ msgid "Your Osclass installation at %s is up and running. You can access the adm
 msgstr "התקנת Osclass ב%s היא ולהפעלתו. אתה יכול לגשת לפנל ניהול עם הפרטים הבאים:"
 
 #: /var/www/osclass-git/oc-includes/osclass/install-location.php:102
-msgid "The <a href=\"http://osclass.org/\">Osclass</a> team"
-msgstr "קבוצת <a href=\"http://osclass.org/\">Osclass</a> "
+msgid "The <a href=\"https://github.com/navjottomer/osclass/\">Osclass</a> team"
+msgstr "קבוצת <a href=\"https://github.com/navjottomer/osclass/\">Osclass</a> "
 
 #: /var/www/osclass-git/oc-includes/osclass/install.php:86
 msgid "Looks like you've already installed Osclass. To reinstall please clear your old database tables first."
@@ -4238,8 +4238,8 @@ msgid "We've encountered some problems while updating the database structure. Th
 msgstr "נתקלנו כמה בעיות בעת עדכון מבנה מסד הנתונים. השאילתות הבאות נכשלו:"
 
 #: /var/www/osclass-git/oc-includes/osclass/upgrade-funcs.php:47
-msgid "These errors could be false-positive errors. If you're sure that is the case, you can <a href=\"%s\">continue with the upgrade</a>, or <a href=\"http://forums.osclass.org/\">ask in our forums</a>."
-msgstr "תקלות אלו יכולות להיות שגיאות חיוביות. אם אתה בטוח שזה המצב ניתן <a href=\"%s\">להמשיך בשדרוג</a>, או <a href=\"http://forums.osclass.org/\">לברר בפורום שלנו</a>."
+msgid "These errors could be false-positive errors. If you're sure that is the case, you can <a href=\"%s\">continue with the upgrade</a>, or <a href=\"https://osclass.discourse.group/\">ask in our forums</a>."
+msgstr "תקלות אלו יכולות להיות שגיאות חיוביות. אם אתה בטוח שזה המצב ניתן <a href=\"%s\">להמשיך בשדרוג</a>, או <a href=\"https://osclass.discourse.group/\">לברר בפורום שלנו</a>."
 
 #: /var/www/osclass-git/oc-includes/osclass/upgrade-funcs.php:286
 msgid "You need to calculate location stats, please go to admin panel, tools, recalculate location stats or click"
@@ -4250,8 +4250,8 @@ msgid "Osclass &raquo; Updated correctly"
 msgstr "Osclass &raquo; שודרג בהצלחה"
 
 #: /var/www/osclass-git/oc-includes/osclass/upgrade-funcs.php:392
-msgid "Osclass has been updated successfully. <a href=\"http://forums.osclass.org/\">Need more help?</a>"
-msgstr "Osclass עודכנה בהצלחה. <a href=\"http://forums.osclass.org/\">צריך עזרה נוספת?</a>"
+msgid "Osclass has been updated successfully. <a href=\"https://osclass.discourse.group/\">Need more help?</a>"
+msgstr "Osclass עודכנה בהצלחה. <a href=\"https://osclass.discourse.group/\">צריך עזרה נוספת?</a>"
 
 #: /var/www/osclass-git/oc-load.php:207
 msgid "The website is currently undergoing maintenance"

--- a/oc-content/languages/he_HE/index.php
+++ b/oc-content/languages/he_HE/index.php
@@ -26,7 +26,7 @@ function locale_he_HE_info() {
         ,'description'     => 'Hebrew translation'
         ,'version'         => '3.1.0'
         ,'author_name'     => 'Osclass'
-        ,'author_url'      => 'http://osclass.org/'
+        ,'author_url'      => 'https://github.com/navjottomer/osclass/'
         ,'currency_format' => '{NUMBER} {CURRENCY}'
         ,'date_format'     => 'm/d/Y'
         ,'stop_words'      => ''

--- a/oc-content/languages/he_HE/theme.po
+++ b/oc-content/languages/he_HE/theme.po
@@ -762,8 +762,8 @@ msgid "Osclass can't upload the logo image from the administration panel."
 msgstr "לא ניתן להעלות את הלוגו מפאנל הניהול"
 
 #: /var/www/osclass-git/oc-content/themes/modern/admin/settings.php:34
-msgid "I want to help Osclass by linking to <a href=\"http://osclass.org/\" target=\"_blank\">osclass.org</a> from my site with the following text:"
-msgstr "I want to help Osclass by linking to <a href=\"http://osclass.org/\" target=\"_blank\">osclass.org</a> from my site with the following text:"
+msgid "I want to help Osclass by linking to <a href=\"https://github.com/navjottomer/osclass/\" target=\"_blank\">osclass.org</a> from my site with the following text:"
+msgstr "I want to help Osclass by linking to <a href=\"https://github.com/navjottomer/osclass/\" target=\"_blank\">osclass.org</a> from my site with the following text:"
 
 #: /var/www/osclass-git/oc-content/themes/modern/admin/header.php:55
 msgid "Please make the aforementioned image folder writable."
@@ -774,8 +774,8 @@ msgid "I would like to contribute to the development of Osclass with a donation 
 msgstr "I would like to contribute to the development of Osclass with a donation of"
 
 #: /var/www/osclass-git/oc-content/themes/modern/footer.php:35
-msgid "This website is proudly using the <a title=\"Osclass web\" href=\"http://osclass.org/\">classifieds scripts</a> software <strong>Osclass</strong>"
-msgstr "This website is proudly using the <a title=\"Osclass web\" href=\"http://osclass.org/\">classifieds scripts</a> software <strong>Osclass</strong>"
+msgid "This website is proudly using the <a title=\"Osclass web\" href=\"https://github.com/navjottomer/osclass/\">classifieds scripts</a> software <strong>Osclass</strong>"
+msgstr "This website is proudly using the <a title=\"Osclass web\" href=\"https://github.com/navjottomer/osclass/\">classifieds scripts</a> software <strong>Osclass</strong>"
 
 #: /var/www/osclass-git/oc-content/themes/modern/admin/settings.php:39
 msgid "Default logo"

--- a/oc-content/languages/hu_HU/core.po
+++ b/oc-content/languages/hu_HU/core.po
@@ -1679,8 +1679,8 @@ msgid "Your Osclass installation at %s is up and running. You can access the adm
 msgstr "Az Osclass telepítésed %s sikeresen létrehzova. Az adminisztrátor vezérlőpultjához a következő adatok segítségével férhetsz hozzá:"
 
 #: oc-includes/osclass/install-location.php:107
-msgid "The <a href=\"http://osclass.org/\">Osclass</a> team"
-msgstr "Az <a href=\"http://osclass.org/\">Osclass</a> csapata"
+msgid "The <a href=\"https://github.com/navjottomer/osclass/\">Osclass</a> team"
+msgstr "Az <a href=\"https://github.com/navjottomer/osclass/\">Osclass</a> csapata"
 
 #: oc-includes/osclass/install.php:89
 msgid "Looks like you've already installed Osclass. To reinstall please clear your old database tables first."
@@ -1739,8 +1739,8 @@ msgid "We've encountered some problems while updating the database structure. Th
 msgstr "Az adatbázis frissítése közben tapasztaltunk néhány hibát. A következő lekérdezés nem sikerült:"
 
 #: oc-includes/osclass/upgrade-funcs.php:46
-msgid "These errors could be false-positive errors. If you're sure that is the case, you can <a href=\"%s\">continue with the upgrade</a>, or <a href=\"http://forums.osclass.org/\">ask in our forums</a>."
-msgstr "Ezek a hibák lehetnek hamis 'false' - pozitív hibák. Ha biztos vagy benne, hogy ez így van akkor <a href=\"%s\">folytathatod a telepítést</a>, vagy <ahref=\"http://forums.osclass.org/\">érdeklődj a fórumban</a>."
+msgid "These errors could be false-positive errors. If you're sure that is the case, you can <a href=\"%s\">continue with the upgrade</a>, or <a href=\"https://osclass.discourse.group/\">ask in our forums</a>."
+msgstr "Ezek a hibák lehetnek hamis 'false' - pozitív hibák. Ha biztos vagy benne, hogy ez így van akkor <a href=\"%s\">folytathatod a telepítést</a>, vagy <ahref=\"https://osclass.discourse.group/\">érdeklődj a fórumban</a>."
 
 #: oc-includes/osclass/upgrade-funcs.php:286
 msgid "You need to calculate location stats, please go to admin panel, tools, recalculate location stats or click"
@@ -1751,8 +1751,8 @@ msgid "Osclass &raquo; Updated correctly"
 msgstr "Osclass &raquo; megfelelően frissítve"
 
 #: oc-includes/osclass/upgrade-funcs.php:521
-msgid "Osclass has been updated successfully. <a href=\"http://forums.osclass.org/\">Need more help?</a>"
-msgstr "Az Osclass sikeresen frissítve. <a href=\"http://forums.osclass.org/\">További infó itt!</a>"
+msgid "Osclass has been updated successfully. <a href=\"https://osclass.discourse.group/\">Need more help?</a>"
+msgstr "Az Osclass sikeresen frissítve. <a href=\"https://osclass.discourse.group/\">További infó itt!</a>"
 
 #: oc-load.php:214
 msgid "The website is currently undergoing maintenance"

--- a/oc-content/languages/hu_HU/index.php
+++ b/oc-content/languages/hu_HU/index.php
@@ -26,7 +26,7 @@ function locale_hu_HU_info() {
         ,'description'     => 'Hungarian translation'
         ,'version'         => 'Osclass 3.5.0'
         ,'author_name'     => 'Osclass'
-        ,'author_url'      => 'http://osclass.org/'
+        ,'author_url'      => 'https://github.com/navjottomer/osclass/'
         ,'currency_format' => '{NUMBER} {CURRENCY}'
         ,'date_format'     => 'm/d/Y'
         ,'stop_words'      => ''

--- a/oc-content/languages/hu_HU/messages.po
+++ b/oc-content/languages/hu_HU/messages.po
@@ -1691,8 +1691,8 @@ msgid "Your email has been sent properly."
 msgstr "Az e-mail-ed megfelelően elküldve."
 
 #: oc-includes/osclass/upgrade-funcs.php:516
-msgid "Osclass has been updated successfully. <a href=\"http://forums.osclass.org/\">Need more help?</a>"
-msgstr "Az Osclass sikeresen frissítve lett. <a href=\"http://forums.osclass.org/\">Kérsz segítséget?</a>"
+msgid "Osclass has been updated successfully. <a href=\"https://osclass.discourse.group/\">Need more help?</a>"
+msgstr "Az Osclass sikeresen frissítve lett. <a href=\"https://osclass.discourse.group/\">Kérsz segítséget?</a>"
 
 #: oc-admin/plugins.php:231
 msgid "The files were deleted"

--- a/oc-content/languages/hu_HU/theme.po
+++ b/oc-content/languages/hu_HU/theme.po
@@ -119,12 +119,12 @@ msgid "Footer link"
 msgstr "Lábléc 'Footer' link"
 
 #: admin/settings.php:67
-msgid "I want to help Osclass by linking to <a href=\"http://osclass.org/\" target=\"_blank\">osclass.org</a> from my site with the following text:"
-msgstr "Szeretnék segíteni az Osclass készítőinek a <a href=\"http://osclass.org/\" target=\"_blank\">osclass.org</a> linkelésével az oldalamról a következő szöveggel."
+msgid "I want to help Osclass by linking to <a href=\"https://github.com/navjottomer/osclass/\" target=\"_blank\">osclass.org</a> from my site with the following text:"
+msgstr "Szeretnék segíteni az Osclass készítőinek a <a href=\"https://github.com/navjottomer/osclass/\" target=\"_blank\">osclass.org</a> linkelésével az oldalamról a következő szöveggel."
 
 #: admin/settings.php:68
-msgid "This website is proudly using the <a title=\"Osclass web\" href=\"http://osclass.org/\">classifieds scripts</a> software <strong>Osclass</strong>"
-msgstr "Az oldal motorja <a title=\"Osclass web\" href=\"http://osclass.org/\">classifieds scripts</a> <strong>Osclass</strong>\" "
+msgid "This website is proudly using the <a title=\"Osclass web\" href=\"https://github.com/navjottomer/osclass/\">classifieds scripts</a> software <strong>Osclass</strong>"
+msgstr "Az oldal motorja <a title=\"Osclass web\" href=\"https://github.com/navjottomer/osclass/\">classifieds scripts</a> <strong>Osclass</strong>\" "
 
 #: admin/settings.php:124
 msgid "Save changes"
@@ -798,8 +798,8 @@ msgstr "%1$d - %2$d a %3$d hirdetésből"
 msgid "Premium listings"
 msgstr "Támogatott hirdetések"
 
-msgid "http://osclass.org/"
-msgstr "http://osclass.org/"
+msgid "https://github.com/navjottomer/osclass/"
+msgstr "https://github.com/navjottomer/osclass/"
 
 msgid "Bender theme"
 msgstr "Bender téma"

--- a/oc-content/languages/id_ID/core.po
+++ b/oc-content/languages/id_ID/core.po
@@ -4214,8 +4214,8 @@ msgid "Your Osclass installation at %s is up and running. You can access the adm
 msgstr "Instalasi Osclass Anda di %s hidup dan jalan. Anda dapat mengakses panel administrasi dengan rincian ini:"
 
 #: /var/www/osclass-git/oc-includes/osclass/install-location.php:102
-msgid "The <a href=\"http://osclass.org/\">Osclass</a> team"
-msgstr "Tim <a href=\"http://osclass.org/\">Osclass</a>"
+msgid "The <a href=\"https://github.com/navjottomer/osclass/\">Osclass</a> team"
+msgstr "Tim <a href=\"https://github.com/navjottomer/osclass/\">Osclass</a>"
 
 #: /var/www/osclass-git/oc-includes/osclass/install.php:86
 msgid "Looks like you've already installed Osclass. To reinstall please clear your old database tables first."
@@ -4238,8 +4238,8 @@ msgid "We've encountered some problems while updating the database structure. Th
 msgstr "Kami telah mengalami beberapa masalah saat memperbarui struktur database-nya. Query berikut gagal:"
 
 #: /var/www/osclass-git/oc-includes/osclass/upgrade-funcs.php:47
-msgid "These errors could be false-positive errors. If you're sure that is the case, you can <a href=\"%s\">continue with the upgrade</a>, or <a href=\"http://forums.osclass.org/\">ask in our forums</a>."
-msgstr "Kesalahan ini bisa kesalahan false-positive. Jika Anda yakin ini terjadi, Anda dapat <a href=\"%s\">melanjutkan upgrade</ a> nya, atau <a href=\"http://forums.osclass.org/\">bertanya di forum</a> kami."
+msgid "These errors could be false-positive errors. If you're sure that is the case, you can <a href=\"%s\">continue with the upgrade</a>, or <a href=\"https://osclass.discourse.group/\">ask in our forums</a>."
+msgstr "Kesalahan ini bisa kesalahan false-positive. Jika Anda yakin ini terjadi, Anda dapat <a href=\"%s\">melanjutkan upgrade</ a> nya, atau <a href=\"https://osclass.discourse.group/\">bertanya di forum</a> kami."
 
 #: /var/www/osclass-git/oc-includes/osclass/upgrade-funcs.php:286
 msgid "You need to calculate location stats, please go to admin panel, tools, recalculate location stats or click"
@@ -4250,8 +4250,8 @@ msgid "Osclass &raquo; Updated correctly"
 msgstr "Osclass &raquo; Sudah diperbarui dengan benar"
 
 #: /var/www/osclass-git/oc-includes/osclass/upgrade-funcs.php:392
-msgid "Osclass has been updated successfully. <a href=\"http://forums.osclass.org/\">Need more help?</a>"
-msgstr "Osclass sudah diperbarui dengan sukses. <a href=\"http://forums.osclass.org/\">Perlu bantuan lagi?</a>"
+msgid "Osclass has been updated successfully. <a href=\"https://osclass.discourse.group/\">Need more help?</a>"
+msgstr "Osclass sudah diperbarui dengan sukses. <a href=\"https://osclass.discourse.group/\">Perlu bantuan lagi?</a>"
 
 #: /var/www/osclass-git/oc-load.php:207
 msgid "The website is currently undergoing maintenance"

--- a/oc-content/languages/id_ID/index.php
+++ b/oc-content/languages/id_ID/index.php
@@ -26,7 +26,7 @@ function locale_id_ID_info() {
         ,'description'     => 'Indonesian translation'
         ,'version'         => '3.1.0'
         ,'author_name'     => 'Osclass'
-        ,'author_url'      => 'http://osclass.org/'
+        ,'author_url'      => 'https://github.com/navjottomer/osclass/'
         ,'currency_format' => '{NUMBER} {CURRENCY}'
         ,'date_format'     => 'm/d/Y'
         ,'stop_words'      => ''

--- a/oc-content/languages/id_ID/theme.po
+++ b/oc-content/languages/id_ID/theme.po
@@ -762,8 +762,8 @@ msgid "Osclass can't upload the logo image from the administration panel."
 msgstr "Osclass tidak bisa mengunggah gambar logo dari panel administrasi"
 
 #: /var/www/osclass-git/oc-content/themes/modern/admin/settings.php:34
-msgid "I want to help Osclass by linking to <a href=\"http://osclass.org/\" target=\"_blank\">osclass.org</a> from my site with the following text:"
-msgstr "Saya ingin membantu Osclass dengan memberi tautan ke <a href=\"http://osclass.org/\" target=\"_blank\">osclass.org</a> dari situs saya dengan teks berikut:"
+msgid "I want to help Osclass by linking to <a href=\"https://github.com/navjottomer/osclass/\" target=\"_blank\">osclass.org</a> from my site with the following text:"
+msgstr "Saya ingin membantu Osclass dengan memberi tautan ke <a href=\"https://github.com/navjottomer/osclass/\" target=\"_blank\">osclass.org</a> dari situs saya dengan teks berikut:"
 
 #: /var/www/osclass-git/oc-content/themes/modern/admin/header.php:55
 msgid "Please make the aforementioned image folder writable."
@@ -774,8 +774,8 @@ msgid "I would like to contribute to the development of Osclass with a donation 
 msgstr "Saya ingin berkontribusi dalam pengembangan Osclass dengan donasi pada"
 
 #: /var/www/osclass-git/oc-content/themes/modern/footer.php:35
-msgid "This website is proudly using the <a title=\"Osclass web\" href=\"http://osclass.org/\">classifieds scripts</a> software <strong>Osclass</strong>"
-msgstr "Website ini dengan bangga menggunakan <a title=\"Osclass web\" href=\"http://osclass.org/\">aplikasi  iklan baris</a> dari <strong>Osclass</strong>"
+msgid "This website is proudly using the <a title=\"Osclass web\" href=\"https://github.com/navjottomer/osclass/\">classifieds scripts</a> software <strong>Osclass</strong>"
+msgstr "Website ini dengan bangga menggunakan <a title=\"Osclass web\" href=\"https://github.com/navjottomer/osclass/\">aplikasi  iklan baris</a> dari <strong>Osclass</strong>"
 
 #: /var/www/osclass-git/oc-content/themes/modern/admin/settings.php:39
 msgid "Default logo"

--- a/oc-content/languages/it_IT/core.po
+++ b/oc-content/languages/it_IT/core.po
@@ -3252,8 +3252,8 @@ msgid "Your Osclass installation at %s is up and running. You can access the adm
 msgstr "La tua installazione di Osclass su %s è completa e pronta per essere eseguita. Accedi al pannello di amministrazione per questi dettagli:"
 
 #: oc-includes/osclass/install-location.php:105
-msgid "The <a href=\"http://osclass.org/\">Osclass</a> team"
-msgstr "Il team <a href=\"http://osclass.org/\">Osclass</a> "
+msgid "The <a href=\"https://github.com/navjottomer/osclass/\">Osclass</a> team"
+msgstr "Il team <a href=\"https://github.com/navjottomer/osclass/\">Osclass</a> "
 
 #: oc-includes/osclass/install.php:88
 msgid "Looks like you've already installed Osclass. To reinstall please clear your old database tables first."
@@ -3312,8 +3312,8 @@ msgid "We've encountered some problems while updating the database structure. Th
 msgstr "Abbiamo riscontrati alcuni problemi durante l'aggiornamento della struttura del database. Le seguenti query sono fallite:"
 
 #: oc-includes/osclass/upgrade-funcs.php:47
-msgid "These errors could be false-positive errors. If you're sure that is the case, you can <a href=\"%s\">continue with the upgrade</a>, or <a href=\"http://forums.osclass.org/\">ask in our forums</a>."
-msgstr "Questi errori potrebbero essere dei falsi problemi. Se sei sicuro di trovarti in questa condizione <a href =\"%s\">  puoi continuare con l'aggiornamento </ a>, oppure <a href=\"http://forums.osclass.org/\"> chiedere in nostri forum </ a>."
+msgid "These errors could be false-positive errors. If you're sure that is the case, you can <a href=\"%s\">continue with the upgrade</a>, or <a href=\"https://osclass.discourse.group/\">ask in our forums</a>."
+msgstr "Questi errori potrebbero essere dei falsi problemi. Se sei sicuro di trovarti in questa condizione <a href =\"%s\">  puoi continuare con l'aggiornamento </ a>, oppure <a href=\"https://osclass.discourse.group/\"> chiedere in nostri forum </ a>."
 
 #: oc-includes/osclass/upgrade-funcs.php:287
 msgid "You need to calculate location stats, please go to admin panel, tools, recalculate location stats or click"
@@ -3324,8 +3324,8 @@ msgid "Osclass &raquo; Updated correctly"
 msgstr "Osclass &raquo; aggiornato correttamente"
 
 #: oc-includes/osclass/upgrade-funcs.php:465
-msgid "Osclass has been updated successfully. <a href=\"http://forums.osclass.org/\">Need more help?</a>"
-msgstr "Osclass è stato aggiornato correttamente. <a href=\"http://forums.osclass.org/\">Hai bisogno di aiuto ?</a>"
+msgid "Osclass has been updated successfully. <a href=\"https://osclass.discourse.group/\">Need more help?</a>"
+msgstr "Osclass è stato aggiornato correttamente. <a href=\"https://osclass.discourse.group/\">Hai bisogno di aiuto ?</a>"
 
 #: oc-load.php:206
 msgid "The website is currently undergoing maintenance"

--- a/oc-content/languages/it_IT/index.php
+++ b/oc-content/languages/it_IT/index.php
@@ -26,7 +26,7 @@ function locale_it_IT_info() {
         ,'description'     => 'Italian translation'
         ,'version'         => '3.3.00'
         ,'author_name'     => 'Osclass'
-        ,'author_url'      => 'http://osclass.org/'
+        ,'author_url'      => 'https://github.com/navjottomer/osclass/'
         ,'currency_format' => '{NUMBER} {CURRENCY}'
         ,'date_format'     => 'm/d/Y'
         ,'stop_words'      => ''

--- a/oc-content/languages/it_IT/messages.po
+++ b/oc-content/languages/it_IT/messages.po
@@ -55,8 +55,8 @@ msgid "Your email has been sent properly."
 msgstr "La tua email è stata inviata correttamente."
 
 #: oc-includes/osclass/upgrade-funcs.php:460
-msgid "Osclass has been updated successfully. <a href=\"http://forums.osclass.org/\">Need more help?</a>"
-msgstr "Osclass è stato aggiornato correttamente. <a href=\"http://forums.osclass.org/\">Hai bisogno di aiuto?</a>"
+msgid "Osclass has been updated successfully. <a href=\"https://osclass.discourse.group/\">Need more help?</a>"
+msgstr "Osclass è stato aggiornato correttamente. <a href=\"https://osclass.discourse.group/\">Hai bisogno di aiuto?</a>"
 
 #: oc-includes/osclass/controller/ajax.php:115
 #: oc-includes/osclass/controller/item.php:320

--- a/oc-content/languages/it_IT/theme.po
+++ b/oc-content/languages/it_IT/theme.po
@@ -30,8 +30,8 @@ msgstr "%1$d - %2$d di %3$d annunci"
 msgid "Premium listings"
 msgstr "Annunci Premium"
 
-msgid "http://osclass.org/"
-msgstr "http://osclass.org/ "
+msgid "https://github.com/navjottomer/osclass/"
+msgstr "https://github.com/navjottomer/osclass/ "
 
 msgid "Bender theme"
 msgstr "Tema Bender"
@@ -148,12 +148,12 @@ msgid "Footer link"
 msgstr "Link piè di pagina"
 
 #: admin/settings.php:45
-msgid "I want to help Osclass by linking to <a href=\"http://osclass.org/\" target=\"_blank\">osclass.org</a> from my site with the following text:"
-msgstr "Voglio aiutare Osclass collegando ad <a href=\"http://osclass.org/\" target=\"_blank\">osclass.org</a> dal mio sito con il seguente testo:"
+msgid "I want to help Osclass by linking to <a href=\"https://github.com/navjottomer/osclass/\" target=\"_blank\">osclass.org</a> from my site with the following text:"
+msgstr "Voglio aiutare Osclass collegando ad <a href=\"https://github.com/navjottomer/osclass/\" target=\"_blank\">osclass.org</a> dal mio sito con il seguente testo:"
 
 #: admin/settings.php:46
-msgid "This website is proudly using the <a title=\"Osclass web\" href=\"http://osclass.org/\">classifieds scripts</a> software <strong>Osclass</strong>"
-msgstr "Questo sito è orgogliosamente usando il <a title=\"Osclass web\" href=\"http://osclass.org/\">script di annunci</a>  <strong>Osclass</strong>"
+msgid "This website is proudly using the <a title=\"Osclass web\" href=\"https://github.com/navjottomer/osclass/\">classifieds scripts</a> software <strong>Osclass</strong>"
+msgstr "Questo sito è orgogliosamente usando il <a title=\"Osclass web\" href=\"https://github.com/navjottomer/osclass/\">script di annunci</a>  <strong>Osclass</strong>"
 
 #: admin/settings.php:50
 msgid "Save changes"

--- a/oc-content/languages/ja_JA/core.po
+++ b/oc-content/languages/ja_JA/core.po
@@ -3269,8 +3269,8 @@ msgid "Your Osclass installation at %s is up and running. You can access the adm
 msgstr "あなたのOsclass %sは稼働中です。以下の詳細から、管理者パネルにアクセス可能です:"
 
 #: oc-includes/osclass/install-location.php:105
-msgid "The <a href=\"http://osclass.org/\">Osclass</a> team"
-msgstr "<a href=\"http://osclass.org/\">Osclass</a>チーム"
+msgid "The <a href=\"https://github.com/navjottomer/osclass/\">Osclass</a> team"
+msgstr "<a href=\"https://github.com/navjottomer/osclass/\">Osclass</a>チーム"
 
 #: oc-includes/osclass/install.php:88
 msgid "Looks like you've already installed Osclass. To reinstall please clear your old database tables first."
@@ -3329,8 +3329,8 @@ msgid "We've encountered some problems while updating the database structure. Th
 msgstr "データベースをアップデート中に問題が発生しました。次のクエリ実行に失敗しました。"
 
 #: oc-includes/osclass/upgrade-funcs.php:47
-msgid "These errors could be false-positive errors. If you're sure that is the case, you can <a href=\"%s\">continue with the upgrade</a>, or <a href=\"http://forums.osclass.org/\">ask in our forums</a>."
-msgstr "これらのエラーはエラーではない可能性があります。そうであると思われる場合には<a href=\"%s\">アップグレードを継続</a>するか、<a href=\"http://forums.osclass.org/\">フォーラムで質問してください</a>。"
+msgid "These errors could be false-positive errors. If you're sure that is the case, you can <a href=\"%s\">continue with the upgrade</a>, or <a href=\"https://osclass.discourse.group/\">ask in our forums</a>."
+msgstr "これらのエラーはエラーではない可能性があります。そうであると思われる場合には<a href=\"%s\">アップグレードを継続</a>するか、<a href=\"https://osclass.discourse.group/\">フォーラムで質問してください</a>。"
 
 #: oc-includes/osclass/upgrade-funcs.php:287
 msgid "You need to calculate location stats, please go to admin panel, tools, recalculate location stats or click"
@@ -3341,8 +3341,8 @@ msgid "Osclass &raquo; Updated correctly"
 msgstr "Osclass &raquo; 正常にアップデートされました"
 
 #: oc-includes/osclass/upgrade-funcs.php:465
-msgid "Osclass has been updated successfully. <a href=\"http://forums.osclass.org/\">Need more help?</a>"
-msgstr "Osclassのアップデートに成功しました。 <a href=\"http://forums.osclass.org/\">不明な点がありますか?</a>"
+msgid "Osclass has been updated successfully. <a href=\"https://osclass.discourse.group/\">Need more help?</a>"
+msgstr "Osclassのアップデートに成功しました。 <a href=\"https://osclass.discourse.group/\">不明な点がありますか?</a>"
 
 #: oc-load.php:206
 msgid "The website is currently undergoing maintenance"

--- a/oc-content/languages/ja_JA/index.php
+++ b/oc-content/languages/ja_JA/index.php
@@ -26,7 +26,7 @@ function locale_ja_JA_info() {
         ,'description'     => 'Japanese translation'
         ,'version'         => '3.3.00'
         ,'author_name'     => 'Osclass'
-        ,'author_url'      => 'http://osclass.org/'
+        ,'author_url'      => 'https://github.com/navjottomer/osclass/'
         ,'currency_format' => '{NUMBER} {CURRENCY}'
         ,'date_format'     => 'm/d/Y'
         ,'stop_words'      => ''

--- a/oc-content/languages/ja_JA/messages.po
+++ b/oc-content/languages/ja_JA/messages.po
@@ -55,8 +55,8 @@ msgid "Your email has been sent properly."
 msgstr "メールは正常に送信されました。"
 
 #: oc-includes/osclass/upgrade-funcs.php:460
-msgid "Osclass has been updated successfully. <a href=\"http://forums.osclass.org/\">Need more help?</a>"
-msgstr "Osclassの更新に成功しました。 <a href=\"http://forums.osclass.org/\">不明な点がありますか？</a>"
+msgid "Osclass has been updated successfully. <a href=\"https://osclass.discourse.group/\">Need more help?</a>"
+msgstr "Osclassの更新に成功しました。 <a href=\"https://osclass.discourse.group/\">不明な点がありますか？</a>"
 
 #: oc-includes/osclass/controller/ajax.php:115
 #: oc-includes/osclass/controller/item.php:320

--- a/oc-content/languages/ja_JA/theme.po
+++ b/oc-content/languages/ja_JA/theme.po
@@ -30,8 +30,8 @@ msgstr "%3$d 件中 %1$d ～ %2$d 件を表示"
 msgid "Premium listings"
 msgstr "注目の広告"
 
-msgid "http://osclass.org/"
-msgstr "http://osclass.org/"
+msgid "https://github.com/navjottomer/osclass/"
+msgstr "https://github.com/navjottomer/osclass/"
 
 msgid "Bender theme"
 msgstr "Bender テーマ"
@@ -148,12 +148,12 @@ msgid "Footer link"
 msgstr "フッターリンク"
 
 #: admin/settings.php:45
-msgid "I want to help Osclass by linking to <a href=\"http://osclass.org/\" target=\"_blank\">osclass.org</a> from my site with the following text:"
-msgstr "<a href=\"http://osclass.org/\" target=\"_blank\">osclass.org</a> への以下のテキストリンクを私のサイトに設置することにより、Osclassの開発に貢献したいです："
+msgid "I want to help Osclass by linking to <a href=\"https://github.com/navjottomer/osclass/\" target=\"_blank\">osclass.org</a> from my site with the following text:"
+msgstr "<a href=\"https://github.com/navjottomer/osclass/\" target=\"_blank\">osclass.org</a> への以下のテキストリンクを私のサイトに設置することにより、Osclassの開発に貢献したいです："
 
 #: admin/settings.php:46
-msgid "This website is proudly using the <a title=\"Osclass web\" href=\"http://osclass.org/\">classifieds scripts</a> software <strong>Osclass</strong>"
-msgstr "このサイトは<a title=\"Osclass web\" href=\"http://osclass.org/\">クラシファイド広告</a>ソフトウェア <strong>Osclass</strong>を使っています。"
+msgid "This website is proudly using the <a title=\"Osclass web\" href=\"https://github.com/navjottomer/osclass/\">classifieds scripts</a> software <strong>Osclass</strong>"
+msgstr "このサイトは<a title=\"Osclass web\" href=\"https://github.com/navjottomer/osclass/\">クラシファイド広告</a>ソフトウェア <strong>Osclass</strong>を使っています。"
 
 #: admin/settings.php:50
 msgid "Save changes"

--- a/oc-content/languages/lt_LT/core.po
+++ b/oc-content/languages/lt_LT/core.po
@@ -3253,8 +3253,8 @@ msgid "Your Osclass installation at %s is up and running. You can access the adm
 msgstr "Jūsų Osclass įdiegimas %s yra paleistas ir veikiantis. Jūs galite atsidaryti administravimo puslapį su šiomis detalėmis:"
 
 #: oc-includes/osclass/install-location.php:105
-msgid "The <a href=\"http://osclass.org/\">Osclass</a> team"
-msgstr "<a href=\"http://osclass.org/\">Osclass</a> komanda"
+msgid "The <a href=\"https://github.com/navjottomer/osclass/\">Osclass</a> team"
+msgstr "<a href=\"https://github.com/navjottomer/osclass/\">Osclass</a> komanda"
 
 #: oc-includes/osclass/install.php:88
 msgid "Looks like you've already installed Osclass. To reinstall please clear your old database tables first."
@@ -3313,8 +3313,8 @@ msgid "We've encountered some problems while updating the database structure. Th
 msgstr "Mes patyrėme problemų kol vyko duomenų bazės struktūros atnaujinimai. Šios užklausos nepavyko:"
 
 #: oc-includes/osclass/upgrade-funcs.php:47
-msgid "These errors could be false-positive errors. If you're sure that is the case, you can <a href=\"%s\">continue with the upgrade</a>, or <a href=\"http://forums.osclass.org/\">ask in our forums</a>."
-msgstr "Šie klaidos pranešimai gali būti klaidingi. Jeigu jūs tikras, jūs galite <a href=\"%s\"> tęsti atnaujinimą</a>, arba  <a href=\"http://forums.osclass.org/\"> pasidomėti forumuose</a>."
+msgid "These errors could be false-positive errors. If you're sure that is the case, you can <a href=\"%s\">continue with the upgrade</a>, or <a href=\"https://osclass.discourse.group/\">ask in our forums</a>."
+msgstr "Šie klaidos pranešimai gali būti klaidingi. Jeigu jūs tikras, jūs galite <a href=\"%s\"> tęsti atnaujinimą</a>, arba  <a href=\"https://osclass.discourse.group/\"> pasidomėti forumuose</a>."
 
 #: oc-includes/osclass/upgrade-funcs.php:287
 msgid "You need to calculate location stats, please go to admin panel, tools, recalculate location stats or click"
@@ -3325,8 +3325,8 @@ msgid "Osclass &raquo; Updated correctly"
 msgstr "Osclass &raquo; Atnaujinta teisingai"
 
 #: oc-includes/osclass/upgrade-funcs.php:465
-msgid "Osclass has been updated successfully. <a href=\"http://forums.osclass.org/\">Need more help?</a>"
-msgstr "Osclass atnaujinta sėkmingai. <a href=\"http://forums.osclass.org/\">Reikia daugiau pagalbos?</a>"
+msgid "Osclass has been updated successfully. <a href=\"https://osclass.discourse.group/\">Need more help?</a>"
+msgstr "Osclass atnaujinta sėkmingai. <a href=\"https://osclass.discourse.group/\">Reikia daugiau pagalbos?</a>"
 
 #: oc-load.php:206
 msgid "The website is currently undergoing maintenance"

--- a/oc-content/languages/lt_LT/index.php
+++ b/oc-content/languages/lt_LT/index.php
@@ -26,7 +26,7 @@ function locale_lt_LT_info() {
         ,'description'     => 'Lithuanian translation'
         ,'version'         => '3.3.00'
         ,'author_name'     => 'Osclass'
-        ,'author_url'      => 'http://osclass.org/'
+        ,'author_url'      => 'https://github.com/navjottomer/osclass/'
         ,'currency_format' => '{NUMBER} {CURRENCY}'
         ,'date_format'     => 'm/d/Y'
         ,'stop_words'      => ''

--- a/oc-content/languages/lt_LT/messages.po
+++ b/oc-content/languages/lt_LT/messages.po
@@ -55,8 +55,8 @@ msgid "Your email has been sent properly."
 msgstr "Jūsų pranešimas išsiųstas teisingai."
 
 #: oc-includes/osclass/upgrade-funcs.php:460
-msgid "Osclass has been updated successfully. <a href=\"http://forums.osclass.org/\">Need more help?</a>"
-msgstr "Osclass atnaujintas sėkmingai. <a href=\"http://forums.osclass.org/\">Reikia pagalbos?</a>"
+msgid "Osclass has been updated successfully. <a href=\"https://osclass.discourse.group/\">Need more help?</a>"
+msgstr "Osclass atnaujintas sėkmingai. <a href=\"https://osclass.discourse.group/\">Reikia pagalbos?</a>"
 
 #: oc-includes/osclass/controller/ajax.php:115
 #: oc-includes/osclass/controller/item.php:320

--- a/oc-content/languages/lt_LT/theme.po
+++ b/oc-content/languages/lt_LT/theme.po
@@ -30,8 +30,8 @@ msgstr "%1$d - %2$d of %3$d skelbimų"
 msgid "Premium listings"
 msgstr "Sponsorius"
 
-msgid "http://osclass.org/"
-msgstr "http://osclass.org/"
+msgid "https://github.com/navjottomer/osclass/"
+msgstr "https://github.com/navjottomer/osclass/"
 
 msgid "Bender theme"
 msgstr "Bender tema"
@@ -148,12 +148,12 @@ msgid "Footer link"
 msgstr "Apatinė nuoroda"
 
 #: admin/settings.php:45
-msgid "I want to help Osclass by linking to <a href=\"http://osclass.org/\" target=\"_blank\">osclass.org</a> from my site with the following text:"
-msgstr "Aš noriu padėti Osclass, pridėdamas nuorodą <a href=\"http://osclass.org/\" target=\"_blank\">osclass.org</a> iš mano tinklapio su šiuo tekstu: "
+msgid "I want to help Osclass by linking to <a href=\"https://github.com/navjottomer/osclass/\" target=\"_blank\">osclass.org</a> from my site with the following text:"
+msgstr "Aš noriu padėti Osclass, pridėdamas nuorodą <a href=\"https://github.com/navjottomer/osclass/\" target=\"_blank\">osclass.org</a> iš mano tinklapio su šiuo tekstu: "
 
 #: admin/settings.php:46
-msgid "This website is proudly using the <a title=\"Osclass web\" href=\"http://osclass.org/\">classifieds scripts</a> software <strong>Osclass</strong>"
-msgstr "Šis tinklapis sukurtas naudojantis <a title=\"Osclass web\" href=\"http://osclass.org/\"> sklebimų </a> skriptu iš <strong>Osclass</strong>"
+msgid "This website is proudly using the <a title=\"Osclass web\" href=\"https://github.com/navjottomer/osclass/\">classifieds scripts</a> software <strong>Osclass</strong>"
+msgstr "Šis tinklapis sukurtas naudojantis <a title=\"Osclass web\" href=\"https://github.com/navjottomer/osclass/\"> sklebimų </a> skriptu iš <strong>Osclass</strong>"
 
 #: admin/settings.php:50
 msgid "Save changes"

--- a/oc-content/languages/nl_NL/core.po
+++ b/oc-content/languages/nl_NL/core.po
@@ -3252,8 +3252,8 @@ msgid "Your Osclass installation at %s is up and running. You can access the adm
 msgstr "Uw Osclass installatie is op %s en loopt nog steeds. U kunt toegang krijgen tot de administratie paneel met deze gegevens:"
 
 #: oc-includes/osclass/install-location.php:105
-msgid "The <a href=\"http://osclass.org/\">Osclass</a> team"
-msgstr "Het  <a href=\"http://osclass.org/\">Osclass</a> team"
+msgid "The <a href=\"https://github.com/navjottomer/osclass/\">Osclass</a> team"
+msgstr "Het  <a href=\"https://github.com/navjottomer/osclass/\">Osclass</a> team"
 
 #: oc-includes/osclass/install.php:88
 msgid "Looks like you've already installed Osclass. To reinstall please clear your old database tables first."
@@ -3312,8 +3312,8 @@ msgid "We've encountered some problems while updating the database structure. Th
 msgstr "We hebben wat problemen ondervonden tijdens het bijwerken van de database-structuur. De volgende query is mislukt:"
 
 #: oc-includes/osclass/upgrade-funcs.php:47
-msgid "These errors could be false-positive errors. If you're sure that is the case, you can <a href=\"%s\">continue with the upgrade</a>, or <a href=\"http://forums.osclass.org/\">ask in our forums</a>."
-msgstr "Deze fouten kunnen worden vals-positieve fouten. Als je zeker weet dat het geval is, kunt u <a href=\"%s\">verder gaan met u updatee</a>, or <a href=\"http://forums.osclass.org/\">vraag op ons forum</a>."
+msgid "These errors could be false-positive errors. If you're sure that is the case, you can <a href=\"%s\">continue with the upgrade</a>, or <a href=\"https://osclass.discourse.group/\">ask in our forums</a>."
+msgstr "Deze fouten kunnen worden vals-positieve fouten. Als je zeker weet dat het geval is, kunt u <a href=\"%s\">verder gaan met u updatee</a>, or <a href=\"https://osclass.discourse.group/\">vraag op ons forum</a>."
 
 #: oc-includes/osclass/upgrade-funcs.php:287
 msgid "You need to calculate location stats, please go to admin panel, tools, recalculate location stats or click"
@@ -3324,8 +3324,8 @@ msgid "Osclass &raquo; Updated correctly"
 msgstr "Osclass &raquo; Correct bijgewerkt"
 
 #: oc-includes/osclass/upgrade-funcs.php:465
-msgid "Osclass has been updated successfully. <a href=\"http://forums.osclass.org/\">Need more help?</a>"
-msgstr "Osclass is succesvol geupdate. <a href=\"http://forums.osclass.org/\">Als u help nodig heeft. </a>"
+msgid "Osclass has been updated successfully. <a href=\"https://osclass.discourse.group/\">Need more help?</a>"
+msgstr "Osclass is succesvol geupdate. <a href=\"https://osclass.discourse.group/\">Als u help nodig heeft. </a>"
 
 #: oc-load.php:206
 msgid "The website is currently undergoing maintenance"

--- a/oc-content/languages/nl_NL/index.php
+++ b/oc-content/languages/nl_NL/index.php
@@ -26,7 +26,7 @@ function locale_nl_NL_info() {
         ,'description'     => 'Dutch translation'
         ,'version'         => '3.3.00'
         ,'author_name'     => 'Osclass'
-        ,'author_url'      => 'http://osclass.org/'
+        ,'author_url'      => 'https://github.com/navjottomer/osclass/'
         ,'currency_format' => '{NUMBER} {CURRENCY}'
         ,'date_format'     => 'm/d/Y'
         ,'stop_words'      => ''

--- a/oc-content/languages/nl_NL/messages.po
+++ b/oc-content/languages/nl_NL/messages.po
@@ -55,8 +55,8 @@ msgid "Your email has been sent properly."
 msgstr "Uw e-mail is correct verzonden."
 
 #: oc-includes/osclass/upgrade-funcs.php:460
-msgid "Osclass has been updated successfully. <a href=\"http://forums.osclass.org/\">Need more help?</a>"
-msgstr "Osclass is succesvol geüpdate. <a href=\"http://forums.osclass.org/\">Heeft u meer hulp nodig?</a>"
+msgid "Osclass has been updated successfully. <a href=\"https://osclass.discourse.group/\">Need more help?</a>"
+msgstr "Osclass is succesvol geüpdate. <a href=\"https://osclass.discourse.group/\">Heeft u meer hulp nodig?</a>"
 
 #: oc-includes/osclass/controller/ajax.php:115
 #: oc-includes/osclass/controller/item.php:320

--- a/oc-content/languages/nl_NL/theme.po
+++ b/oc-content/languages/nl_NL/theme.po
@@ -30,8 +30,8 @@ msgstr "%1$d - %2$d of %3$d advertenties"
 msgid "Premium listings"
 msgstr "Premium advertenties"
 
-msgid "http://osclass.org/"
-msgstr "http://osclass.org/"
+msgid "https://github.com/navjottomer/osclass/"
+msgstr "https://github.com/navjottomer/osclass/"
 
 msgid "Bender theme"
 msgstr "Bender thema"
@@ -148,12 +148,12 @@ msgid "Footer link"
 msgstr "Voet link"
 
 #: admin/settings.php:45
-msgid "I want to help Osclass by linking to <a href=\"http://osclass.org/\" target=\"_blank\">osclass.org</a> from my site with the following text:"
-msgstr "Ik wil Osclass helpen met een link naar <a href=\"http://osclass.org/\" target=\"_blank\">osclass.org</a> vanaf mijn site met de volgende text:"
+msgid "I want to help Osclass by linking to <a href=\"https://github.com/navjottomer/osclass/\" target=\"_blank\">osclass.org</a> from my site with the following text:"
+msgstr "Ik wil Osclass helpen met een link naar <a href=\"https://github.com/navjottomer/osclass/\" target=\"_blank\">osclass.org</a> vanaf mijn site met de volgende text:"
 
 #: admin/settings.php:46
-msgid "This website is proudly using the <a title=\"Osclass web\" href=\"http://osclass.org/\">classifieds scripts</a> software <strong>Osclass</strong>"
-msgstr "Deze website maakt met trots gebruik van <a title=\"Osclass web\" href=\"http://osclass.org/\">classifieds scripts</a> software <strong>Osclass</strong>"
+msgid "This website is proudly using the <a title=\"Osclass web\" href=\"https://github.com/navjottomer/osclass/\">classifieds scripts</a> software <strong>Osclass</strong>"
+msgstr "Deze website maakt met trots gebruik van <a title=\"Osclass web\" href=\"https://github.com/navjottomer/osclass/\">classifieds scripts</a> software <strong>Osclass</strong>"
 
 #: admin/settings.php:50
 msgid "Save changes"

--- a/oc-content/languages/no_NO/core.po
+++ b/oc-content/languages/no_NO/core.po
@@ -3252,8 +3252,8 @@ msgid "Your Osclass installation at %s is up and running. You can access the adm
 msgstr "Din Osclass-installasjon på %s er oppe å kjører. Du kan få tilgang til administrasjonpanelet med disse detaljene:"
 
 #: oc-includes/osclass/install-location.php:105
-msgid "The <a href=\"http://osclass.org/\">Osclass</a> team"
-msgstr "<a href=\"http://osclass.org/\">Osclass</a>-teamet"
+msgid "The <a href=\"https://github.com/navjottomer/osclass/\">Osclass</a> team"
+msgstr "<a href=\"https://github.com/navjottomer/osclass/\">Osclass</a>-teamet"
 
 #: oc-includes/osclass/install.php:88
 msgid "Looks like you've already installed Osclass. To reinstall please clear your old database tables first."
@@ -3312,8 +3312,8 @@ msgid "We've encountered some problems while updating the database structure. Th
 msgstr "Vi har støtt på noen problemer under oppdatering av databasestruktur. Følgende spørring feilet:"
 
 #: oc-includes/osclass/upgrade-funcs.php:47
-msgid "These errors could be false-positive errors. If you're sure that is the case, you can <a href=\"%s\">continue with the upgrade</a>, or <a href=\"http://forums.osclass.org/\">ask in our forums</a>."
-msgstr "Disse feilene kan være falsk-positive feil. Hvis du er sikker på at det er tilfelle, kan du <a href=\"%s\">fortsette med oppgraderingen</a> eller <a href=\"http://forums.osclass.org/\">spør i vårt forum</a>."
+msgid "These errors could be false-positive errors. If you're sure that is the case, you can <a href=\"%s\">continue with the upgrade</a>, or <a href=\"https://osclass.discourse.group/\">ask in our forums</a>."
+msgstr "Disse feilene kan være falsk-positive feil. Hvis du er sikker på at det er tilfelle, kan du <a href=\"%s\">fortsette med oppgraderingen</a> eller <a href=\"https://osclass.discourse.group/\">spør i vårt forum</a>."
 
 #: oc-includes/osclass/upgrade-funcs.php:287
 msgid "You need to calculate location stats, please go to admin panel, tools, recalculate location stats or click"
@@ -3324,8 +3324,8 @@ msgid "Osclass &raquo; Updated correctly"
 msgstr "Osclass &raquo; Oppdatert riktig"
 
 #: oc-includes/osclass/upgrade-funcs.php:465
-msgid "Osclass has been updated successfully. <a href=\"http://forums.osclass.org/\">Need more help?</a>"
-msgstr "Osclass har blitt oppdatert. <a href=\"http://forums.osclass.org/\">Trenger du mer hjelp?</a>"
+msgid "Osclass has been updated successfully. <a href=\"https://osclass.discourse.group/\">Need more help?</a>"
+msgstr "Osclass har blitt oppdatert. <a href=\"https://osclass.discourse.group/\">Trenger du mer hjelp?</a>"
 
 #: oc-load.php:206
 msgid "The website is currently undergoing maintenance"

--- a/oc-content/languages/no_NO/index.php
+++ b/oc-content/languages/no_NO/index.php
@@ -26,7 +26,7 @@ function locale_no_NO_info() {
         ,'description'     => 'Norwegian translation'
         ,'version'         => '3.3.00'
         ,'author_name'     => 'Osclass'
-        ,'author_url'      => 'http://osclass.org/'
+        ,'author_url'      => 'https://github.com/navjottomer/osclass/'
         ,'currency_format' => '{NUMBER} {CURRENCY}'
         ,'date_format'     => 'm/d/Y'
         ,'stop_words'      => ''

--- a/oc-content/languages/no_NO/messages.po
+++ b/oc-content/languages/no_NO/messages.po
@@ -55,8 +55,8 @@ msgid "Your email has been sent properly."
 msgstr "Din e-post har blitt sendt uten feil."
 
 #: oc-includes/osclass/upgrade-funcs.php:460
-msgid "Osclass has been updated successfully. <a href=\"http://forums.osclass.org/\">Need more help?</a>"
-msgstr "Osclass har blitt oppdatert. <a href=\"http://forums.osclass.org/\">Need more help?</a>"
+msgid "Osclass has been updated successfully. <a href=\"https://osclass.discourse.group/\">Need more help?</a>"
+msgstr "Osclass har blitt oppdatert. <a href=\"https://osclass.discourse.group/\">Need more help?</a>"
 
 #: oc-includes/osclass/controller/ajax.php:115
 #: oc-includes/osclass/controller/item.php:320

--- a/oc-content/languages/no_NO/theme.po
+++ b/oc-content/languages/no_NO/theme.po
@@ -30,8 +30,8 @@ msgstr "%1$d - %2$d av %3$d annonser"
 msgid "Premium listings"
 msgstr "Premium annonser"
 
-msgid "http://osclass.org/"
-msgstr "http://osclass.org/"
+msgid "https://github.com/navjottomer/osclass/"
+msgstr "https://github.com/navjottomer/osclass/"
 
 msgid "Bender theme"
 msgstr "Bender tema"
@@ -148,12 +148,12 @@ msgid "Footer link"
 msgstr "Bunntekstlink"
 
 #: admin/settings.php:45
-msgid "I want to help Osclass by linking to <a href=\"http://osclass.org/\" target=\"_blank\">osclass.org</a> from my site with the following text:"
-msgstr "Jeg ønsker å hjelpe Osclass ved å linke til <a href=\"http://osclass.org/\" target=\"_blank\">osclass.org</a> fra nettstedet mitt med følgende tekst:"
+msgid "I want to help Osclass by linking to <a href=\"https://github.com/navjottomer/osclass/\" target=\"_blank\">osclass.org</a> from my site with the following text:"
+msgstr "Jeg ønsker å hjelpe Osclass ved å linke til <a href=\"https://github.com/navjottomer/osclass/\" target=\"_blank\">osclass.org</a> fra nettstedet mitt med følgende tekst:"
 
 #: admin/settings.php:46
-msgid "This website is proudly using the <a title=\"Osclass web\" href=\"http://osclass.org/\">classifieds scripts</a> software <strong>Osclass</strong>"
-msgstr "Denne nettsiden er en stolt bruker av <a title=\"Osclass web\" href=\"http://osclass.org/\">rubrikkannonse</a>-programvaren <strong>Osclass</strong>"
+msgid "This website is proudly using the <a title=\"Osclass web\" href=\"https://github.com/navjottomer/osclass/\">classifieds scripts</a> software <strong>Osclass</strong>"
+msgstr "Denne nettsiden er en stolt bruker av <a title=\"Osclass web\" href=\"https://github.com/navjottomer/osclass/\">rubrikkannonse</a>-programvaren <strong>Osclass</strong>"
 
 #: admin/settings.php:50
 msgid "Save changes"

--- a/oc-content/languages/pl_PL/core.po
+++ b/oc-content/languages/pl_PL/core.po
@@ -1678,8 +1678,8 @@ msgid "Your Osclass installation at %s is up and running. You can access the adm
 msgstr "Twoja instalacja Osclass %s została poprawnie uruchomiona. Możesz zalogować się do panelu administracyjnego używając nastepujących danych:"
 
 #: oc-includes/osclass/install-location.php:107
-msgid "The <a href=\"http://osclass.org/\">Osclass</a> team"
-msgstr "Zespół <a href=\"http://osclass.org/\">Osclass</a>"
+msgid "The <a href=\"https://github.com/navjottomer/osclass/\">Osclass</a> team"
+msgstr "Zespół <a href=\"https://github.com/navjottomer/osclass/\">Osclass</a>"
 
 #: oc-includes/osclass/install.php:89
 msgid "Looks like you've already installed Osclass. To reinstall please clear your old database tables first."
@@ -1738,8 +1738,8 @@ msgid "We've encountered some problems while updating the database structure. Th
 msgstr "Wystąpił błąd podczas aktualizowania struktury bazy danych. Nie powiodły się następujące zapytania:"
 
 #: oc-includes/osclass/upgrade-funcs.php:46
-msgid "These errors could be false-positive errors. If you're sure that is the case, you can <a href=\"%s\">continue with the upgrade</a>, or <a href=\"http://forums.osclass.org/\">ask in our forums</a>."
-msgstr "Te błędy mogą być błędami fałszywie dodatnymi. Jeżeli to ten przypadek, możesz <a href=\"%s\">kontynuować aktualizację</a>, lub <a href=\"http://forums.osclass.org/\">skonsultować go na forum</a>."
+msgid "These errors could be false-positive errors. If you're sure that is the case, you can <a href=\"%s\">continue with the upgrade</a>, or <a href=\"https://osclass.discourse.group/\">ask in our forums</a>."
+msgstr "Te błędy mogą być błędami fałszywie dodatnymi. Jeżeli to ten przypadek, możesz <a href=\"%s\">kontynuować aktualizację</a>, lub <a href=\"https://osclass.discourse.group/\">skonsultować go na forum</a>."
 
 #: oc-includes/osclass/upgrade-funcs.php:286
 msgid "You need to calculate location stats, please go to admin panel, tools, recalculate location stats or click"
@@ -1750,8 +1750,8 @@ msgid "Osclass &raquo; Updated correctly"
 msgstr "Osclass &raquo; zostało zaktualizowane poprawnie"
 
 #: oc-includes/osclass/upgrade-funcs.php:521
-msgid "Osclass has been updated successfully. <a href=\"http://forums.osclass.org/\">Need more help?</a>"
-msgstr "Osclass zostało zaktualizowane poprawnie.  <a href=\"http://forums.osclass.org/\">Potrzebujesz pomocy?</a>"
+msgid "Osclass has been updated successfully. <a href=\"https://osclass.discourse.group/\">Need more help?</a>"
+msgstr "Osclass zostało zaktualizowane poprawnie.  <a href=\"https://osclass.discourse.group/\">Potrzebujesz pomocy?</a>"
 
 #: oc-load.php:214
 msgid "The website is currently undergoing maintenance"

--- a/oc-content/languages/pl_PL/index.php
+++ b/oc-content/languages/pl_PL/index.php
@@ -26,7 +26,7 @@ function locale_pl_PL_info() {
         ,'description'     => 'Polish translation'
         ,'version'         => 'Osclass 3.5.0'
         ,'author_name'     => 'Osclass'
-        ,'author_url'      => 'http://osclass.org/'
+        ,'author_url'      => 'https://github.com/navjottomer/osclass/'
         ,'currency_format' => '{NUMBER} {CURRENCY}'
         ,'date_format'     => 'm/d/Y'
         ,'stop_words'      => ''

--- a/oc-content/languages/pl_PL/messages.po
+++ b/oc-content/languages/pl_PL/messages.po
@@ -1689,8 +1689,8 @@ msgid "Your email has been sent properly."
 msgstr "Twój e-mail został wysłany."
 
 #: oc-includes/osclass/upgrade-funcs.php:516
-msgid "Osclass has been updated successfully. <a href=\"http://forums.osclass.org/\">Need more help?</a>"
-msgstr "Osclass został uaktualniony. <a href=\"http://forums.osclass.org/\">Potrzebujesz jeszcze pomocy?</a>"
+msgid "Osclass has been updated successfully. <a href=\"https://osclass.discourse.group/\">Need more help?</a>"
+msgstr "Osclass został uaktualniony. <a href=\"https://osclass.discourse.group/\">Potrzebujesz jeszcze pomocy?</a>"
 
 #: oc-admin/plugins.php:231
 msgid "The files were deleted"

--- a/oc-content/languages/pl_PL/theme.po
+++ b/oc-content/languages/pl_PL/theme.po
@@ -119,12 +119,12 @@ msgid "Footer link"
 msgstr "Link w stopce"
 
 #: admin/settings.php:67
-msgid "I want to help Osclass by linking to <a href=\"http://osclass.org/\" target=\"_blank\">osclass.org</a> from my site with the following text:"
-msgstr "Chcę wspomóc Osclass dodając link do strony <a href=\"http://osclass.org/\" target=\"_blank\">osclass.org</a> z następującym tekstem:"
+msgid "I want to help Osclass by linking to <a href=\"https://github.com/navjottomer/osclass/\" target=\"_blank\">osclass.org</a> from my site with the following text:"
+msgstr "Chcę wspomóc Osclass dodając link do strony <a href=\"https://github.com/navjottomer/osclass/\" target=\"_blank\">osclass.org</a> z następującym tekstem:"
 
 #: admin/settings.php:68
-msgid "This website is proudly using the <a title=\"Osclass web\" href=\"http://osclass.org/\">classifieds scripts</a> software <strong>Osclass</strong>"
-msgstr "Ten serwis z dumą korzysta ze <a title=\"Osclass web\" href=\"http://osclass.org/\">skryptu</a> <strong>Osclass</strong>"
+msgid "This website is proudly using the <a title=\"Osclass web\" href=\"https://github.com/navjottomer/osclass/\">classifieds scripts</a> software <strong>Osclass</strong>"
+msgstr "Ten serwis z dumą korzysta ze <a title=\"Osclass web\" href=\"https://github.com/navjottomer/osclass/\">skryptu</a> <strong>Osclass</strong>"
 
 #: admin/settings.php:124
 msgid "Save changes"
@@ -798,8 +798,8 @@ msgstr "%1$d - %2$d z %3$d ogłoszeń"
 msgid "Premium listings"
 msgstr "Ogłoszenia premium"
 
-msgid "http://osclass.org/"
-msgstr "http://osclass.org/"
+msgid "https://github.com/navjottomer/osclass/"
+msgstr "https://github.com/navjottomer/osclass/"
 
 msgid "Bender theme"
 msgstr "Motyw Bender"

--- a/oc-content/languages/pt_BR/core.po
+++ b/oc-content/languages/pt_BR/core.po
@@ -5265,8 +5265,8 @@ msgid "Your Osclass installation at %s is up and running. You can access the adm
 msgstr "Sua instalação Osclass at %s está instalado e funcionando. Você pode acessar o painel de administração com esses detalhes:"
 
 #: oc-includes/osclass/install-location.php:105
-msgid "The <a href=\"http://osclass.org/\">Osclass</a> team"
-msgstr "O <a href=\"http://osclass.org/\">Osclass</a> equipe"
+msgid "The <a href=\"https://github.com/navjottomer/osclass/\">Osclass</a> team"
+msgstr "O <a href=\"https://github.com/navjottomer/osclass/\">Osclass</a> equipe"
 
 #: oc-includes/osclass/install.php:88
 msgid "Looks like you've already installed Osclass. To reinstall please clear your old database tables first."
@@ -5325,8 +5325,8 @@ msgid "We've encountered some problems while updating the database structure. Th
 msgstr "Nós encontramos alguns problemas ao atualizar a estrutura do banco. As consultas a seguir falhou:"
 
 #: oc-includes/osclass/upgrade-funcs.php:47
-msgid "These errors could be false-positive errors. If you're sure that is the case, you can <a href=\"%s\">continue with the upgrade</a>, or <a href=\"http://forums.osclass.org/\">ask in our forums</a>."
-msgstr "Esses erros podem ser erros de falso-positivos. Se você tem certeza que é o caso, você pode <a href=\"%s\"> continuar com a atualização</a>, ou <a href=\"http://forums.osclass.org/\"> pedir em nossos fóruns</a>."
+msgid "These errors could be false-positive errors. If you're sure that is the case, you can <a href=\"%s\">continue with the upgrade</a>, or <a href=\"https://osclass.discourse.group/\">ask in our forums</a>."
+msgstr "Esses erros podem ser erros de falso-positivos. Se você tem certeza que é o caso, você pode <a href=\"%s\"> continuar com a atualização</a>, ou <a href=\"https://osclass.discourse.group/\"> pedir em nossos fóruns</a>."
 
 #: oc-includes/osclass/upgrade-funcs.php:287
 msgid "You need to calculate location stats, please go to admin panel, tools, recalculate location stats or click"
@@ -5337,8 +5337,8 @@ msgid "Osclass &raquo; Updated correctly"
 msgstr "Osclass Atualizado corretamente"
 
 #: oc-includes/osclass/upgrade-funcs.php:447
-msgid "Osclass has been updated successfully. <a href=\"http://forums.osclass.org/\">Need more help?</a>"
-msgstr "Osclass foi atualizado com sucesso. <a href=\"http://forums.osclass.org/\"> Precisa de mais ajuda? </a>"
+msgid "Osclass has been updated successfully. <a href=\"https://osclass.discourse.group/\">Need more help?</a>"
+msgstr "Osclass foi atualizado com sucesso. <a href=\"https://osclass.discourse.group/\"> Precisa de mais ajuda? </a>"
 
 #: oc-load.php:206
 msgid "The website is currently undergoing maintenance"

--- a/oc-content/languages/pt_BR/index.php
+++ b/oc-content/languages/pt_BR/index.php
@@ -26,7 +26,7 @@ function locale_pt_BR_info() {
         ,'description'     => 'Portuguese (Brazil) translation'
         ,'version'         => 'Dev version'
         ,'author_name'     => 'Osclass'
-        ,'author_url'      => 'http://osclass.org/'
+        ,'author_url'      => 'https://github.com/navjottomer/osclass/'
         ,'currency_format' => '{NUMBER} {CURRENCY}'
         ,'date_format'     => 'm/d/Y'
         ,'stop_words'      => ''

--- a/oc-content/languages/pt_BR/theme.po
+++ b/oc-content/languages/pt_BR/theme.po
@@ -119,12 +119,12 @@ msgid "Footer link"
 msgstr "Link de Rodapé"
 
 #: admin/settings.php:45
-msgid "I want to help Osclass by linking to <a href=\"http://osclass.org/\" target=\"_blank\">osclass.org</a> from my site with the following text:"
-msgstr "Eu quero ajudar o Osclass colocando o link <a href=\"http://osclass.org/\" target=\"_blank\">osclass.org</a> do meu site com o seguinte texto:"
+msgid "I want to help Osclass by linking to <a href=\"https://github.com/navjottomer/osclass/\" target=\"_blank\">osclass.org</a> from my site with the following text:"
+msgstr "Eu quero ajudar o Osclass colocando o link <a href=\"https://github.com/navjottomer/osclass/\" target=\"_blank\">osclass.org</a> do meu site com o seguinte texto:"
 
 #: admin/settings.php:46
-msgid "This website is proudly using the <a title=\"Osclass web\" href=\"http://osclass.org/\">classifieds scripts</a> software <strong>Osclass</strong>"
-msgstr "Este site é orgulhosamente usa <a title=\"Osclass web\" href=\"http://osclass.org/\">classificados</a> software <strong>Osclass</strong>"
+msgid "This website is proudly using the <a title=\"Osclass web\" href=\"https://github.com/navjottomer/osclass/\">classifieds scripts</a> software <strong>Osclass</strong>"
+msgstr "Este site é orgulhosamente usa <a title=\"Osclass web\" href=\"https://github.com/navjottomer/osclass/\">classificados</a> software <strong>Osclass</strong>"
 
 #: admin/settings.php:50
 msgid "Save changes"

--- a/oc-content/languages/pt_PT/core.po
+++ b/oc-content/languages/pt_PT/core.po
@@ -4798,8 +4798,8 @@ msgid "Your Osclass installation at %s is up and running. You can access the adm
 msgstr "A sua instalação do Osclass em %s está pronta e a correr. Pode aceder ao painel de administração com os detalhes seguintes:"
 
 #: oc-includes/osclass/install-location.php:105
-msgid "The <a href=\"http://osclass.org/\">Osclass</a> team"
-msgstr "A equipa <a href=\"http://osclass.org/\">Osclass</a>"
+msgid "The <a href=\"https://github.com/navjottomer/osclass/\">Osclass</a> team"
+msgstr "A equipa <a href=\"https://github.com/navjottomer/osclass/\">Osclass</a>"
 
 #: oc-includes/osclass/install.php:88
 msgid "Looks like you've already installed Osclass. To reinstall please clear your old database tables first."
@@ -4858,8 +4858,8 @@ msgid "We've encountered some problems while updating the database structure. Th
 msgstr "Encontrámos alguns problemas ao atualizar a estrutura da base de dados. As seguintes queries falharam:"
 
 #: oc-includes/osclass/upgrade-funcs.php:47
-msgid "These errors could be false-positive errors. If you're sure that is the case, you can <a href=\"%s\">continue with the upgrade</a>, or <a href=\"http://forums.osclass.org/\">ask in our forums</a>."
-msgstr "Estes erros podem ser falsos positivos. Se tem a certeza que é o caso pode <a href=\"%s\">continuar com a atualização</a>, ou <a href=\"http://forums.osclass.org/\">perguntar nos nossos forums</a>."
+msgid "These errors could be false-positive errors. If you're sure that is the case, you can <a href=\"%s\">continue with the upgrade</a>, or <a href=\"https://osclass.discourse.group/\">ask in our forums</a>."
+msgstr "Estes erros podem ser falsos positivos. Se tem a certeza que é o caso pode <a href=\"%s\">continuar com a atualização</a>, ou <a href=\"https://osclass.discourse.group/\">perguntar nos nossos forums</a>."
 
 #: oc-includes/osclass/upgrade-funcs.php:286
 msgid "You need to calculate location stats, please go to admin panel, tools, recalculate location stats or click"
@@ -4870,8 +4870,8 @@ msgid "Osclass &raquo; Updated correctly"
 msgstr "Osclass &raquo; Atualizado corretamente"
 
 #: oc-includes/osclass/upgrade-funcs.php:426
-msgid "Osclass has been updated successfully. <a href=\"http://forums.osclass.org/\">Need more help?</a>"
-msgstr "O Osclass foi atualizado corretamente.  <a href=\"http://forums.osclass.org/\">Necessita de mais ajuda?</a>"
+msgid "Osclass has been updated successfully. <a href=\"https://osclass.discourse.group/\">Need more help?</a>"
+msgstr "O Osclass foi atualizado corretamente.  <a href=\"https://osclass.discourse.group/\">Necessita de mais ajuda?</a>"
 
 #: oc-load.php:212
 msgid "The website is currently undergoing maintenance"

--- a/oc-content/languages/pt_PT/index.php
+++ b/oc-content/languages/pt_PT/index.php
@@ -26,7 +26,7 @@ function locale_pt_PT_info() {
         ,'description'     => 'Portuguese (Portugal) translation'
         ,'version'         => '3.1.0'
         ,'author_name'     => 'Osclass'
-        ,'author_url'      => 'http://osclass.org/'
+        ,'author_url'      => 'https://github.com/navjottomer/osclass/'
         ,'currency_format' => '{NUMBER} {CURRENCY}'
         ,'date_format'     => 'm/d/Y'
         ,'stop_words'      => ''

--- a/oc-content/languages/pt_PT/theme.po
+++ b/oc-content/languages/pt_PT/theme.po
@@ -768,8 +768,8 @@ msgid "Osclass can't upload the logo image from the administration panel."
 msgstr "O Osclass não pode carregar o logotipo pelo painel de administração."
 
 #: admin/settings.php:34
-msgid "I want to help Osclass by linking to <a href=\"http://osclass.org/\" target=\"_blank\">osclass.org</a> from my site with the following text:"
-msgstr "Quero ajudar o Osclass fazendo um link para  <a href=\"http://osclass.org/\" target=\"_blank\">osclass.org</a>  do meu portal com o seguinte texto:"
+msgid "I want to help Osclass by linking to <a href=\"https://github.com/navjottomer/osclass/\" target=\"_blank\">osclass.org</a> from my site with the following text:"
+msgstr "Quero ajudar o Osclass fazendo um link para  <a href=\"https://github.com/navjottomer/osclass/\" target=\"_blank\">osclass.org</a>  do meu portal com o seguinte texto:"
 
 #: admin/header.php:55
 msgid "Please make the aforementioned image folder writable."
@@ -780,8 +780,8 @@ msgid "I would like to contribute to the development of Osclass with a donation 
 msgstr "Desejo contribuir para o desenvolvimento do Osclass com um donativo de"
 
 #: admin/settings.php:35 footer.php:35
-msgid "This website is proudly using the <a title=\"Osclass web\" href=\"http://osclass.org/\">classifieds scripts</a> software <strong>Osclass</strong>"
-msgstr "Este portal está a utilizar o  <a title=\"Osclass web\" href=\"http://osclass.org/\">script de classificados</a>  <strong>Osclass</strong>"
+msgid "This website is proudly using the <a title=\"Osclass web\" href=\"https://github.com/navjottomer/osclass/\">classifieds scripts</a> software <strong>Osclass</strong>"
+msgstr "Este portal está a utilizar o  <a title=\"Osclass web\" href=\"https://github.com/navjottomer/osclass/\">script de classificados</a>  <strong>Osclass</strong>"
 
 #: admin/settings.php:39
 msgid "Default logo"

--- a/oc-content/languages/ro_RO/core.po
+++ b/oc-content/languages/ro_RO/core.po
@@ -1678,8 +1678,8 @@ msgid "Your Osclass installation at %s is up and running. You can access the adm
 msgstr "Instanța de Osclass aflată la %s este funcțională. Poți accesa panoul de control folosind aceste detalii:"
 
 #: oc-includes/osclass/install-location.php:107
-msgid "The <a href=\"http://osclass.org/\">Osclass</a> team"
-msgstr "Echipa <a href=\"http://osclass.org/\">Osclass</a>"
+msgid "The <a href=\"https://github.com/navjottomer/osclass/\">Osclass</a> team"
+msgstr "Echipa <a href=\"https://github.com/navjottomer/osclass/\">Osclass</a>"
 
 #: oc-includes/osclass/install.php:89
 msgid "Looks like you've already installed Osclass. To reinstall please clear your old database tables first."
@@ -1738,8 +1738,8 @@ msgid "We've encountered some problems while updating the database structure. Th
 msgstr "Am întâmpinat câteva probleme încercând să actualizăm structura bazei de date. Următoarele querie au eșuat:"
 
 #: oc-includes/osclass/upgrade-funcs.php:46
-msgid "These errors could be false-positive errors. If you're sure that is the case, you can <a href=\"%s\">continue with the upgrade</a>, or <a href=\"http://forums.osclass.org/\">ask in our forums</a>."
-msgstr "Aceste erori pot fi fals-pozitive. Dacă ești sigur că așa este, poți <a href=\"%s\">continua cu actualizarea</a>, sau <a href=\"http://forums.osclass.org/\">întreaba în forumul nostru</a>."
+msgid "These errors could be false-positive errors. If you're sure that is the case, you can <a href=\"%s\">continue with the upgrade</a>, or <a href=\"https://osclass.discourse.group/\">ask in our forums</a>."
+msgstr "Aceste erori pot fi fals-pozitive. Dacă ești sigur că așa este, poți <a href=\"%s\">continua cu actualizarea</a>, sau <a href=\"https://osclass.discourse.group/\">întreaba în forumul nostru</a>."
 
 #: oc-includes/osclass/upgrade-funcs.php:286
 msgid "You need to calculate location stats, please go to admin panel, tools, recalculate location stats or click"
@@ -1750,8 +1750,8 @@ msgid "Osclass &raquo; Updated correctly"
 msgstr "Osclass &raquo; s-a actualizat corect"
 
 #: oc-includes/osclass/upgrade-funcs.php:521
-msgid "Osclass has been updated successfully. <a href=\"http://forums.osclass.org/\">Need more help?</a>"
-msgstr "Osclass s-a actualizat corect. <a href=\"http://forums.osclass.org/\">Mai vrei ajutor pentru altceva?</a>"
+msgid "Osclass has been updated successfully. <a href=\"https://osclass.discourse.group/\">Need more help?</a>"
+msgstr "Osclass s-a actualizat corect. <a href=\"https://osclass.discourse.group/\">Mai vrei ajutor pentru altceva?</a>"
 
 #: oc-load.php:214
 msgid "The website is currently undergoing maintenance"

--- a/oc-content/languages/ro_RO/index.php
+++ b/oc-content/languages/ro_RO/index.php
@@ -26,7 +26,7 @@ function locale_ro_RO_info() {
         ,'description'     => 'Romanian translation'
         ,'version'         => 'Osclass 3.5.0'
         ,'author_name'     => 'Osclass'
-        ,'author_url'      => 'http://osclass.org/'
+        ,'author_url'      => 'https://github.com/navjottomer/osclass/'
         ,'currency_format' => '{NUMBER} {CURRENCY}'
         ,'date_format'     => 'm/d/Y'
         ,'stop_words'      => ''

--- a/oc-content/languages/ro_RO/messages.po
+++ b/oc-content/languages/ro_RO/messages.po
@@ -1689,8 +1689,8 @@ msgid "Your email has been sent properly."
 msgstr "E-mail-ul a fost trimis corespunzător."
 
 #: oc-includes/osclass/upgrade-funcs.php:516
-msgid "Osclass has been updated successfully. <a href=\"http://forums.osclass.org/\">Need more help?</a>"
-msgstr "Osclass a fost actualizat cu succes. <a href=\"http://forums.osclass.org/\">Ai nevoie de mai mult ajutor?</a>"
+msgid "Osclass has been updated successfully. <a href=\"https://osclass.discourse.group/\">Need more help?</a>"
+msgstr "Osclass a fost actualizat cu succes. <a href=\"https://osclass.discourse.group/\">Ai nevoie de mai mult ajutor?</a>"
 
 #: oc-admin/plugins.php:231
 msgid "The files were deleted"

--- a/oc-content/languages/ro_RO/theme.po
+++ b/oc-content/languages/ro_RO/theme.po
@@ -119,12 +119,12 @@ msgid "Footer link"
 msgstr "Link subsol"
 
 #: admin/settings.php:67
-msgid "I want to help Osclass by linking to <a href=\"http://osclass.org/\" target=\"_blank\">osclass.org</a> from my site with the following text:"
-msgstr "Doresc să ajut Osclass prin conectarea la <a href=\"http://osclass.org/\" target=\"_blank\">osclass.org</a> direct de pe site-ul meu, folosind următorul text:"
+msgid "I want to help Osclass by linking to <a href=\"https://github.com/navjottomer/osclass/\" target=\"_blank\">osclass.org</a> from my site with the following text:"
+msgstr "Doresc să ajut Osclass prin conectarea la <a href=\"https://github.com/navjottomer/osclass/\" target=\"_blank\">osclass.org</a> direct de pe site-ul meu, folosind următorul text:"
 
 #: admin/settings.php:68
-msgid "This website is proudly using the <a title=\"Osclass web\" href=\"http://osclass.org/\">classifieds scripts</a> software <strong>Osclass</strong>"
-msgstr "Acest site foloseşte cu încredere <a title=\"Osclass web\" href=\"http://osclass.org/\">scripturile de anunţuri</a><strong>Osclass</strong>"
+msgid "This website is proudly using the <a title=\"Osclass web\" href=\"https://github.com/navjottomer/osclass/\">classifieds scripts</a> software <strong>Osclass</strong>"
+msgstr "Acest site foloseşte cu încredere <a title=\"Osclass web\" href=\"https://github.com/navjottomer/osclass/\">scripturile de anunţuri</a><strong>Osclass</strong>"
 
 #: admin/settings.php:124
 msgid "Save changes"
@@ -798,8 +798,8 @@ msgstr "%1$d - %2$d din %3$d anunţuri"
 msgid "Premium listings"
 msgstr "Anunţuri premium"
 
-msgid "http://osclass.org/"
-msgstr "http://osclass.org/"
+msgid "https://github.com/navjottomer/osclass/"
+msgstr "https://github.com/navjottomer/osclass/"
 
 msgid "Bender theme"
 msgstr "Tema Bender"

--- a/oc-content/languages/ru_RU/core.po
+++ b/oc-content/languages/ru_RU/core.po
@@ -1678,8 +1678,8 @@ msgid "Your Osclass installation at %s is up and running. You can access the adm
 msgstr "Osclass установлен %s запущен и работает. Вы можете получить доступ к панели администратора с такими данными:"
 
 #: oc-includes/osclass/install-location.php:107
-msgid "The <a href=\"http://osclass.org/\">Osclass</a> team"
-msgstr "Команда <a href=\"http://osclass.org/\">Osclass</a>"
+msgid "The <a href=\"https://github.com/navjottomer/osclass/\">Osclass</a> team"
+msgstr "Команда <a href=\"https://github.com/navjottomer/osclass/\">Osclass</a>"
 
 #: oc-includes/osclass/install.php:89
 msgid "Looks like you've already installed Osclass. To reinstall please clear your old database tables first."
@@ -1738,8 +1738,8 @@ msgid "We've encountered some problems while updating the database structure. Th
 msgstr "Мы столкнулись с некоторыми проблемами при обновлении структуры базы данных. Следующие запросы не удалось:"
 
 #: oc-includes/osclass/upgrade-funcs.php:46
-msgid "These errors could be false-positive errors. If you're sure that is the case, you can <a href=\"%s\">continue with the upgrade</a>, or <a href=\"http://forums.osclass.org/\">ask in our forums</a>."
-msgstr "Эти ошибки могут быть ложно-положительные. Если вы уверены, что это так, вы можете <a href=\"%s\">продолжить установку обновления</a>, или <a href=\"http://forums.osclass.org/\">сообщить на форум</a>."
+msgid "These errors could be false-positive errors. If you're sure that is the case, you can <a href=\"%s\">continue with the upgrade</a>, or <a href=\"https://osclass.discourse.group/\">ask in our forums</a>."
+msgstr "Эти ошибки могут быть ложно-положительные. Если вы уверены, что это так, вы можете <a href=\"%s\">продолжить установку обновления</a>, или <a href=\"https://osclass.discourse.group/\">сообщить на форум</a>."
 
 #: oc-includes/osclass/upgrade-funcs.php:286
 msgid "You need to calculate location stats, please go to admin panel, tools, recalculate location stats or click"
@@ -1750,8 +1750,8 @@ msgid "Osclass &raquo; Updated correctly"
 msgstr "Osclass &raquo; успешно обновлен"
 
 #: oc-includes/osclass/upgrade-funcs.php:521
-msgid "Osclass has been updated successfully. <a href=\"http://forums.osclass.org/\">Need more help?</a>"
-msgstr "Osclass успешно обновлен. <a href=\"http://forums.osclass.org/\">Если нужна помощь?</a>"
+msgid "Osclass has been updated successfully. <a href=\"https://osclass.discourse.group/\">Need more help?</a>"
+msgstr "Osclass успешно обновлен. <a href=\"https://osclass.discourse.group/\">Если нужна помощь?</a>"
 
 #: oc-load.php:214
 msgid "The website is currently undergoing maintenance"

--- a/oc-content/languages/ru_RU/index.php
+++ b/oc-content/languages/ru_RU/index.php
@@ -26,7 +26,7 @@ function locale_ru_RU_info() {
         ,'description'     => 'Russian translation'
         ,'version'         => 'Osclass 3.5.0'
         ,'author_name'     => 'Osclass'
-        ,'author_url'      => 'http://osclass.org/'
+        ,'author_url'      => 'https://github.com/navjottomer/osclass/'
         ,'currency_format' => '{NUMBER} {CURRENCY}'
         ,'date_format'     => 'm/d/Y'
         ,'stop_words'      => ''

--- a/oc-content/languages/ru_RU/messages.po
+++ b/oc-content/languages/ru_RU/messages.po
@@ -1689,8 +1689,8 @@ msgid "Your email has been sent properly."
 msgstr "Ваш email успешно отправлен."
 
 #: oc-includes/osclass/upgrade-funcs.php:516
-msgid "Osclass has been updated successfully. <a href=\"http://forums.osclass.org/\">Need more help?</a>"
-msgstr "Osclass успешно обновлен. <a href=\"http://forums.osclass.org/\">Нужна помощь?</a>"
+msgid "Osclass has been updated successfully. <a href=\"https://osclass.discourse.group/\">Need more help?</a>"
+msgstr "Osclass успешно обновлен. <a href=\"https://osclass.discourse.group/\">Нужна помощь?</a>"
 
 #: oc-admin/plugins.php:231
 msgid "The files were deleted"

--- a/oc-content/languages/ru_RU/theme.po
+++ b/oc-content/languages/ru_RU/theme.po
@@ -119,12 +119,12 @@ msgid "Footer link"
 msgstr "Ссылка нижнего колонтитула"
 
 #: admin/settings.php:67
-msgid "I want to help Osclass by linking to <a href=\"http://osclass.org/\" target=\"_blank\">osclass.org</a> from my site with the following text:"
-msgstr "Я хочу помочь Osclass, установив ссылку<a href=\"http://osclass.org/\" target=\"_blank\">osclass.org</a> с моего сайта со следующим текстом:"
+msgid "I want to help Osclass by linking to <a href=\"https://github.com/navjottomer/osclass/\" target=\"_blank\">osclass.org</a> from my site with the following text:"
+msgstr "Я хочу помочь Osclass, установив ссылку<a href=\"https://github.com/navjottomer/osclass/\" target=\"_blank\">osclass.org</a> с моего сайта со следующим текстом:"
 
 #: admin/settings.php:68
-msgid "This website is proudly using the <a title=\"Osclass web\" href=\"http://osclass.org/\">classifieds scripts</a> software <strong>Osclass</strong>"
-msgstr "Этот вебсайт использует <a title=\"Osclass web\" href=\"http://osclass.org/\">classifieds scripts</a> ПО <strong>Osclass</strong>"
+msgid "This website is proudly using the <a title=\"Osclass web\" href=\"https://github.com/navjottomer/osclass/\">classifieds scripts</a> software <strong>Osclass</strong>"
+msgstr "Этот вебсайт использует <a title=\"Osclass web\" href=\"https://github.com/navjottomer/osclass/\">classifieds scripts</a> ПО <strong>Osclass</strong>"
 
 #: admin/settings.php:124
 msgid "Save changes"
@@ -798,8 +798,8 @@ msgstr "%1$d - %2$d из %3$d объявлений"
 msgid "Premium listings"
 msgstr "Премиум объявления"
 
-msgid "http://osclass.org/"
-msgstr "http://osclass.org/"
+msgid "https://github.com/navjottomer/osclass/"
+msgstr "https://github.com/navjottomer/osclass/"
 
 msgid "Bender theme"
 msgstr "Тема Bender"

--- a/oc-content/languages/th_TH/core.po
+++ b/oc-content/languages/th_TH/core.po
@@ -5265,8 +5265,8 @@ msgid "Your Osclass installation at %s is up and running. You can access the adm
 msgstr "การติดตั้ง Osclass ของคุณที่ %s และทำงาน คุณสามารถเข้าถึงแผงการควบคุมที่มีรายละเอียดเหล่านี้:"
 
 #: oc-includes/osclass/install-location.php:105
-msgid "The <a href=\"http://osclass.org/\">Osclass</a> team"
-msgstr "ทีมงาน <a href=\"http://osclass.org/\">Osclass</a> "
+msgid "The <a href=\"https://github.com/navjottomer/osclass/\">Osclass</a> team"
+msgstr "ทีมงาน <a href=\"https://github.com/navjottomer/osclass/\">Osclass</a> "
 
 #: oc-includes/osclass/install.php:88
 msgid "Looks like you've already installed Osclass. To reinstall please clear your old database tables first."
@@ -5325,8 +5325,8 @@ msgid "We've encountered some problems while updating the database structure. Th
 msgstr "เราได้พบปัญหาบางอย่างในขณะที่การปรับปรุงโครงสร้างฐานข้อมูล, คำสั่งดังต่อไปนี้ล้มเหลว:"
 
 #: oc-includes/osclass/upgrade-funcs.php:47
-msgid "These errors could be false-positive errors. If you're sure that is the case, you can <a href=\"%s\">continue with the upgrade</a>, or <a href=\"http://forums.osclass.org/\">ask in our forums</a>."
-msgstr "ข้อผิดพลาดเหล่านี้อาจเป็นข้อผิดพลาดแบบ false-positive errors. ถ้าคุณแน่ใจว่าเป็นกรณีนี้ คุณสามารถ <a href=\"%s\"> อัพเกรดต่อเนื่องได้ </a>, หรือ <a href=\"http://forums.osclass.org/\">ถามคำถามในฟอรั่ม</a>."
+msgid "These errors could be false-positive errors. If you're sure that is the case, you can <a href=\"%s\">continue with the upgrade</a>, or <a href=\"https://osclass.discourse.group/\">ask in our forums</a>."
+msgstr "ข้อผิดพลาดเหล่านี้อาจเป็นข้อผิดพลาดแบบ false-positive errors. ถ้าคุณแน่ใจว่าเป็นกรณีนี้ คุณสามารถ <a href=\"%s\"> อัพเกรดต่อเนื่องได้ </a>, หรือ <a href=\"https://osclass.discourse.group/\">ถามคำถามในฟอรั่ม</a>."
 
 #: oc-includes/osclass/upgrade-funcs.php:287
 msgid "You need to calculate location stats, please go to admin panel, tools, recalculate location stats or click"
@@ -5337,8 +5337,8 @@ msgid "Osclass &raquo; Updated correctly"
 msgstr "Osclass &raquo; อัพเดตอย่างถูกต้อง"
 
 #: oc-includes/osclass/upgrade-funcs.php:447
-msgid "Osclass has been updated successfully. <a href=\"http://forums.osclass.org/\">Need more help?</a>"
-msgstr "Osclass ได้ทำการอัพเดตเรียบร้อยแล้ว . <a href=\"http://forums.osclass.org/\">ต้องการความช่วยเหลืออื่น ๆ ?</a>"
+msgid "Osclass has been updated successfully. <a href=\"https://osclass.discourse.group/\">Need more help?</a>"
+msgstr "Osclass ได้ทำการอัพเดตเรียบร้อยแล้ว . <a href=\"https://osclass.discourse.group/\">ต้องการความช่วยเหลืออื่น ๆ ?</a>"
 
 #: oc-load.php:206
 msgid "The website is currently undergoing maintenance"

--- a/oc-content/languages/th_TH/index.php
+++ b/oc-content/languages/th_TH/index.php
@@ -26,7 +26,7 @@ function locale_th_TH_info() {
         ,'description'     => 'Thai translation'
         ,'version'         => 'Dev version'
         ,'author_name'     => 'Osclass'
-        ,'author_url'      => 'http://osclass.org/'
+        ,'author_url'      => 'https://github.com/navjottomer/osclass/'
         ,'currency_format' => '{NUMBER} {CURRENCY}'
         ,'date_format'     => 'm/d/Y'
         ,'stop_words'      => ''

--- a/oc-content/languages/th_TH/theme.po
+++ b/oc-content/languages/th_TH/theme.po
@@ -119,12 +119,12 @@ msgid "Footer link"
 msgstr "ลิ้งค์ด้านล่าง"
 
 #: admin/settings.php:45
-msgid "I want to help Osclass by linking to <a href=\"http://osclass.org/\" target=\"_blank\">osclass.org</a> from my site with the following text:"
-msgstr "ฉันต้องการที่จะช่วยให้ Osclass โดยเชื่อมโยงไป <a href=\"http://osclass.org/\" target=\"_blank\"> osclass.org </ a> จากเว็บไซต์ของฉันที่มีข้อความต่อไปนี้:"
+msgid "I want to help Osclass by linking to <a href=\"https://github.com/navjottomer/osclass/\" target=\"_blank\">osclass.org</a> from my site with the following text:"
+msgstr "ฉันต้องการที่จะช่วยให้ Osclass โดยเชื่อมโยงไป <a href=\"https://github.com/navjottomer/osclass/\" target=\"_blank\"> osclass.org </ a> จากเว็บไซต์ของฉันที่มีข้อความต่อไปนี้:"
 
 #: admin/settings.php:46
-msgid "This website is proudly using the <a title=\"Osclass web\" href=\"http://osclass.org/\">classifieds scripts</a> software <strong>Osclass</strong>"
-msgstr "เว็บไซต์นี้ได้อย่างภาคภูมิใจโดยใช้ <a title=\"Osclass web\" href=\"http://osclass.org/\"> คลาสสิฟายด์สคริปต์ </ a> ซอฟแวร์ <strong> Osclass </ strong>"
+msgid "This website is proudly using the <a title=\"Osclass web\" href=\"https://github.com/navjottomer/osclass/\">classifieds scripts</a> software <strong>Osclass</strong>"
+msgstr "เว็บไซต์นี้ได้อย่างภาคภูมิใจโดยใช้ <a title=\"Osclass web\" href=\"https://github.com/navjottomer/osclass/\"> คลาสสิฟายด์สคริปต์ </ a> ซอฟแวร์ <strong> Osclass </ strong>"
 
 #: admin/settings.php:50
 msgid "Save changes"

--- a/oc-content/languages/tr_TR/core.po
+++ b/oc-content/languages/tr_TR/core.po
@@ -3254,8 +3254,8 @@ msgid "Your Osclass installation at %s is up and running. You can access the adm
 msgstr "%s adresindeki Osclass kurulumu tamam ve işler durumda. Yönetici paneline şu bilgilerle erişilebilir:"
 
 #: oc-includes/osclass/install-location.php:105
-msgid "The <a href=\"http://osclass.org/\">Osclass</a> team"
-msgstr "<a href=\"http://osclass.org/\">Osclass</a> takımı"
+msgid "The <a href=\"https://github.com/navjottomer/osclass/\">Osclass</a> team"
+msgstr "<a href=\"https://github.com/navjottomer/osclass/\">Osclass</a> takımı"
 
 #: oc-includes/osclass/install.php:88
 msgid "Looks like you've already installed Osclass. To reinstall please clear your old database tables first."
@@ -3314,8 +3314,8 @@ msgid "We've encountered some problems while updating the database structure. Th
 msgstr "Veritabanı yapısını güncellerken bazı sorunlarla karşılaştık. Şu sorgular başarısız:"
 
 #: oc-includes/osclass/upgrade-funcs.php:47
-msgid "These errors could be false-positive errors. If you're sure that is the case, you can <a href=\"%s\">continue with the upgrade</a>, or <a href=\"http://forums.osclass.org/\">ask in our forums</a>."
-msgstr "Bu hatalar yanlışlıkla rapor edilmiş hatalar da olabilir. Durumun böyle olduğuna eminseniz <a href=\"%s\">yükseltme işlemine devam edin</a> ya da <a href=\"http://forums.osclass.org/\">forumlarda çözüm arayın</a>."
+msgid "These errors could be false-positive errors. If you're sure that is the case, you can <a href=\"%s\">continue with the upgrade</a>, or <a href=\"https://osclass.discourse.group/\">ask in our forums</a>."
+msgstr "Bu hatalar yanlışlıkla rapor edilmiş hatalar da olabilir. Durumun böyle olduğuna eminseniz <a href=\"%s\">yükseltme işlemine devam edin</a> ya da <a href=\"https://osclass.discourse.group/\">forumlarda çözüm arayın</a>."
 
 #: oc-includes/osclass/upgrade-funcs.php:287
 msgid "You need to calculate location stats, please go to admin panel, tools, recalculate location stats or click"
@@ -3326,8 +3326,8 @@ msgid "Osclass &raquo; Updated correctly"
 msgstr "Osclass &raquo; Doğru olarak yükseltildi"
 
 #: oc-includes/osclass/upgrade-funcs.php:465
-msgid "Osclass has been updated successfully. <a href=\"http://forums.osclass.org/\">Need more help?</a>"
-msgstr "Osclass başarıyla yükseltildi.<a href=\"http://forums.osclass.org/\">Daha fazla yardım gerekiyor mu?</a>"
+msgid "Osclass has been updated successfully. <a href=\"https://osclass.discourse.group/\">Need more help?</a>"
+msgstr "Osclass başarıyla yükseltildi.<a href=\"https://osclass.discourse.group/\">Daha fazla yardım gerekiyor mu?</a>"
 
 #: oc-load.php:206
 msgid "The website is currently undergoing maintenance"

--- a/oc-content/languages/tr_TR/index.php
+++ b/oc-content/languages/tr_TR/index.php
@@ -26,7 +26,7 @@ function locale_tr_TR_info() {
         ,'description'     => 'Turkish translation'
         ,'version'         => '3.3.00'
         ,'author_name'     => 'Osclass'
-        ,'author_url'      => 'http://osclass.org/'
+        ,'author_url'      => 'https://github.com/navjottomer/osclass/'
         ,'currency_format' => '{NUMBER} {CURRENCY}'
         ,'date_format'     => 'm/d/Y'
         ,'stop_words'      => ''

--- a/oc-content/languages/tr_TR/messages.po
+++ b/oc-content/languages/tr_TR/messages.po
@@ -55,8 +55,8 @@ msgid "Your email has been sent properly."
 msgstr "E-postanız gönderildi."
 
 #: oc-includes/osclass/upgrade-funcs.php:460
-msgid "Osclass has been updated successfully. <a href=\"http://forums.osclass.org/\">Need more help?</a>"
-msgstr "Osclass başarıyla yükseltildi.<a href=\"http://forums.osclass.org/\">Daha fazla yardım gerekiyor mu?</a>"
+msgid "Osclass has been updated successfully. <a href=\"https://osclass.discourse.group/\">Need more help?</a>"
+msgstr "Osclass başarıyla yükseltildi.<a href=\"https://osclass.discourse.group/\">Daha fazla yardım gerekiyor mu?</a>"
 
 #: oc-includes/osclass/controller/ajax.php:115
 #: oc-includes/osclass/controller/item.php:320

--- a/oc-content/languages/tr_TR/theme.po
+++ b/oc-content/languages/tr_TR/theme.po
@@ -30,7 +30,7 @@ msgstr "%3$d ilan içersinde %1$d - %2$d arası"
 msgid "Premium listings"
 msgstr "Öne çıkan ilanlar"
 
-msgid "http://osclass.org/"
+msgid "https://github.com/navjottomer/osclass/"
 msgstr "http://www.osclass.org/"
 
 msgid "Bender theme"
@@ -148,12 +148,12 @@ msgid "Footer link"
 msgstr "Alt bölüm linki"
 
 #: admin/settings.php:45
-msgid "I want to help Osclass by linking to <a href=\"http://osclass.org/\" target=\"_blank\">osclass.org</a> from my site with the following text:"
-msgstr "Websitemden <a href=\"http://osclass.org/\" target=\"_blank\">osclass.org</a>'a bağlantı verip, şu metin aracılığıyla Osclass'a yardım etmek istiyorum:"
+msgid "I want to help Osclass by linking to <a href=\"https://github.com/navjottomer/osclass/\" target=\"_blank\">osclass.org</a> from my site with the following text:"
+msgstr "Websitemden <a href=\"https://github.com/navjottomer/osclass/\" target=\"_blank\">osclass.org</a>'a bağlantı verip, şu metin aracılığıyla Osclass'a yardım etmek istiyorum:"
 
 #: admin/settings.php:46
-msgid "This website is proudly using the <a title=\"Osclass web\" href=\"http://osclass.org/\">classifieds scripts</a> software <strong>Osclass</strong>"
-msgstr "Bu web sitesinde <a title=\"Osclass web\" href=\"http://osclass.org/\">seri ilan</a> yazılımı <strong>Osclass</strong> kullanılıyor"
+msgid "This website is proudly using the <a title=\"Osclass web\" href=\"https://github.com/navjottomer/osclass/\">classifieds scripts</a> software <strong>Osclass</strong>"
+msgstr "Bu web sitesinde <a title=\"Osclass web\" href=\"https://github.com/navjottomer/osclass/\">seri ilan</a> yazılımı <strong>Osclass</strong> kullanılıyor"
 
 #: admin/settings.php:50
 msgid "Save changes"

--- a/oc-content/languages/uk_UK/core.po
+++ b/oc-content/languages/uk_UK/core.po
@@ -1678,8 +1678,8 @@ msgid "Your Osclass installation at %s is up and running. You can access the adm
 msgstr "Osclass встановлений %s запущений і працює. Ви можете отримати доступ до панелі адміністратора з такими даними:"
 
 #: oc-includes/osclass/install-location.php:107
-msgid "The <a href=\"http://osclass.org/\">Osclass</a> team"
-msgstr "Команда <a href=\"http://osclass.org/\">Osclass</a>"
+msgid "The <a href=\"https://github.com/navjottomer/osclass/\">Osclass</a> team"
+msgstr "Команда <a href=\"https://github.com/navjottomer/osclass/\">Osclass</a>"
 
 #: oc-includes/osclass/install.php:89
 msgid "Looks like you've already installed Osclass. To reinstall please clear your old database tables first."
@@ -1738,8 +1738,8 @@ msgid "We've encountered some problems while updating the database structure. Th
 msgstr "Ми зіткнулися з деякими проблемами при оновленні структури бази даних. Такі запити не вдалися:"
 
 #: oc-includes/osclass/upgrade-funcs.php:46
-msgid "These errors could be false-positive errors. If you're sure that is the case, you can <a href=\"%s\">continue with the upgrade</a>, or <a href=\"http://forums.osclass.org/\">ask in our forums</a>."
-msgstr "Ці помилки можуть бути хибно-позитивних помилок. Якщо ви впевнені, що це так, ви можете <a href=\"%s\">продовжити оновлення</a>або <a href=\"http://forums.osclass.org/\">задати у форумі</a>."
+msgid "These errors could be false-positive errors. If you're sure that is the case, you can <a href=\"%s\">continue with the upgrade</a>, or <a href=\"https://osclass.discourse.group/\">ask in our forums</a>."
+msgstr "Ці помилки можуть бути хибно-позитивних помилок. Якщо ви впевнені, що це так, ви можете <a href=\"%s\">продовжити оновлення</a>або <a href=\"https://osclass.discourse.group/\">задати у форумі</a>."
 
 #: oc-includes/osclass/upgrade-funcs.php:286
 msgid "You need to calculate location stats, please go to admin panel, tools, recalculate location stats or click"
@@ -1750,8 +1750,8 @@ msgid "Osclass &raquo; Updated correctly"
 msgstr "Osclass &raquo; успішно оновлено"
 
 #: oc-includes/osclass/upgrade-funcs.php:521
-msgid "Osclass has been updated successfully. <a href=\"http://forums.osclass.org/\">Need more help?</a>"
-msgstr "Osclass успішно оновлено. <a href=\"http://forums.osclass.org/\">Потрібна допомога?</a>"
+msgid "Osclass has been updated successfully. <a href=\"https://osclass.discourse.group/\">Need more help?</a>"
+msgstr "Osclass успішно оновлено. <a href=\"https://osclass.discourse.group/\">Потрібна допомога?</a>"
 
 #: oc-load.php:214
 msgid "The website is currently undergoing maintenance"

--- a/oc-content/languages/uk_UK/index.php
+++ b/oc-content/languages/uk_UK/index.php
@@ -26,7 +26,7 @@ function locale_uk_UK_info() {
         ,'description'     => 'Ukrainian translation'
         ,'version'         => 'Osclass 3.5.0'
         ,'author_name'     => 'Osclass'
-        ,'author_url'      => 'http://osclass.org/'
+        ,'author_url'      => 'https://github.com/navjottomer/osclass/'
         ,'currency_format' => '{NUMBER} {CURRENCY}'
         ,'date_format'     => 'm/d/Y'
         ,'stop_words'      => ''

--- a/oc-content/languages/uk_UK/messages.po
+++ b/oc-content/languages/uk_UK/messages.po
@@ -1689,8 +1689,8 @@ msgid "Your email has been sent properly."
 msgstr "Ваше повідомлення успішно відправлено."
 
 #: oc-includes/osclass/upgrade-funcs.php:516
-msgid "Osclass has been updated successfully. <a href=\"http://forums.osclass.org/\">Need more help?</a>"
-msgstr "Osclass успішно оновлено. <a href=\"http://forums.osclass.org/\">Потрібна допомога?</a>"
+msgid "Osclass has been updated successfully. <a href=\"https://osclass.discourse.group/\">Need more help?</a>"
+msgstr "Osclass успішно оновлено. <a href=\"https://osclass.discourse.group/\">Потрібна допомога?</a>"
 
 #: oc-admin/plugins.php:231
 msgid "The files were deleted"

--- a/oc-content/languages/uk_UK/theme.po
+++ b/oc-content/languages/uk_UK/theme.po
@@ -119,12 +119,12 @@ msgid "Footer link"
 msgstr "Посилання в підвалі"
 
 #: admin/settings.php:67
-msgid "I want to help Osclass by linking to <a href=\"http://osclass.org/\" target=\"_blank\">osclass.org</a> from my site with the following text:"
-msgstr "Я хочу допомогти Osclass посилання на <a href=\"http://osclass.org/\" target=\"_blank\">osclass.org</a> з мого сайту з наступним текстом:"
+msgid "I want to help Osclass by linking to <a href=\"https://github.com/navjottomer/osclass/\" target=\"_blank\">osclass.org</a> from my site with the following text:"
+msgstr "Я хочу допомогти Osclass посилання на <a href=\"https://github.com/navjottomer/osclass/\" target=\"_blank\">osclass.org</a> з мого сайту з наступним текстом:"
 
 #: admin/settings.php:68
-msgid "This website is proudly using the <a title=\"Osclass web\" href=\"http://osclass.org/\">classifieds scripts</a> software <strong>Osclass</strong>"
-msgstr "Цей сайт з гордістю працює на <a title=\"OSClass web\" href=\"http://osclass.org/\">скрипт дошки оголошень</a> <strong>OSClass</strong>"
+msgid "This website is proudly using the <a title=\"Osclass web\" href=\"https://github.com/navjottomer/osclass/\">classifieds scripts</a> software <strong>Osclass</strong>"
+msgstr "Цей сайт з гордістю працює на <a title=\"OSClass web\" href=\"https://github.com/navjottomer/osclass/\">скрипт дошки оголошень</a> <strong>OSClass</strong>"
 
 #: admin/settings.php:124
 msgid "Save changes"
@@ -798,8 +798,8 @@ msgstr "%1$d - %2$d з %3$d оголошень"
 msgid "Premium listings"
 msgstr "Преміум оголошення"
 
-msgid "http://osclass.org/"
-msgstr "http://osclass.org/"
+msgid "https://github.com/navjottomer/osclass/"
+msgstr "https://github.com/navjottomer/osclass/"
 
 msgid "Bender theme"
 msgstr "Тема Bender"

--- a/oc-content/languages/vi_VN/core.po
+++ b/oc-content/languages/vi_VN/core.po
@@ -5348,8 +5348,8 @@ msgid "Your Osclass installation at %s is up and running. You can access the adm
 msgstr "Osclass của bạn đã được cài đặt tại %s và đang hoạt động. Bạn có thể truy cập bảng quản trị với những thông tin sau:"
 
 #: oc-includes/osclass/install-location.php:107
-msgid "The <a href=\"http://osclass.org/\">Osclass</a> team"
-msgstr "Nhóm <a href=\"http://osclass.org/\">Osclass</a>"
+msgid "The <a href=\"https://github.com/navjottomer/osclass/\">Osclass</a> team"
+msgstr "Nhóm <a href=\"https://github.com/navjottomer/osclass/\">Osclass</a>"
 
 #: oc-includes/osclass/install.php:89
 msgid "Looks like you've already installed Osclass. To reinstall please clear your old database tables first."
@@ -5408,8 +5408,8 @@ msgid "We've encountered some problems while updating the database structure. Th
 msgstr "Chúng tôi đã gặp phải một số vấn đề khi cập nhật cấu trúc cơ sở dữ liệu. Các truy vấn sau đây bị thất bại:"
 
 #: oc-includes/osclass/upgrade-funcs.php:46
-msgid "These errors could be false-positive errors. If you're sure that is the case, you can <a href=\"%s\">continue with the upgrade</a>, or <a href=\"http://forums.osclass.org/\">ask in our forums</a>."
-msgstr "Những lỗi này có thể là lỗi sai tích cực. Nếu bạn chắc chắn đúng như vậy, bạn có thể <a href=\"%s\">tiếp tục nâng cấp</a>, hoặc <a href =\"http://forums.osclass.org/ \">đặt câu hỏi trong các diễn đàn của chúng tôi</a>."
+msgid "These errors could be false-positive errors. If you're sure that is the case, you can <a href=\"%s\">continue with the upgrade</a>, or <a href=\"https://osclass.discourse.group/\">ask in our forums</a>."
+msgstr "Những lỗi này có thể là lỗi sai tích cực. Nếu bạn chắc chắn đúng như vậy, bạn có thể <a href=\"%s\">tiếp tục nâng cấp</a>, hoặc <a href =\"https://osclass.discourse.group/ \">đặt câu hỏi trong các diễn đàn của chúng tôi</a>."
 
 #: oc-includes/osclass/upgrade-funcs.php:286
 msgid "You need to calculate location stats, please go to admin panel, tools, recalculate location stats or click"
@@ -5420,8 +5420,8 @@ msgid "Osclass &raquo; Updated correctly"
 msgstr "Osclass &raquo; Đã cập nhật chính xác"
 
 #: oc-includes/osclass/upgrade-funcs.php:475
-msgid "Osclass has been updated successfully. <a href=\"http://forums.osclass.org/\">Need more help?</a>"
-msgstr "Osclass đã được cập nhật thành công. <a href=\"http://forums.osclass.org/\">Cần thêm trợ giúp?</a>"
+msgid "Osclass has been updated successfully. <a href=\"https://osclass.discourse.group/\">Need more help?</a>"
+msgstr "Osclass đã được cập nhật thành công. <a href=\"https://osclass.discourse.group/\">Cần thêm trợ giúp?</a>"
 
 #: oc-load.php:210
 msgid "The website is currently undergoing maintenance"

--- a/oc-content/languages/vi_VN/index.php
+++ b/oc-content/languages/vi_VN/index.php
@@ -26,7 +26,7 @@ function locale_vi_VN_info() {
         ,'description'     => 'Vietnamese translation'
         ,'version'         => 'Osclass 3.4.0'
         ,'author_name'     => 'Osclass'
-        ,'author_url'      => 'http://osclass.org/'
+        ,'author_url'      => 'https://github.com/navjottomer/osclass/'
         ,'currency_format' => '{NUMBER} {CURRENCY}'
         ,'date_format'     => 'm/d/Y'
         ,'stop_words'      => ''

--- a/oc-content/languages/vi_VN/messages.po
+++ b/oc-content/languages/vi_VN/messages.po
@@ -1696,8 +1696,8 @@ msgid "Your email has been sent properly."
 msgstr "Email của bạn đã được gửi đi."
 
 #: oc-includes/osclass/upgrade-funcs.php:470
-msgid "Osclass has been updated successfully. <a href=\"http://forums.osclass.org/\">Need more help?</a>"
-msgstr "Osclass đã cập nhật thành công. <a href=\"http://forums.osclass.org/\">Cần thêm thông tin?</a>"
+msgid "Osclass has been updated successfully. <a href=\"https://osclass.discourse.group/\">Need more help?</a>"
+msgstr "Osclass đã cập nhật thành công. <a href=\"https://osclass.discourse.group/\">Cần thêm thông tin?</a>"
 
 #: oc-admin/plugins.php:231
 msgid "The files were deleted"

--- a/oc-content/languages/vi_VN/theme.po
+++ b/oc-content/languages/vi_VN/theme.po
@@ -119,12 +119,12 @@ msgid "Footer link"
 msgstr "Liên kết cuối trang"
 
 #: admin/settings.php:67
-msgid "I want to help Osclass by linking to <a href=\"http://osclass.org/\" target=\"_blank\">osclass.org</a> from my site with the following text:"
-msgstr "I muốn hỗ trợ Osclass bằng cách đặt liên kết <a href=\"http://osclass.org/\" target=\"_blank\">osclass.org</a> trên trang web của tôi với nội dung sau:"
+msgid "I want to help Osclass by linking to <a href=\"https://github.com/navjottomer/osclass/\" target=\"_blank\">osclass.org</a> from my site with the following text:"
+msgstr "I muốn hỗ trợ Osclass bằng cách đặt liên kết <a href=\"https://github.com/navjottomer/osclass/\" target=\"_blank\">osclass.org</a> trên trang web của tôi với nội dung sau:"
 
 #: admin/settings.php:68
-msgid "This website is proudly using the <a title=\"Osclass web\" href=\"http://osclass.org/\">classifieds scripts</a> software <strong>Osclass</strong>"
-msgstr "Website tự hào sử dụng <a title=\"Osclass web\" href=\"http://osclass.org/\">mã nguồn rao vặt</a> của <strong>Osclass</strong>"
+msgid "This website is proudly using the <a title=\"Osclass web\" href=\"https://github.com/navjottomer/osclass/\">classifieds scripts</a> software <strong>Osclass</strong>"
+msgstr "Website tự hào sử dụng <a title=\"Osclass web\" href=\"https://github.com/navjottomer/osclass/\">mã nguồn rao vặt</a> của <strong>Osclass</strong>"
 
 #: admin/settings.php:72
 msgid "Save changes"
@@ -798,8 +798,8 @@ msgstr "%1$d - %2$d của %3$d mẫu tin"
 msgid "Premium listings"
 msgstr "Mẫu tin ưu tiên"
 
-msgid "http://osclass.org/"
-msgstr "http://osclass.org/"
+msgid "https://github.com/navjottomer/osclass/"
+msgstr "https://github.com/navjottomer/osclass/"
 
 msgid "Bender theme"
 msgstr "Bender theme"

--- a/oc-content/languages/zh_CN/core.po
+++ b/oc-content/languages/zh_CN/core.po
@@ -4214,8 +4214,8 @@ msgid "Your Osclass installation at %s is up and running. You can access the adm
 msgstr "安装正在进行，别急，管理面板中有如下信息："
 
 #: /var/www/osclass-git/oc-includes/osclass/install-location.php:102
-msgid "The <a href=\"http://osclass.org/\">Osclass</a> team"
-msgstr "The <a href=\"http://osclass.org/\">Osclass</a> 团队"
+msgid "The <a href=\"https://github.com/navjottomer/osclass/\">Osclass</a> team"
+msgstr "The <a href=\"https://github.com/navjottomer/osclass/\">Osclass</a> 团队"
 
 #: /var/www/osclass-git/oc-includes/osclass/install.php:86
 msgid "Looks like you've already installed Osclass. To reinstall please clear your old database tables first."
@@ -4238,8 +4238,8 @@ msgid "We've encountered some problems while updating the database structure. Th
 msgstr "更新数据库出了点毛病，如下："
 
 #: /var/www/osclass-git/oc-includes/osclass/upgrade-funcs.php:47
-msgid "These errors could be false-positive errors. If you're sure that is the case, you can <a href=\"%s\">continue with the upgrade</a>, or <a href=\"http://forums.osclass.org/\">ask in our forums</a>."
-msgstr "出错显示可能是假的哈, 如果你确定你可以 <a href=\"%s\">继续更新，懒得理会</a>, or <a href=\"http://forums.osclass.org/\">或者到论坛去潜潜水</a>."
+msgid "These errors could be false-positive errors. If you're sure that is the case, you can <a href=\"%s\">continue with the upgrade</a>, or <a href=\"https://osclass.discourse.group/\">ask in our forums</a>."
+msgstr "出错显示可能是假的哈, 如果你确定你可以 <a href=\"%s\">继续更新，懒得理会</a>, or <a href=\"https://osclass.discourse.group/\">或者到论坛去潜潜水</a>."
 
 #: /var/www/osclass-git/oc-includes/osclass/upgrade-funcs.php:286
 msgid "You need to calculate location stats, please go to admin panel, tools, recalculate location stats or click"
@@ -4250,8 +4250,8 @@ msgid "Osclass &raquo; Updated correctly"
 msgstr "Osclass &raquo; 更新成功"
 
 #: /var/www/osclass-git/oc-includes/osclass/upgrade-funcs.php:392
-msgid "Osclass has been updated successfully. <a href=\"http://forums.osclass.org/\">Need more help?</a>"
-msgstr "Osclass更新成功 <a href=\"http://forums.osclass.org/\">需要更多帮助?</a>"
+msgid "Osclass has been updated successfully. <a href=\"https://osclass.discourse.group/\">Need more help?</a>"
+msgstr "Osclass更新成功 <a href=\"https://osclass.discourse.group/\">需要更多帮助?</a>"
 
 #: /var/www/osclass-git/oc-load.php:207
 msgid "The website is currently undergoing maintenance"

--- a/oc-content/languages/zh_CN/index.php
+++ b/oc-content/languages/zh_CN/index.php
@@ -26,7 +26,7 @@ function locale_zh_CN_info() {
         ,'description'     => 'Chinese (China) translation'
         ,'version'         => '3.1.0'
         ,'author_name'     => 'Osclass'
-        ,'author_url'      => 'http://osclass.org/'
+        ,'author_url'      => 'https://github.com/navjottomer/osclass/'
         ,'currency_format' => '{NUMBER} {CURRENCY}'
         ,'date_format'     => 'm/d/Y'
         ,'stop_words'      => ''

--- a/oc-content/languages/zh_CN/theme.po
+++ b/oc-content/languages/zh_CN/theme.po
@@ -762,8 +762,8 @@ msgid "Osclass can't upload the logo image from the administration panel."
 msgstr "Osclass不能上传管理面板处上传图标图像"
 
 #: /var/www/osclass-git/oc-content/themes/modern/admin/settings.php:34
-msgid "I want to help Osclass by linking to <a href=\"http://osclass.org/\" target=\"_blank\">osclass.org</a> from my site with the following text:"
-msgstr "我想帮助Osclass，<a href=\"http://osclass.org/\" target=\"_blank\">osclass.org</a> 在我的网站上添加链接文字如下:"
+msgid "I want to help Osclass by linking to <a href=\"https://github.com/navjottomer/osclass/\" target=\"_blank\">osclass.org</a> from my site with the following text:"
+msgstr "我想帮助Osclass，<a href=\"https://github.com/navjottomer/osclass/\" target=\"_blank\">osclass.org</a> 在我的网站上添加链接文字如下:"
 
 #: /var/www/osclass-git/oc-content/themes/modern/admin/header.php:55
 msgid "Please make the aforementioned image folder writable."
@@ -774,8 +774,8 @@ msgid "I would like to contribute to the development of Osclass with a donation 
 msgstr "我想赞助一下Osclass程序"
 
 #: /var/www/osclass-git/oc-content/themes/modern/footer.php:35
-msgid "This website is proudly using the <a title=\"Osclass web\" href=\"http://osclass.org/\">classifieds scripts</a> software <strong>Osclass</strong>"
-msgstr "本网站骄傲地使用了<a title=\"Osclass web\" href=\"http://osclass.org/\">分类脚本</a> software <strong>Osclass</strong>"
+msgid "This website is proudly using the <a title=\"Osclass web\" href=\"https://github.com/navjottomer/osclass/\">classifieds scripts</a> software <strong>Osclass</strong>"
+msgstr "本网站骄傲地使用了<a title=\"Osclass web\" href=\"https://github.com/navjottomer/osclass/\">分类脚本</a> software <strong>Osclass</strong>"
 
 #: /var/www/osclass-git/oc-content/themes/modern/admin/settings.php:39
 msgid "Default logo"

--- a/oc-content/languages/zh_TW/core.po
+++ b/oc-content/languages/zh_TW/core.po
@@ -1676,8 +1676,8 @@ msgid "Your Osclass installation at %s is up and running. You can access the adm
 msgstr "您在 %s 的 Osclass 已經正常運作，您可以去操作管理面板及其細節："
 
 #: oc-includes/osclass/install-location.php:107
-msgid "The <a href=\"http://osclass.org/\">Osclass</a> team"
-msgstr "我們是 <a href=\"http://osclass.org/\">Osclass</a> 團隊"
+msgid "The <a href=\"https://github.com/navjottomer/osclass/\">Osclass</a> team"
+msgstr "我們是 <a href=\"https://github.com/navjottomer/osclass/\">Osclass</a> 團隊"
 
 #: oc-includes/osclass/install.php:89
 msgid "Looks like you've already installed Osclass. To reinstall please clear your old database tables first."
@@ -1736,8 +1736,8 @@ msgid "We've encountered some problems while updating the database structure. Th
 msgstr "我們遇到了一些問題，同時更新了資料庫結構。下面的查詢指令失敗："
 
 #: oc-includes/osclass/upgrade-funcs.php:46
-msgid "These errors could be false-positive errors. If you're sure that is the case, you can <a href=\"%s\">continue with the upgrade</a>, or <a href=\"http://forums.osclass.org/\">ask in our forums</a>."
-msgstr "這些錯誤原因不明。請參閱 <a href=\"%s\">繼續升級</a>，或 <a href=\"http://forums.osclass.org/\">到我們的論壇查詢</a>."
+msgid "These errors could be false-positive errors. If you're sure that is the case, you can <a href=\"%s\">continue with the upgrade</a>, or <a href=\"https://osclass.discourse.group/\">ask in our forums</a>."
+msgstr "這些錯誤原因不明。請參閱 <a href=\"%s\">繼續升級</a>，或 <a href=\"https://osclass.discourse.group/\">到我們的論壇查詢</a>."
 
 #: oc-includes/osclass/upgrade-funcs.php:286
 msgid "You need to calculate location stats, please go to admin panel, tools, recalculate location stats or click"
@@ -1748,8 +1748,8 @@ msgid "Osclass &raquo; Updated correctly"
 msgstr "Osclass &raquo; 更新完畢"
 
 #: oc-includes/osclass/upgrade-funcs.php:521
-msgid "Osclass has been updated successfully. <a href=\"http://forums.osclass.org/\">Need more help?</a>"
-msgstr "Osclass 已經成功更新。<a href=\"http://forums.osclass.org/\">需要更多說明？</a>"
+msgid "Osclass has been updated successfully. <a href=\"https://osclass.discourse.group/\">Need more help?</a>"
+msgstr "Osclass 已經成功更新。<a href=\"https://osclass.discourse.group/\">需要更多說明？</a>"
 
 #: oc-load.php:214
 msgid "The website is currently undergoing maintenance"

--- a/oc-content/languages/zh_TW/index.php
+++ b/oc-content/languages/zh_TW/index.php
@@ -26,7 +26,7 @@ function locale_zh_TW_info() {
         ,'description'     => 'Chinese (Taiwan) translation'
         ,'version'         => 'Osclass 3.5.0'
         ,'author_name'     => 'Osclass'
-        ,'author_url'      => 'http://osclass.org/'
+        ,'author_url'      => 'https://github.com/navjottomer/osclass/'
         ,'currency_format' => '{NUMBER} {CURRENCY}'
         ,'date_format'     => 'm/d/Y'
         ,'stop_words'      => ''

--- a/oc-content/languages/zh_TW/messages.po
+++ b/oc-content/languages/zh_TW/messages.po
@@ -1689,8 +1689,8 @@ msgid "Your email has been sent properly."
 msgstr "您的電子郵件已經成功傳送。"
 
 #: oc-includes/osclass/upgrade-funcs.php:516
-msgid "Osclass has been updated successfully. <a href=\"http://forums.osclass.org/\">Need more help?</a>"
-msgstr "Osclass 已經成功更新。<a href=\"http://forums.osclass.org/\">需要更多說明嗎？</a>"
+msgid "Osclass has been updated successfully. <a href=\"https://osclass.discourse.group/\">Need more help?</a>"
+msgstr "Osclass 已經成功更新。<a href=\"https://osclass.discourse.group/\">需要更多說明嗎？</a>"
 
 #: oc-admin/plugins.php:231
 msgid "The files were deleted"

--- a/oc-content/languages/zh_TW/theme.po
+++ b/oc-content/languages/zh_TW/theme.po
@@ -119,12 +119,12 @@ msgid "Footer link"
 msgstr "頁尾連結"
 
 #: admin/settings.php:67
-msgid "I want to help Osclass by linking to <a href=\"http://osclass.org/\" target=\"_blank\">osclass.org</a> from my site with the following text:"
-msgstr "我要協助 Osclass 從我的網站透過下列文字連結到 a href=\"http://osclass.org/\" target=\"_blank\">osclass.org</a>："
+msgid "I want to help Osclass by linking to <a href=\"https://github.com/navjottomer/osclass/\" target=\"_blank\">osclass.org</a> from my site with the following text:"
+msgstr "我要協助 Osclass 從我的網站透過下列文字連結到 a href=\"https://github.com/navjottomer/osclass/\" target=\"_blank\">osclass.org</a>："
 
 #: admin/settings.php:68
-msgid "This website is proudly using the <a title=\"Osclass web\" href=\"http://osclass.org/\">classifieds scripts</a> software <strong>Osclass</strong>"
-msgstr "這個網站驕傲的使用 <a title=\"Osclass web\" href=\"http://osclass.org/\">classifieds scripts</a> 開發的 <strong>Osclass 軟體</strong>"
+msgid "This website is proudly using the <a title=\"Osclass web\" href=\"https://github.com/navjottomer/osclass/\">classifieds scripts</a> software <strong>Osclass</strong>"
+msgstr "這個網站驕傲的使用 <a title=\"Osclass web\" href=\"https://github.com/navjottomer/osclass/\">classifieds scripts</a> 開發的 <strong>Osclass 軟體</strong>"
 
 #: admin/settings.php:124
 msgid "Save changes"
@@ -798,8 +798,8 @@ msgstr "顯示第 %1$d ~ %2$d 項，全部共有 %3$d 個廣告"
 msgid "Premium listings"
 msgstr "需付費的廣告"
 
-msgid "http://osclass.org/"
-msgstr "http://osclass.org/"
+msgid "https://github.com/navjottomer/osclass/"
+msgstr "https://github.com/navjottomer/osclass/"
 
 msgid "Bender theme"
 msgstr "Bender 佈景主題"

--- a/oc-includes/osclass/classes/database/DBConnectionClass.php
+++ b/oc-includes/osclass/classes/database/DBConnectionClass.php
@@ -283,7 +283,7 @@
 
                 require_once LIB_PATH . 'osclass/helpers/hErrors.php';
                 $title    = 'Osclass &raquo; Error';
-                $message  = 'Osclass database server is not available. <a href="http://forums.osclass.org/">Need more help?</a></p>';
+                $message  = 'Osclass database server is not available. <a href="https://osclass.discourse.group/">Need more help?</a></p>';
                 osc_die($title, $message);
             }
 
@@ -306,7 +306,7 @@
 
                 require_once LIB_PATH . 'osclass/helpers/hErrors.php';
                 $title    = 'Osclass &raquo; Error';
-                $message  = 'Osclass database is not available. <a href="http://forums.osclass.org/">Need more help?</a></p>';
+                $message  = 'Osclass database is not available. <a href="https://osclass.discourse.group/">Need more help?</a></p>';
                 osc_die($title, $message);
             }
 

--- a/oc-includes/osclass/emails.php
+++ b/oc-includes/osclass/emails.php
@@ -1613,7 +1613,7 @@
             $body  .= '<p>We failed trying to upgrade your site to Osclass {VERSION}. Heres is the error message: {MESSAGE}</p>';
         }
         $body .= '<p>If you experience any issues or need support, we will be happy to help you at the Osclass support forums</p>';
-        $body .= '<p><a href="http://forums.osclass.org/">http://forums.osclass.org/</a></p>';
+        $body .= '<p><a href="https://osclass.discourse.group/">https://osclass.discourse.group/</a></p>';
         $body .= '<p>The Osclass team</p>';
 
         $words   = array ();

--- a/oc-includes/osclass/gui/admin/settings.php
+++ b/oc-includes/osclass/gui/admin/settings.php
@@ -32,7 +32,7 @@
     <input type="hidden" name="rm" value="2">
     <input type="hidden" name="business" value="info@osclass.org">
     <input type="hidden" name="item_name" value="Osclass project">
-    <input type="hidden" name="return" value="http://osclass.org/paypal/">
+    <input type="hidden" name="return" value="https://github.com/navjottomer/osclass/paypal/">
     <input type="hidden" name="currency_code" value="USD">
     <input type="hidden" name="lc" value="US" />
     <input type="hidden" name="custom" value="<?php echo osc_admin_render_theme_url('oc-content/themes/bender/admin/settings.php'); ?>&donation=successful&source=bender">
@@ -69,8 +69,8 @@
             <div class="form-row">
                 <div class="form-label"><?php _e('Footer link', 'bender'); ?></div>
                 <div class="form-controls">
-                    <div class="form-label-checkbox"><input type="checkbox" name="footer_link" value="1" <?php echo (osc_get_preference('footer_link', 'bender') ? 'checked' : ''); ?> > <?php _e('I want to help Osclass by linking to <a href="http://osclass.org/" target="_blank">osclass.org</a> from my site with the following text:', 'bender'); ?></div>
-                    <span class="help-box"><?php _e('This website is proudly using the <a title="Osclass web" href="http://osclass.org/">classifieds scripts</a> software <strong>Osclass</strong>', 'bender'); ?></span>
+                    <div class="form-label-checkbox"><input type="checkbox" name="footer_link" value="1" <?php echo (osc_get_preference('footer_link', 'bender') ? 'checked' : ''); ?> > <?php _e('I want to help Osclass by linking to <a href="https://github.com/navjottomer/osclass/" target="_blank">osclass.org</a> from my site with the following text:', 'bender'); ?></div>
+                    <span class="help-box"><?php _e('This website is proudly using the <a title="Osclass web" href="https://github.com/navjottomer/osclass/">classifieds scripts</a> software <strong>Osclass</strong>', 'bender'); ?></span>
                 </div>
             </div>
             <?php } ?>

--- a/oc-includes/osclass/gui/footer.php
+++ b/oc-includes/osclass/gui/footer.php
@@ -69,7 +69,7 @@
             </li>
         </ul>
         <?php if( (!defined('MULTISITE') || MULTISITE==0) && osc_get_preference('footer_link', 'bender') !== '0') {
-            echo '<div>' . sprintf(__('This website is proudly using the <a title="Osclass web" href="%s">classifieds scripts</a> software <strong>Osclass</strong>'), 'http://osclass.org/') . '</div>';
+            echo '<div>' . sprintf(__('This website is proudly using the <a title="Osclass web" href="%s">classifieds scripts</a> software <strong>Osclass</strong>'), 'https://github.com/navjottomer/osclass/') . '</div>';
         }
         ?>
         <?php if ( osc_count_web_enabled_locales() > 1) { ?>

--- a/oc-includes/osclass/gui/index.php
+++ b/oc-includes/osclass/gui/index.php
@@ -21,11 +21,11 @@
 
 /*
 Theme Name: bender
-Theme URI: http://osclass.org/
+Theme URI: https://github.com/navjottomer/osclass/
 Description: Bender theme
 Version: 3.1.5
 Author: Osclass
-Author URI: http://osclass.org/
+Author URI: https://github.com/navjottomer/osclass/
 Widgets:  header, footer
 Theme update URI: bender
 */
@@ -39,7 +39,7 @@ Theme update URI: bender
             ,'version'     => '3.1.5'
             ,'description' => 'Bender theme'
             ,'author_name' => 'Osclass'
-            ,'author_url'  => 'http://osclass.org'
+            ,'author_url'  => 'https://github.com/navjottomer/osclass'
             ,'locations'   => array()
         );
     }

--- a/oc-includes/osclass/gui/index.php.tpl
+++ b/oc-includes/osclass/gui/index.php.tpl
@@ -21,11 +21,11 @@
 
 /*
 Theme Name: bender
-Theme URI: http://osclass.org/
+Theme URI: https://github.com/navjottomer/osclass/
 Description: <%- pkg.description %>
 Version: <%- pkg.version %>
 Author: <%- pkg.author %>
-Author URI: http://osclass.org/
+Author URI: https://github.com/navjottomer/osclass/
 Widgets:  header, footer
 Theme update URI: bender
 */
@@ -36,7 +36,7 @@ Theme update URI: bender
             ,'version'     => '<%- pkg.version %>'
             ,'description' => '<%- pkg.description %>'
             ,'author_name' => '<%- pkg.author %>'
-            ,'author_url'  => 'http://osclass.org'
+            ,'author_url'  => 'https://github.com/navjottomer/osclass'
             ,'locations'   => array()
         );
     }

--- a/oc-includes/osclass/gui/languages/en_US/theme.po
+++ b/oc-includes/osclass/gui/languages/en_US/theme.po
@@ -126,11 +126,11 @@ msgid "Footer link"
 msgstr ""
 
 #: admin/settings.php:45
-msgid "I want to help Osclass by linking to <a href=\"http://osclass.org/\" target=\"_blank\">osclass.org</a> from my site with the following text:"
+msgid "I want to help Osclass by linking to <a href=\"https://github.com/navjottomer/osclass/\" target=\"_blank\">osclass.org</a> from my site with the following text:"
 msgstr ""
 
 #: admin/settings.php:46
-msgid "This website is proudly using the <a title=\"Osclass web\" href=\"http://osclass.org/\">classifieds scripts</a> software <strong>Osclass</strong>"
+msgid "This website is proudly using the <a title=\"Osclass web\" href=\"https://github.com/navjottomer/osclass/\">classifieds scripts</a> software <strong>Osclass</strong>"
 msgstr ""
 
 #: admin/settings.php:50
@@ -902,7 +902,7 @@ msgstr ""
 #. Theme URI of the plugin/theme
 #. #-#-#-#-#  theme.po (Osclass)  #-#-#-#-#
 #. Author URI of the plugin/theme
-msgid "http://osclass.org/"
+msgid "https://github.com/navjottomer/osclass/"
 msgstr ""
 
 #. Description of the plugin/theme

--- a/oc-includes/osclass/install.php
+++ b/oc-includes/osclass/install.php
@@ -208,7 +208,7 @@
 										<?php } ?>
 									<?php } ?>
                                     <li>
-                                        <a href="https://osclass.org/page/hosting?utm_source=installation-hosting-page&utm_medium=installation&utm_campaign=hosting_page"
+                                        <a href="https://example.org/page/hosting?utm_source=installation-hosting-page&utm_medium=installation&utm_campaign=hosting_page"
                                            hreflang="en"><?php _e( 'Need more help?' ); ?></a></li>
                                 </ul>
                             </div>
@@ -280,7 +280,7 @@
                     <a href="https://github.com/navjottomer/Osclass/" target="_blank" hreflang="en"><?php _e( 'Feedback' ); ?></a>
                 </li>
                 <li>
-                    <a href="http://forums.osclasscommunity.com/" target="_blank"
+                    <a href="https://osclass.discourse.group/" target="_blank"
                        hreflang="en"><?php _e( 'Forums' ); ?></a>
                 </li>
             </ul>

--- a/oc-includes/osclass/installer/readme.php
+++ b/oc-includes/osclass/installer/readme.php
@@ -199,7 +199,7 @@
                     </p>
                 </div>
                 <p>If you experienced any problem during the process, please don't hesitate in contact us in <a
-                            href="https://forums.osclasscommunity.com/">Osclass Support Forums</a>.
+                            href="https://osclass.discourse.group">Osclass Support Forums</a>.
                     We recommend to perform a backup of database and files before each upgrade. You could backup your
                     data from the "Backup" option in the admin panel.
                     If you want to run the autoupgrade manually you could do that from the following URL :
@@ -216,7 +216,7 @@
         <div id="footer">
             <ul>
                 <li><a href="https://github.com/navjottomer/Osclass/issues/" target="_blank">Report Issue</a></li>
-                <li><a href="https://forums.osclasscommunity.com/" target="_blank">Forums</a></li>
+                <li><a href="https://osclass.discourse.group" target="_blank">Forums</a></li>
             </ul>
         </div>
     </div>

--- a/oc-includes/osclass/upgrade-funcs.php
+++ b/oc-includes/osclass/upgrade-funcs.php
@@ -32,7 +32,7 @@
             $title    = __('Osclass &raquo; Has some errors');
             $message  = __("We've encountered some problems while updating the database structure. The following queries failed:");
             $message .= '<br/><br/>' . implode('<br>', $error_queries[2]);
-            $message .= '<br/><br/>' . sprintf(__("These errors could be false-positive errors. If you're sure that is the case, you can <a href=\"%s\">continue with the upgrade</a>, or <a href=\"https://forums.osclasscommunity.com/\">ask in our forums</a>."), $skip_db_link);
+            $message .= '<br/><br/>' . sprintf(__("These errors could be false-positive errors. If you're sure that is the case, you can <a href=\"%s\">continue with the upgrade</a>, or <a href=\"https://osclass.discourse.group\">ask in our forums</a>."), $skip_db_link);
             osc_die($title, $message);
         }
     }

--- a/oc-includes/osclass/utils.php
+++ b/oc-includes/osclass/utils.php
@@ -2265,7 +2265,7 @@
         /***********************
          **** DOWNLOAD FILE ****
          ***********************/
-        $data        = osc_file_get_contents('https://osclass.org/latest_version_v1.php');
+        $data        = osc_file_get_contents('https://example.org/latest_version_v1.php');
         $data        = json_decode(substr($data, 1, -2), true);
         $source_file = $data['url'];
         if ($source_file != '') {
@@ -2400,7 +2400,7 @@
 
     function osc_do_auto_upgrade()
     {
-        $data = osc_file_get_contents('https://osclass.org/latest_version_v1.php?callback=?');
+        $data = osc_file_get_contents('https://example.org/latest_version_v1.php?callback=?');
         $data = preg_replace('|^\?\((.*?)\);$|', '$01', $data);
         /** @var object $json */
         $json            = json_decode($data);

--- a/oc-load.php
+++ b/oc-load.php
@@ -29,7 +29,7 @@
         require_once LIB_PATH . 'osclass/helpers/hErrors.php';
 
         $title   = 'Osclass &raquo; Error';
-        $message = 'There doesn\'t seem to be a <code>config.php</code> file. Osclass isn\'t installed. <a href="http://forums.osclass.org/">Need more help?</a></p>';
+        $message = 'There doesn\'t seem to be a <code>config.php</code> file. Osclass isn\'t installed. <a href="https://osclass.discourse.group/">Need more help?</a></p>';
         $message .= '<p><a class="button" href="' . osc_get_absolute_url() . 'oc-includes/osclass/install.php">Install</a></p>';
         osc_die($title, $message);
     }
@@ -73,7 +73,7 @@
         require_once LIB_PATH . 'osclass/helpers/hErrors.php';
 
         $title   = 'Osclass &raquo; Error';
-        $message = 'Osclass isn\'t installed. <a href="http://forums.osclass.org/">Need more help?</a></p>';
+        $message = 'Osclass isn\'t installed. <a href="https://osclass.discourse.group/">Need more help?</a></p>';
         $message .= '<p><a class="button" href="' . osc_get_absolute_url() . 'oc-includes/osclass/install.php">Install</a></p>';
 
         osc_die($title, $message);


### PR DESCRIPTION
Forums URLs are replaced with osclass.discourse.group (Happily donated by discourse team! All thanks to them)
osclass.org URLs are replaced with GitHub repo. (Will be changed in future when we convert this repo to an organisation)
Please review it for any issue.
Will merge it after review. I will also do it in the mean time.
@dev-101 @webmods-croatia @eurobank