### PR TITLE
cache: list 'osclass' session cookie explicitly (CLI/web parity)

### DIFF
--- a/oc-includes/osclass/helpers/hHttpCache.php
+++ b/oc-includes/osclass/helpers/hHttpCache.php
@@ -57,10 +57,15 @@ function osc_mark_response_cacheable($cacheable = true)
  */
 function osc_cache_relevant_cookies()
 {
-    return osc_apply_filter('cache_relevant_cookies', array(
+    // 'osclass' is listed explicitly, not just as a session_name() fallback: the web
+    // runtime sets the session cookie name to 'osclass', but session_name() is the PHP
+    // default ('PHPSESSID') under the CLI (e.g. a plugin re-applying rules), so relying
+    // on it alone would emit a rule that never matches the real session cookie.
+    return osc_apply_filter('cache_relevant_cookies', array_values(array_unique(array(
         session_name() ?: 'osclass',
+        'osclass',
         'oc_cache_bypass',
-    ));
+    ))));
 }
 
 /**


### PR DESCRIPTION
`osc_cache_relevant_cookies()` used `session_name() ?: 'osclass'`, but `session_name()` is the web runtime's `osclass` only in a web request — under the CLI it's the PHP default `PHPSESSID`. So a plugin re-applying its Cloudflare rules from the CLI emitted a bypass rule matching `PHPSESSID` instead of the real `osclass` session cookie.

List `osclass` explicitly so the helper is correct in any context. The nginx micro-cache map (entrypoint + reference conf) already matches `oc_cache_bypass|osclass|PHPSESSID`, so all three layers now agree.

No version bump .