### PR TITLE
plugins/themes: reset opcache on lifecycle changes

### DIFF
--- a/oc-includes/osclass/classes/Plugins.php
+++ b/oc-includes/osclass/classes/Plugins.php
@@ -362,6 +362,7 @@ class Plugins
     public static function install($path)
     {
         osc_run_hook('before_plugin_install');
+        self::resetOpcache();
 
         $plugins_list = unserialize(osc_installed_plugins(), array('allowed_classes' => false));
 
@@ -428,6 +429,7 @@ class Plugins
     public static function activate($path)
     {
         osc_run_hook('before_plugin_activate');
+        self::resetOpcache();
 
         $plugins_list = unserialize(osc_active_plugins(), array('allowed_classes' => false));
 
@@ -471,6 +473,22 @@ class Plugins
                     include_once $pluginPath;
                 }
             }
+        }
+    }
+
+    /**
+     * Drop the compiled-bytecode (opcache) cache so a plugin's code change takes
+     * effect immediately. With opcache.validate_timestamps=Off (the usual production
+     * setting) a just-installed, updated, activated or deactivated plugin would keep
+     * running the OLD bytecode until php-fpm restarts — which looks like the change
+     * "not taking", or worse, runs a stale class against new state and fatals. Called
+     * from a web request (the normal admin flow) this clears the FPM pool's cache so
+     * the next request recompiles from disk. Public so theme activation can reuse it.
+     */
+    public static function resetOpcache()
+    {
+        if (function_exists('opcache_reset') && ini_get('opcache.enable')) {
+            @opcache_reset();
         }
     }
 
@@ -520,6 +538,7 @@ class Plugins
     public static function uninstall($path)
     {
         osc_run_hook('before_plugin_uninstall');
+        self::resetOpcache();
 
         $plugins_list = unserialize(osc_installed_plugins(), array('allowed_classes' => false));
 
@@ -561,6 +580,7 @@ class Plugins
     public static function deactivate($path)
     {
         osc_run_hook('before_plugin_deactivate');
+        self::resetOpcache();
 
         $plugins_list = unserialize(osc_active_plugins(), array('allowed_classes' => false));
 

--- a/oc-includes/osclass/classes/cli/Cli.php
+++ b/oc-includes/osclass/classes/cli/Cli.php
@@ -708,6 +708,7 @@ class Cli
         }
 
         osc_set_preference('theme', $theme);
+        \Plugins::resetOpcache();
         // Mirror the admin activation hook so plugins/themes can react.
         osc_run_hook('theme_activate', $theme);
 

--- a/oc-includes/osclass/classes/controller/admin/CAdminAppearance.php
+++ b/oc-includes/osclass/classes/controller/admin/CAdminAppearance.php
@@ -322,6 +322,9 @@ class CAdminAppearance extends AdminSecBaseModel
             case ('activate'):
                 osc_csrf_check();
                 osc_set_preference('theme', Params::getParam('theme'));
+                // Clear opcache so the new theme's code runs at once even with
+                // opcache.validate_timestamps=Off (see Plugins::resetOpcache).
+                Plugins::resetOpcache();
                 osc_add_flash_ok_message(_m('Theme activated correctly'), 'admin');
                 osc_run_hook('theme_activate', Params::getParam('theme'));
                 $this->redirectTo(osc_admin_base_url(true) . '?page=appearance');


### PR DESCRIPTION
With `opcache.validate_timestamps=Off` (typical production setting), activating / deactivating / installing / uninstalling a plugin, or switching a theme, kept running the **old** bytecode until php-fpm restarted. Symptoms: the change appears not to take (new settings UI not showing), or a stale class runs against new state and fatals — which osclass then auto-deactivates the plugin over.

Adds `Plugins::resetOpcache()` (guarded by `function_exists` + `opcache.enable`) and calls it from the four plugin lifecycle methods and both theme-activation paths (admin + CLI). Called from a web request (the normal admin flow) it clears the FPM pool's cache so the next request recompiles from disk.

Note: CLI-driven updates (`oc-cli market:update`) still need a php-fpm reload, since a CLI process can't clear the FPM opcache — this fixes the browser admin flows.