### PR TITLE
Fix bug and keep support for plugin and theme updates

### DIFF
--- a/oc-admin/themes/modern/settings/index.php
+++ b/oc-admin/themes/modern/settings/index.php
@@ -316,7 +316,7 @@
                         </div>
                     </div>
                     <?php
-                    /**
+                    /*
                     <h2 class="render-title separate-top"><?php _e('Software updates'); ?></h2>
                     <div class="form-row">
                         <div class="form-label"><?php _e('Core updates'); ?></div>
@@ -329,6 +329,8 @@
                             </select>
                         </div>
                     </div>
+                    */
+                    ?>
                     <div class="form-row">
                         <div class="form-label"><?php _e('Plugin updates'); ?></div>
                         <div class="form-controls">
@@ -351,6 +353,8 @@
                             </div>
                         </div>
                     </div>
+                    <?php
+                    /*
                     <div class="form-row">
                         <div class="form-label"><?php _e('Language updates'); ?></div>
                         <div class="form-controls">
@@ -362,14 +366,14 @@
                             </div>
                         </div>
                     </div>
+                    */
+                    ?>
                     <div class="form-row">
                         <div class="form-label"></div>
                         <div class="form-controls">
                             <?php printf(__('Last checked on %s'), osc_format_date( date('d-m-Y h:i:s', osc_get_preference('themes_last_version_check')) )); ?> <a class="btn btn-mini" href="<?php echo osc_admin_base_url(true); ?>?page=settings&action=check_updates"><?php _e('Check updates');?></a>
                         </div>
                     </div>
-                     * */
-                    ?>
                     <div class="clear"></div>
                     <div class="form-actions">
                         <input type="submit" id="save_changes" value="<?php echo osc_esc_html( __('Save changes') ); ?>" class="btn btn-submit" />


### PR DESCRIPTION
https://github.com/navjottomer/Osclass/issues/117

I uncommented allow plugin and theme updates. That fixes the problem and allows for auto plugin and theme update from external sources (like my new free plugins).