### PR TITLE
i18n: file-only references in templates (stop line-number churn)

### DIFF
--- a/oc-content/languages/core.pot
+++ b/oc-content/languages/core.pot
@@ -9,3945 +9,3665 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "x-generator: scripts/build-i18n.mjs\n"
 
-#: oc-includes/osclass/classes/upgrade/Osclass.php:130
+#: oc-includes/osclass/classes/upgrade/Osclass.php
 msgid " If you're sure that is the case, you can continue with the upgrade."
 msgstr ""
 
-#: oc-includes/osclass/classes/upgrade/Osclass.php:132
+#: oc-includes/osclass/classes/upgrade/Osclass.php
 msgid " Or you can ask for help in our community discussions"
 msgstr ""
 
-#: oc-includes/osclass/functions.php:560
+#: oc-includes/osclass/functions.php
 msgid " is available"
 msgstr ""
 
-#: oc-admin/themes/modern/parts/ui.php:97
+#: oc-admin/themes/modern/parts/ui.php
 msgid "%1$s &raquo; %2$s"
 msgstr ""
 
-#: oc-admin/themes/modern/billing/credits.php:34
+#: oc-admin/themes/modern/billing/credits.php
 msgid "%1$s credits held across %2$s accounts"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:662
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "%1$s entries, %2$s"
 msgstr ""
 
-#: oc-admin/themes/modern/billing/index.php:86
+#: oc-admin/themes/modern/billing/index.php
 msgid "%1$s orders · %2$s paid · %3$s awaiting payment"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:469
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "%1$s per file, %2$s per request."
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:285
+#: oc-admin/themes/modern/tools/system-info.php
 msgid ""
 "%1$s surfaces errors while you diagnose a problem; %2$s sends them to a log "
 "file instead of the page. Both belong off on a live site."
 msgstr ""
 
-#: oc-admin/themes/modern/parts/market.php:480
+#: oc-admin/themes/modern/parts/market.php
 msgid "%1$s → %2$s"
 msgstr ""
 
-#: oc-admin/themes/modern/parts/ui.php:453
+#: oc-admin/themes/modern/parts/ui.php
 msgid "%1$s–%2$s of %3$s"
 msgstr ""
 
-#: oc-admin/themes/modern/items/index.php:133
-#: oc-admin/themes/modern/items/reported.php:40
-#: oc-admin/themes/modern/items/reported.php:43
-#: oc-admin/themes/modern/items/reported.php:46
-#: oc-admin/themes/modern/items/reported.php:49
+#: oc-admin/themes/modern/items/index.php
+#: oc-admin/themes/modern/items/reported.php
 msgid "%d Listings"
 msgstr ""
 
-#: oc-admin/themes/modern/plugins/index.php:145
+#: oc-admin/themes/modern/plugins/index.php
 msgid "%d Plugins"
 msgstr ""
 
-#: oc-admin/themes/modern/users/index.php:82
+#: oc-admin/themes/modern/users/index.php
 msgid "%d Users"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/index.php:110
+#: oc-admin/themes/modern/fields/index.php
 msgid "%d cats · no form"
 msgstr ""
 
-#: oc-admin/themes/modern/upgrade/index.php:295
+#: oc-admin/themes/modern/upgrade/index.php
 msgid "%d change"
 msgid_plural "%d changes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: oc-admin/themes/modern/tools/system-info.php:100
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "%d day"
 msgid_plural "%d days"
 msgstr[0] ""
 msgstr[1] ""
 
-#: oc-admin/themes/modern/functions.php:22
+#: oc-admin/themes/modern/functions.php
 msgid "%d days"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/index.php:720
+#: oc-admin/themes/modern/fields/index.php
 msgid "%d fields from before Forms are attached straight to categories."
 msgstr ""
 
-#: oc-admin/themes/modern/media/index.php:266
+#: oc-admin/themes/modern/media/index.php
 msgid "%d files"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:96
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "%d hour"
 msgid_plural "%d hours"
 msgstr[0] ""
 msgstr[1] ""
 
-#: oc-admin/themes/modern/categories/index.php:97
+#: oc-admin/themes/modern/categories/index.php
 msgid "%d listing"
 msgid_plural "%d listings"
 msgstr[0] ""
 msgstr[1] ""
 
-#: oc-admin/themes/modern/tools/system-info.php:91
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "%d minute"
 msgid_plural "%d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: oc-admin/themes/modern/upgrade/index.php:312
+#: oc-admin/themes/modern/upgrade/index.php
 msgid "%d more change"
 msgid_plural "%d more changes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: oc-admin/themes/modern/parts/ui.php:713
+#: oc-admin/themes/modern/parts/ui.php
 msgid "%d per page"
 msgstr ""
 
-#: oc-admin/themes/modern/categories/index.php:89
+#: oc-admin/themes/modern/categories/index.php
 msgid "%d subcategory"
 msgid_plural "%d subcategories"
 msgstr[0] ""
 msgstr[1] ""
 
-#: oc-admin/themes/modern/fields/submissions.php:118
+#: oc-admin/themes/modern/fields/submissions.php
 msgid "%d submissions"
 msgstr ""
 
-#: oc-admin/themes/modern/appearance/widgets.php:99
+#: oc-admin/themes/modern/appearance/widgets.php
 msgid "%d widget"
 msgid_plural "%d widgets"
 msgstr[0] ""
 msgstr[1] ""
 
-#: oc-admin/themes/modern/billing/order.php:82
+#: oc-admin/themes/modern/billing/order.php
 msgid "%s (plugin not installed)"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:547
-#: oc-admin/themes/modern/tools/system-info.php:554
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "%s ago"
 msgstr ""
 
-#: oc-includes/osclass/classes/market/Compatibility.php:191
+#: oc-includes/osclass/classes/market/Compatibility.php
 msgid "%s and newer"
 msgstr ""
 
-#: oc-admin/themes/modern/items/settings.php:217
-#: oc-admin/themes/modern/items/settings.php:229
+#: oc-admin/themes/modern/items/settings.php
 msgid "%s characters "
 msgstr ""
 
-#: oc-includes/osclass/classes/ImageProcessing.php:40
+#: oc-includes/osclass/classes/ImageProcessing.php
 msgid "%s does not exist!"
 msgstr ""
 
-#: oc-admin/themes/modern/parts/market.php:410
-#: oc-admin/themes/modern/parts/market.php:617
+#: oc-admin/themes/modern/parts/market.php
 msgid "%s downloads"
 msgstr ""
 
-#: oc-includes/osclass/classes/ImageProcessing.php:48
+#: oc-includes/osclass/classes/ImageProcessing.php
 msgid "%s is corrupt or broken!"
 msgstr ""
 
-#: oc-includes/osclass/classes/forms/FieldValidator.php:189
-#: oc-includes/osclass/classes/forms/FieldValidator.php:203
-#: oc-includes/osclass/classes/forms/FieldValidator.php:223
-#: oc-includes/osclass/classes/forms/FieldValidator.php:226
-#: oc-includes/osclass/classes/forms/FieldValidator.php:235
-#: oc-includes/osclass/helpers/hFields.php:182
+#: oc-includes/osclass/classes/forms/FieldValidator.php
+#: oc-includes/osclass/helpers/hFields.php
 msgid "%s is invalid."
 msgstr ""
 
-#: oc-includes/osclass/classes/ImageProcessing.php:44
+#: oc-includes/osclass/classes/ImageProcessing.php
 msgid "%s is not readable!"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:588
+#: oc-admin/themes/modern/tools/system-info.php
 msgid ""
 "%s is on. That is for development — on a live site it exposes internal "
 "detail and slows requests. Turn it off in config.php."
 msgstr ""
 
-#: oc-includes/osclass/classes/forms/FieldValidator.php:192
-#: oc-includes/osclass/classes/forms/FieldValidator.php:195
-#: oc-includes/osclass/classes/forms/FieldValidator.php:206
-#: oc-includes/osclass/classes/forms/FieldValidator.php:229
-#: oc-includes/osclass/classes/forms/FieldValidator.php:238
-#: oc-includes/osclass/classes/forms/FieldValidator.php:245
+#: oc-includes/osclass/classes/forms/FieldValidator.php
 msgid "%s is required."
 msgstr ""
 
-#: oc-admin/themes/modern/stats/users.php:244
+#: oc-admin/themes/modern/stats/users.php
 msgid "%s listings per user"
 msgstr ""
 
-#: oc-admin/themes/modern/users/frm.php:211
+#: oc-admin/themes/modern/users/frm.php
 msgid "%s on %s"
 msgstr ""
 
-#: oc-includes/osclass/classes/Breadcrumb.php:55
+#: oc-includes/osclass/classes/Breadcrumb.php
 msgid "%s's profile"
 msgstr ""
 
-#: oc-admin/themes/modern/users/ban_frm.php:96
+#: oc-admin/themes/modern/users/ban_frm.php
 msgid "(e.g. *@badsite.com, *@subdomain.badsite.com, *@*badsite.com)"
 msgstr ""
 
-#: oc-admin/themes/modern/users/ban_frm.php:89
+#: oc-admin/themes/modern/users/ban_frm.php
 msgid "(e.g. 192.168.10-20.*)"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/submissions.php:179
+#: oc-admin/themes/modern/fields/submissions.php
 msgid "(no values)"
 msgstr ""
 
-#: oc-admin/themes/modern/users/frm.php:230
+#: oc-admin/themes/modern/users/frm.php
 msgid "(required)"
 msgstr ""
 
-#: oc-admin/themes/modern/users/frm.php:330
+#: oc-admin/themes/modern/users/frm.php
 msgid "(twice, required)"
 msgstr ""
 
-#: oc-admin/themes/modern/users/frm.php:395
-#: oc-includes/osclass/classes/datatables/AlertsDataTable.php:175
+#: oc-admin/themes/modern/users/frm.php
+#: oc-includes/osclass/classes/datatables/AlertsDataTable.php
 msgid "...More"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/cleanup.php:138
+#: oc-admin/themes/modern/tools/cleanup.php
 msgid ""
 "0 keeps it forever. This is the history behind the statistics charts, which "
 "look back up to ten months; it is a few rows per day for the whole site."
 msgstr ""
 
-#: oc-admin/themes/modern/functions.php:21
+#: oc-admin/themes/modern/functions.php
 msgid "1 day"
 msgstr ""
 
-#: oc-admin/themes/modern/appearance/widgets.php:292
+#: oc-admin/themes/modern/appearance/widgets.php
 msgid "1 widget"
 msgstr ""
 
-#: oc-admin/themes/modern/users/frm.php:398
-#: oc-includes/osclass/classes/datatables/AlertsDataTable.php:178
+#: oc-admin/themes/modern/users/frm.php
+#: oc-includes/osclass/classes/datatables/AlertsDataTable.php
 msgid "<b>Categories:</b> %s"
 msgstr ""
 
-#: oc-admin/themes/modern/users/frm.php:380
-#: oc-includes/osclass/classes/datatables/AlertsDataTable.php:163
+#: oc-admin/themes/modern/users/frm.php
+#: oc-includes/osclass/classes/datatables/AlertsDataTable.php
 msgid "<b>Pattern:</b> %s"
 msgstr ""
 
-#: oc-includes/osclass/install-functions.php:237
+#: oc-includes/osclass/install-functions.php
 msgid "<code>config-sample.php</code> file exists"
 msgstr ""
 
-#: oc-includes/osclass/install-functions.php:239
+#: oc-includes/osclass/install-functions.php
 msgid ""
 "<code>config-sample.php</code> file is required, you should re-download "
 "Shopclass."
 msgstr ""
 
-#: oc-includes/osclass/install-functions.php:216
+#: oc-includes/osclass/install-functions.php
 msgid ""
 "<code>config.php</code> file has to be writable, i.e.: <code>chmod 0755 "
 "%sconfig.php</code>"
 msgstr ""
 
-#: oc-includes/osclass/install-functions.php:213
+#: oc-includes/osclass/install-functions.php
 msgid "<code>config.php</code> file is writable"
 msgstr ""
 
-#: oc-includes/osclass/install-functions.php:178
+#: oc-includes/osclass/install-functions.php
 msgid "<code>downloads</code> folder has to be writable, i.e.: "
 msgstr ""
 
-#: oc-includes/osclass/install-functions.php:198
+#: oc-includes/osclass/install-functions.php
 msgid "<code>languages</code> folder has to be writable, i.e.: "
 msgstr ""
 
-#: oc-includes/osclass/install-functions.php:175
+#: oc-includes/osclass/install-functions.php
 msgid "<code>oc-content/downloads</code> folder is writable"
 msgstr ""
 
-#: oc-includes/osclass/install-functions.php:195
+#: oc-includes/osclass/install-functions.php
 msgid "<code>oc-content/languages</code> folder is writable"
 msgstr ""
 
-#: oc-includes/osclass/install-functions.php:155
+#: oc-includes/osclass/install-functions.php
 msgid "<code>oc-content/uploads</code> folder is writable"
 msgstr ""
 
-#: oc-includes/osclass/install-functions.php:158
+#: oc-includes/osclass/install-functions.php
 msgid "<code>uploads</code> folder has to be writable, i.e.: "
 msgstr ""
 
-#: oc-includes/osclass/emails.php:1858
+#: oc-includes/osclass/emails.php
 msgid "<p>Dear {WEB_TITLE} admin,</p>"
 msgstr ""
 
-#: oc-includes/osclass/emails.php:1863
+#: oc-includes/osclass/emails.php
 msgid "<p>There were some minor errors removing temporary files. "
 msgstr ""
 
-#: oc-includes/osclass/emails.php:1861
+#: oc-includes/osclass/emails.php
 msgid ""
 "<p>Your site at {WEB_LINK} has been updated automatically to Shopclass "
 "{VERSION}</p>"
 msgstr ""
 
-#: oc-admin/themes/modern/items/settings.php:140
+#: oc-admin/themes/modern/items/settings.php
 msgid "<strong>Remember</strong> that you must configure reCAPTCHA first"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/billing.php:130
+#: oc-admin/themes/modern/settings/billing.php
 msgid "A 3-letter ISO 4217 code, e.g. USD, EUR."
 msgstr ""
 
-#: oc-admin/themes/modern/billing/package.php:60
+#: oc-admin/themes/modern/billing/package.php
 msgid "A 3-letter ISO 4217 code, e.g. USD."
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:143
+#: oc-admin/themes/modern/tools/system-info.php
 msgid ""
 "A checked view of the environment Shopclass is running on: what it needs, "
 "what it can and cannot do, and where a quiet misconfiguration would bite."
 msgstr ""
 
-#: oc-admin/themes/modern/settings/comments.php:106
+#: oc-admin/themes/modern/settings/comments.php
 msgid "A comment is being held for moderation"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/index.php:742
+#: oc-admin/themes/modern/fields/index.php
 msgid ""
 "A form is a set of fields shown together on the listing form, for the "
 "categories you choose."
 msgstr ""
 
-#: oc-admin/themes/modern/settings/comments.php:139
+#: oc-admin/themes/modern/settings/comments.php
 msgid "A new comment is posted"
 msgstr ""
 
-#: oc-admin/themes/modern/billing/packages.php:33
+#: oc-admin/themes/modern/billing/packages.php
 msgid ""
 "A package is what a buyer picks at checkout. Add one to start selling "
 "credits."
 msgstr ""
 
-#: oc-admin/themes/modern/tools/logs.php:16
+#: oc-admin/themes/modern/tools/logs.php
 msgid "A record of admin and listing activity — who did what, and when. "
 msgstr ""
 
-#: oc-includes/osclass/helpers/hUtils.php:348
+#: oc-includes/osclass/helpers/hUtils.php
 msgid "AM"
 msgstr ""
 
-#: oc-admin/themes/modern/billing/order.php:169
+#: oc-admin/themes/modern/billing/order.php
 msgid "About this order"
 msgstr ""
 
-#: oc-admin/themes/modern/users/frm.php:277
+#: oc-admin/themes/modern/users/frm.php
 msgid "About you"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/billing.php:157
+#: oc-admin/themes/modern/settings/billing.php
 msgid "Accept bank transfer / cash payment"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:396
-#: oc-admin/themes/modern/settings/permalinks.php:409
-#: oc-admin/themes/modern/settings/permalinks.php:422
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid "Accepted keywords: %s"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/storage.php:155
+#: oc-admin/themes/modern/settings/storage.php
 msgid "Access key"
 msgstr ""
 
-#: oc-includes/osclass/classes/Breadcrumb.php:56
+#: oc-includes/osclass/classes/Breadcrumb.php
 msgid "Account"
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:78
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Accounting - Finance"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/cleanup.php:28
+#: oc-admin/themes/modern/tools/cleanup.php
 msgid "Accounts never activated from the confirmation email."
 msgstr ""
 
-#: oc-includes/osclass/classes/datatables/LogsDataTable.php:68
-#: oc-includes/osclass/classes/datatables/MediaDataTable.php:91
+#: oc-includes/osclass/classes/datatables/LogsDataTable.php
+#: oc-includes/osclass/classes/datatables/MediaDataTable.php
 msgid "Action"
 msgstr ""
 
-#: oc-admin/themes/modern/billing/credits.php:57
-#: oc-admin/themes/modern/billing/packages.php:45
-#: oc-admin/themes/modern/media/index.php:294
-#: oc-admin/themes/modern/media/index.php:353
+#: oc-admin/themes/modern/billing/credits.php
+#: oc-admin/themes/modern/billing/packages.php
+#: oc-admin/themes/modern/media/index.php
 msgid "Actions"
 msgstr ""
 
-#: oc-admin/themes/modern/appearance/index.php:158
-#: oc-admin/themes/modern/comments/frm.php:87
-#: oc-admin/themes/modern/users/alerts.php:61
-#: oc-admin/themes/modern/users/alerts.php:62
-#: oc-includes/osclass/classes/controller/admin/CAdminItemComments.php:285
-#: oc-includes/osclass/classes/controller/admin/CAdminItemComments.php:287
-#: oc-includes/osclass/classes/controller/admin/CAdminItems.php:577
-#: oc-includes/osclass/classes/controller/admin/CAdminItems.php:982
-#: oc-includes/osclass/classes/controller/admin/CAdminItems.php:984
-#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php:111
-#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php:718
-#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php:720
-#: oc-includes/osclass/classes/datatables/AlertsDataTable.php:141
-#: oc-includes/osclass/classes/datatables/CommentsDataTable.php:159
-#: oc-includes/osclass/classes/datatables/ItemsDataTable.php:255
-#: oc-includes/osclass/classes/datatables/UsersDataTable.php:223
+#: oc-admin/themes/modern/appearance/index.php
+#: oc-admin/themes/modern/comments/frm.php
+#: oc-admin/themes/modern/users/alerts.php
+#: oc-includes/osclass/classes/controller/admin/CAdminItemComments.php
+#: oc-includes/osclass/classes/controller/admin/CAdminItems.php
+#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php
+#: oc-includes/osclass/classes/datatables/AlertsDataTable.php
+#: oc-includes/osclass/classes/datatables/CommentsDataTable.php
+#: oc-includes/osclass/classes/datatables/ItemsDataTable.php
+#: oc-includes/osclass/classes/datatables/UsersDataTable.php
 msgid "Activate"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:279
-#: oc-admin/themes/modern/settings/permalinks.php:280
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid "Activate alert url: this field is required"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:243
-#: oc-admin/themes/modern/settings/permalinks.php:244
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid "Activate listing url: this field is required"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:351
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid ""
 "Activate this option if you want your site's URLs to be more attractive to "
 "search engines and intelligible for users."
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:275
-#: oc-admin/themes/modern/settings/permalinks.php:276
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid "Activate user url: this field is required"
 msgstr ""
 
-#: oc-admin/themes/modern/comments/frm.php:83
-#: oc-admin/themes/modern/items/index.php:284
-#: oc-admin/themes/modern/users/index.php:207
-#: oc-includes/osclass/classes/controller/admin/CAdminPlugins.php:428
-#: oc-includes/osclass/classes/datatables/CommentsDataTable.php:241
-#: oc-includes/osclass/classes/datatables/ItemsDataTable.php:477
-#: oc-includes/osclass/classes/datatables/UsersDataTable.php:321
+#: oc-admin/themes/modern/comments/frm.php
+#: oc-admin/themes/modern/items/index.php
+#: oc-admin/themes/modern/users/index.php
+#: oc-includes/osclass/classes/controller/admin/CAdminPlugins.php
+#: oc-includes/osclass/classes/datatables/CommentsDataTable.php
+#: oc-includes/osclass/classes/datatables/ItemsDataTable.php
+#: oc-includes/osclass/classes/datatables/UsersDataTable.php
 msgid "Active"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/storage.php:102
+#: oc-admin/themes/modern/settings/storage.php
 msgid "Active storage"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/logs.php:15
-#: oc-admin/themes/modern/tools/logs.php:34
-#: oc-includes/osclass/classes/AdminMenu.php:468
+#: oc-admin/themes/modern/tools/logs.php
+#: oc-includes/osclass/classes/AdminMenu.php
 msgid "Activity log"
 msgstr ""
 
-#: oc-admin/themes/modern/admins/frm.php:33
-#: oc-admin/themes/modern/comments/frm.php:28
-#: oc-admin/themes/modern/settings/currencies.php:24
-#: oc-admin/themes/modern/settings/currency_form.php:57
-#: oc-admin/themes/modern/users/index.php:151
-#: oc-admin/themes/modern/users/index.php:25
+#: oc-admin/themes/modern/admins/frm.php
+#: oc-admin/themes/modern/comments/frm.php
+#: oc-admin/themes/modern/settings/currencies.php
+#: oc-admin/themes/modern/settings/currency_form.php
+#: oc-admin/themes/modern/users/index.php
 msgid "Add"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/sitemap.php:127
+#: oc-admin/themes/modern/settings/sitemap.php
 msgid "Add URL"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/sitemap.php:93
+#: oc-admin/themes/modern/settings/sitemap.php
 msgid ""
 "Add URLs the sitemap would not otherwise discover on its own, such as pages "
 "served by a plugin."
 msgstr ""
 
-#: oc-admin/themes/modern/settings/keywordBlock.php:238
+#: oc-admin/themes/modern/settings/keywordBlock.php
 msgid ""
 "Add a keyword above, or import a list, to start quarantining matching "
 "listings."
 msgstr ""
 
-#: oc-admin/themes/modern/admins/frm.php:31
-#: oc-admin/themes/modern/admins/index.php:25
-#: oc-admin/themes/modern/admins/index.php:76
+#: oc-admin/themes/modern/admins/frm.php
+#: oc-admin/themes/modern/admins/index.php
 msgid "Add admin"
 msgstr ""
 
-#: oc-admin/themes/modern/categories/index.php:179
-#: oc-admin/themes/modern/categories/index.php:31
+#: oc-admin/themes/modern/categories/index.php
 msgid "Add category"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/locations.php:138
+#: oc-admin/themes/modern/settings/locations.php
 msgid "Add city"
 msgstr ""
 
-#: oc-admin/themes/modern/comments/frm.php:26
+#: oc-admin/themes/modern/comments/frm.php
 msgid "Add comment"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/locations.php:139
+#: oc-admin/themes/modern/settings/locations.php
 msgid "Add country"
 msgstr ""
 
-#: oc-admin/themes/modern/billing/wallet.php:129
-#: oc-admin/themes/modern/billing/wallet.php:147
+#: oc-admin/themes/modern/billing/wallet.php
 msgid "Add credits"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/currency_form.php:74
-#: oc-admin/themes/modern/settings/currency_form.php:75
+#: oc-admin/themes/modern/settings/currency_form.php
 msgid "Add currency"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/index.php:516
-#: oc-admin/themes/modern/fields/index.php:777
+#: oc-admin/themes/modern/fields/index.php
 msgid "Add field"
 msgstr ""
 
-#: oc-admin/themes/modern/languages/add.php:18
-#: oc-admin/themes/modern/languages/add.php:23
+#: oc-admin/themes/modern/languages/add.php
 msgid "Add language"
 msgstr ""
 
-#: oc-admin/themes/modern/items/frm.php:36
-#: oc-admin/themes/modern/items/frm.php:37
-#: oc-admin/themes/modern/items/index.php:187
-#: oc-admin/themes/modern/items/index.php:24
+#: oc-admin/themes/modern/items/frm.php
+#: oc-admin/themes/modern/items/index.php
 msgid "Add listing"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/keywordBlock.php:23
-#: oc-admin/themes/modern/settings/locations.php:104
-#: oc-admin/themes/modern/settings/locations.php:42
-#: oc-admin/themes/modern/settings/locations.php:86
-#: oc-admin/themes/modern/users/ban.php:137
-#: oc-admin/themes/modern/users/ban.php:24
+#: oc-admin/themes/modern/settings/keywordBlock.php
+#: oc-admin/themes/modern/settings/locations.php
+#: oc-admin/themes/modern/users/ban.php
 msgid "Add new"
 msgstr ""
 
-#: oc-admin/themes/modern/users/ban_frm.php:33
-#: oc-admin/themes/modern/users/ban_frm.php:35
+#: oc-admin/themes/modern/users/ban_frm.php
 msgid "Add new ban rule"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/currencies.php:19
+#: oc-admin/themes/modern/settings/currencies.php
 msgid ""
 "Add new currencies or edit existing currencies so users can publish "
 "listings in their country's currency."
 msgstr ""
 
-#: oc-admin/themes/modern/settings/keywordBlock_frm.php:30
-#: oc-admin/themes/modern/settings/keywordBlock_frm.php:32
+#: oc-admin/themes/modern/settings/keywordBlock_frm.php
 msgid "Add new keyword"
 msgstr ""
 
-#: oc-admin/themes/modern/items/frm.php:212
-#: oc-admin/themes/modern/items/frm.php:213
+#: oc-admin/themes/modern/items/frm.php
 msgid "Add new photo"
 msgstr ""
 
-#: oc-admin/themes/modern/appearance/add.php:26
+#: oc-admin/themes/modern/appearance/add.php
 msgid "Add new theme"
 msgstr ""
 
-#: oc-admin/themes/modern/users/frm.php:38
-#: oc-admin/themes/modern/users/frm.php:40
+#: oc-admin/themes/modern/users/frm.php
 msgid "Add new user"
 msgstr ""
 
-#: oc-admin/themes/modern/billing/package.php:34
-#: oc-admin/themes/modern/billing/package.php:84
-#: oc-admin/themes/modern/billing/packages.php:26
-#: oc-admin/themes/modern/billing/packages.php:34
+#: oc-admin/themes/modern/billing/package.php
+#: oc-admin/themes/modern/billing/packages.php
 msgid "Add package"
 msgstr ""
 
-#: oc-admin/themes/modern/pages/frm.php:61
-#: oc-admin/themes/modern/pages/frm.php:63
+#: oc-admin/themes/modern/pages/frm.php
 msgid "Add page"
 msgstr ""
 
-#: oc-admin/themes/modern/plugins/add.php:18
-#: oc-admin/themes/modern/plugins/add.php:25
-#: oc-admin/themes/modern/plugins/index.php:134
-#: oc-admin/themes/modern/plugins/index.php:25
+#: oc-admin/themes/modern/plugins/add.php
+#: oc-admin/themes/modern/plugins/index.php
 msgid "Add plugin"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/locations.php:140
+#: oc-admin/themes/modern/settings/locations.php
 msgid "Add region"
 msgstr ""
 
-#: oc-admin/themes/modern/appearance/add.php:18
-#: oc-admin/themes/modern/appearance/index.php:30
+#: oc-admin/themes/modern/appearance/add.php
+#: oc-admin/themes/modern/appearance/index.php
 msgid "Add theme"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:268
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "Add these near the top of %1$s, above its closing %2$s."
 msgstr ""
 
-#: oc-admin/themes/modern/appearance/widgets.php:166
+#: oc-admin/themes/modern/appearance/widgets.php
 msgid "Add to a section"
 msgstr ""
 
-#: oc-admin/themes/modern/appearance/widgets.php:248
+#: oc-admin/themes/modern/appearance/widgets.php
 msgid "Add to which section?"
 msgstr ""
 
-#: oc-admin/themes/modern/admins/index.php:19
+#: oc-admin/themes/modern/admins/index.php
 msgid "Add users who can manage your page. You can add admins or moderators: "
 msgstr ""
 
-#: oc-admin/themes/modern/appearance/add_widget.php:124
-#: oc-admin/themes/modern/appearance/add_widget.php:126
-#: oc-admin/themes/modern/appearance/add_widget.php:32
-#: oc-admin/themes/modern/appearance/add_widget.php:34
-#: oc-admin/themes/modern/appearance/page-block-form.php:95
-#: oc-admin/themes/modern/pages/frm.php:204
-#: oc-admin/themes/modern/pages/frm.php:412
-#: oc-admin/themes/modern/pages/frm.php:446
-#: oc-admin/themes/modern/pages/frm.php:447
+#: oc-admin/themes/modern/appearance/add_widget.php
+#: oc-admin/themes/modern/appearance/page-block-form.php
+#: oc-admin/themes/modern/pages/frm.php
 msgid "Add widget"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/index.php:362
+#: oc-admin/themes/modern/settings/index.php
 msgid "Add your Google Maps JavaScript API key."
 msgstr ""
 
-#: oc-admin/themes/modern/settings/index.php:372
+#: oc-admin/themes/modern/settings/index.php
 msgid "Add your Mapquest Consumer key."
 msgstr ""
 
-#: oc-admin/themes/modern/users/ban.php:19
+#: oc-admin/themes/modern/users/ban.php
 msgid ""
 "Add, edit or delete ban rules. Keep in mind that ban rules prevent users to "
 "register, publish or comment on listings."
 msgstr ""
 
-#: oc-admin/themes/modern/users/alerts.php:17
+#: oc-admin/themes/modern/users/alerts.php
 msgid "Add, edit or delete information associated to alerts."
 msgstr ""
 
-#: oc-admin/themes/modern/users/index.php:19
+#: oc-admin/themes/modern/users/index.php
 msgid ""
 "Add, edit or delete information associated to registered users. Keep in "
 "mind that deleting a user also "
 msgstr ""
 
-#: oc-admin/themes/modern/categories/index.php:35
+#: oc-admin/themes/modern/categories/index.php
 msgid ""
 "Add, edit or delete the categories in which users post listings. Drag a row "
 "by its handle to "
 msgstr ""
 
-#: oc-admin/themes/modern/settings/locations.php:20
+#: oc-admin/themes/modern/settings/locations.php
 msgid ""
 "Add, edit or delete the countries, regions and cities installed on your "
 "Shopclass. "
 msgstr ""
 
-#: oc-admin/themes/modern/languages/index.php:19
+#: oc-admin/themes/modern/languages/index.php
 msgid "Add, edit or delete the language in which your Shopclass is displayed, "
 msgstr ""
 
-#: oc-admin/themes/modern/billing/order.php:48
-#: oc-admin/themes/modern/billing/wallet.php:34
+#: oc-admin/themes/modern/billing/order.php
+#: oc-admin/themes/modern/billing/wallet.php
 msgid "Added by admin"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/billing.php:337
+#: oc-admin/themes/modern/settings/billing.php
 msgid "Added on top of the category's own expiration ceiling."
 msgstr ""
 
-#: oc-admin/themes/modern/users/frm.php:285
+#: oc-admin/themes/modern/users/frm.php
 msgid "Additional information"
 msgstr ""
 
-#: oc-admin/themes/modern/items/frm.php:281
-#: oc-admin/themes/modern/users/frm.php:322
+#: oc-admin/themes/modern/items/frm.php
+#: oc-admin/themes/modern/users/frm.php
 msgid "Address"
 msgstr ""
 
-#: oc-includes/osclass/classes/form/ItemForm.php:1197
-#: oc-includes/osclass/classes/form/ItemForm.php:970
+#: oc-includes/osclass/classes/form/ItemForm.php
 msgid "Address: enter at least 3 characters"
 msgstr ""
 
-#: oc-includes/osclass/classes/form/ItemForm.php:1198
-#: oc-includes/osclass/classes/form/ItemForm.php:971
+#: oc-includes/osclass/classes/form/ItemForm.php
 msgid "Address: no more than 100 characters"
 msgstr ""
 
-#: oc-includes/osclass/emails.php:1090
-#: oc-includes/osclass/emails.php:1317
+#: oc-includes/osclass/emails.php
 msgid "Admin"
 msgstr ""
 
-#: oc-includes/osclass/installer/gui/install-target.php:62
+#: oc-includes/osclass/installer/gui/install-target.php
 msgid "Admin account"
 msgstr ""
 
-#: oc-admin/themes/modern/users/settings.php:59
+#: oc-admin/themes/modern/users/settings.php
 msgid "Admin notifications"
 msgstr ""
 
-#: oc-admin/themes/modern/parts/header.php:34
+#: oc-admin/themes/modern/parts/header.php
 msgid "Admin sections"
 msgstr ""
 
-#: oc-admin/themes/modern/admins/frm.php:91
+#: oc-admin/themes/modern/admins/frm.php
 msgid "Admin type <em>(required)</em>"
 msgstr ""
 
-#: oc-includes/osclass/classes/form/AdminForm.php:85
+#: oc-includes/osclass/classes/form/AdminForm.php
 msgid "Administrator"
 msgstr ""
 
-#: oc-includes/osclass/classes/AdminMenu.php:132
+#: oc-includes/osclass/classes/AdminMenu.php
 msgid "Administrators"
 msgstr ""
 
-#: oc-admin/themes/modern/admins/frm.php:95
+#: oc-admin/themes/modern/admins/frm.php
 msgid "Administrators have total control over all aspects of your installation, "
 msgstr ""
 
-#: oc-admin/themes/modern/admins/index.php:18
+#: oc-admin/themes/modern/admins/index.php
 msgid "Admins"
 msgstr ""
 
-#: oc-admin/themes/modern/admins/index.php:74
+#: oc-admin/themes/modern/admins/index.php
 msgid "Admins manage the whole panel; moderators only handle listings and stats."
 msgstr ""
 
-#: oc-admin/themes/modern/settings/storage.php:304
+#: oc-admin/themes/modern/settings/storage.php
 msgid "Adopt existing Better S3 images"
 msgstr ""
 
-#: oc-includes/osclass/classes/AdminMenu.php:417
+#: oc-includes/osclass/classes/AdminMenu.php
 msgid "Advanced"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/advanced.php:39
-#: oc-admin/themes/modern/settings/advanced.php:49
+#: oc-admin/themes/modern/settings/advanced.php
 msgid "Advanced Settings"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/iframe.php:250
+#: oc-admin/themes/modern/fields/iframe.php
 msgid "Advanced options"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:387
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid "Advanced: customize URL structure"
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:79
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Advertising - Public Relations"
 msgstr ""
 
-#: oc-admin/themes/modern/items/settings.php:117
+#: oc-admin/themes/modern/items/settings.php
 msgid ""
 "After %s validated listings the user doesn't need to validate the listings "
 "any more"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/index.php:471
-#: oc-admin/themes/modern/fields/index.php:635
-#: oc-admin/themes/modern/fields/index.php:640
+#: oc-admin/themes/modern/fields/index.php
 msgid "Ajax error, please try again."
 msgstr ""
 
-#: oc-admin/themes/modern/fields/group_iframe.php:123
-#: oc-admin/themes/modern/fields/group_iframe.php:126
-#: oc-admin/themes/modern/fields/iframe.php:413
-#: oc-admin/themes/modern/fields/iframe.php:435
-#: oc-admin/themes/modern/fields/iframe.php:438
-#: oc-admin/themes/modern/fields/index.php:850
-#: oc-admin/themes/modern/fields/index.php:865
-#: oc-admin/themes/modern/fields/submissions.php:286
-#: oc-admin/themes/modern/fields/submissions.php:344
-#: oc-admin/themes/modern/fields/submissions.php:368
+#: oc-admin/themes/modern/fields/group_iframe.php
+#: oc-admin/themes/modern/fields/iframe.php
+#: oc-admin/themes/modern/fields/index.php
+#: oc-admin/themes/modern/fields/submissions.php
 msgid "Ajax error, try again."
 msgstr ""
 
-#: oc-admin/themes/modern/settings/spamNbots.php:35
+#: oc-admin/themes/modern/settings/spamNbots.php
 msgid "Akismet"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/spamNbots.php:44
+#: oc-admin/themes/modern/settings/spamNbots.php
 msgid "Akismet API Key"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/spamNbots.php:36
+#: oc-admin/themes/modern/settings/spamNbots.php
 msgid ""
 "Akismet is a hosted web service that saves you time by automatically "
 "detecting comment and trackback spam. "
 msgstr ""
 
-#: oc-admin/themes/modern/settings/spamNbots.php:65
+#: oc-admin/themes/modern/settings/spamNbots.php
 msgid ""
 "Akismet is disabled, please enter an API key. <a href=\"%s\" "
 "target=\"_blank\">(Get your key)</a>"
 msgstr ""
 
-#: oc-includes/osclass/classes/datatables/AlertsDataTable.php:61
+#: oc-includes/osclass/classes/datatables/AlertsDataTable.php
 msgid "Alert"
 msgstr ""
 
-#: oc-admin/themes/modern/users/frm.php:377
+#: oc-admin/themes/modern/users/frm.php
 msgid "Alert #%d"
 msgstr ""
 
-#: oc-admin/themes/modern/stats/items.php:97
-#: oc-admin/themes/modern/users/frm.php:366
-#: oc-includes/osclass/classes/AdminMenu.php:125
+#: oc-admin/themes/modern/stats/items.php
+#: oc-admin/themes/modern/users/frm.php
+#: oc-includes/osclass/classes/AdminMenu.php
 msgid "Alerts"
 msgstr ""
 
-#: oc-admin/themes/modern/users/alerts.php:109
+#: oc-admin/themes/modern/users/alerts.php
 msgid "Alerts notify a user by email when a new listing matches their saved search."
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminMedia.php:116
-#: oc-includes/osclass/classes/form/UserForm.php:392
+#: oc-includes/osclass/classes/controller/admin/CAdminMedia.php
+#: oc-includes/osclass/classes/form/UserForm.php
 msgid "All"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/submissions.php:105
+#: oc-admin/themes/modern/fields/submissions.php
 msgid "All (%d)"
 msgstr ""
 
-#: oc-admin/themes/modern/parts/market.php:355
+#: oc-admin/themes/modern/parts/market.php
 msgid "All categories"
 msgstr ""
 
-#: oc-admin/themes/modern/comments/index.php:48
+#: oc-admin/themes/modern/comments/index.php
 msgid "All comments"
 msgstr ""
 
-#: oc-admin/themes/modern/billing/wallet.php:42
+#: oc-admin/themes/modern/billing/wallet.php
 msgid "All credits"
 msgstr ""
 
-#: oc-admin/themes/modern/billing/package.php:35
+#: oc-admin/themes/modern/billing/package.php
 msgid "All packages"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/logs.php:85
+#: oc-admin/themes/modern/tools/logs.php
 msgid "All sections"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php:617
+#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php
 msgid "All submissions for this form have been deleted"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/index.php:445
+#: oc-admin/themes/modern/settings/index.php
 msgid "Allow Prerelease"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/index.php:344
+#: oc-admin/themes/modern/settings/index.php
 msgid "Allow Shopclass to run a built-in <a href=\"%s\" target=\"_blank\">cron</a>"
 msgstr ""
 
-#: oc-admin/themes/modern/items/settings.php:156
+#: oc-admin/themes/modern/items/settings.php
 msgid "Allow attached files in contact publisher form"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/index.php:425
+#: oc-admin/themes/modern/settings/index.php
 msgid "Allow auto-updates of languages"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/index.php:413
+#: oc-admin/themes/modern/settings/index.php
 msgid "Allow auto-updates of themes"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/index.php:401
+#: oc-admin/themes/modern/settings/index.php
 msgid "Allow auto-updates plugins"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:236
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "Allow bigger photo uploads"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/index.php:330
+#: oc-admin/themes/modern/settings/index.php
 msgid "Allow people to attach a file to the contact form"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/comments.php:90
+#: oc-admin/themes/modern/settings/comments.php
 msgid "Allow people to post comments on listings"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/index.php:449
+#: oc-admin/themes/modern/settings/index.php
 msgid "Allow prerelease update"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/index.php:318
+#: oc-admin/themes/modern/settings/index.php
 msgid ""
 "Allow users to select a parent category as a category\n"
 "                                    when inserting or editing a listing "
 msgstr ""
 
-#: oc-admin/themes/modern/fields/iframe.php:164
+#: oc-admin/themes/modern/fields/iframe.php
 msgid "Always show"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/storage.php:108
+#: oc-admin/themes/modern/settings/storage.php
 msgid "Amazon S3-compatible"
 msgstr ""
 
-#: oc-admin/themes/modern/billing/index.php:116
-#: oc-admin/themes/modern/billing/order.php:59
+#: oc-admin/themes/modern/billing/index.php
+#: oc-admin/themes/modern/billing/order.php
 msgid "Amount"
 msgstr ""
 
-#: oc-includes/osclass/installer/gui/install-database.php:95
+#: oc-includes/osclass/installer/gui/install-database.php
 msgid "An account allowed to create databases. Only used once, during setup."
 msgstr ""
 
-#: oc-admin/themes/modern/billing/credits.php:45
+#: oc-admin/themes/modern/billing/credits.php
 msgid "An account appears here the first time credits are added to it, whether "
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php:270
-#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php:502
-#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php:607
+#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php
 msgid "An error occurred"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php:450
-#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php:566
-#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php:612
-#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php:617
-#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php:708
+#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php
 msgid "An error occurred while deleting"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php:583
+#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php
 msgid "An error occurred while saving the form"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php:552
+#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php
 msgid "An error occurred while saving the group"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php:838
-#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php:860
+#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php
 msgid "An error occurred while sending email"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php:421
-#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php:782
+#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php
 msgid "An error occurred while updating"
 msgstr ""
 
-#: oc-admin/themes/modern/billing/order.php:171
+#: oc-admin/themes/modern/billing/order.php
 msgid ""
 "An order records one attempt to pay. Shopclass stores what was bought and "
 "what "
 msgstr ""
 
-#: oc-admin/themes/modern/items/settings.php:83
+#: oc-admin/themes/modern/items/settings.php
 msgid "An user has to wait %s seconds between each listing added"
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:12
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Animals"
 msgstr ""
 
-#: oc-includes/osclass/classes/actions/ItemActions.php:187
+#: oc-includes/osclass/classes/actions/ItemActions.php
 msgid "Anonymous"
 msgstr ""
 
-#: oc-admin/themes/modern/billing/index.php:68
+#: oc-admin/themes/modern/billing/index.php
 msgid "Any payment method"
 msgstr ""
 
-#: oc-admin/themes/modern/billing/index.php:56
+#: oc-admin/themes/modern/billing/index.php
 msgid "Any status"
 msgstr ""
 
-#: oc-admin/themes/modern/users/settings.php:45
+#: oc-admin/themes/modern/users/settings.php
 msgid "Anyone can register"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/mailserver.php:161
+#: oc-admin/themes/modern/settings/mailserver.php
 msgid "Apache Module <b>mod_ssl</b> is not loaded"
 msgstr ""
 
-#: oc-admin/themes/modern/appearance/add.php:17
-#: oc-admin/themes/modern/appearance/add_widget.php:112
-#: oc-admin/themes/modern/appearance/index.php:21
-#: oc-admin/themes/modern/appearance/index.php:22
-#: oc-admin/themes/modern/appearance/view.php:18
-#: oc-admin/themes/modern/appearance/view.php:19
-#: oc-admin/themes/modern/appearance/widgets.php:24
-#: oc-admin/themes/modern/appearance/widgets.php:25
-#: oc-includes/osclass/classes/AdminMenu.php:284
+#: oc-admin/themes/modern/appearance/add.php
+#: oc-admin/themes/modern/appearance/add_widget.php
+#: oc-admin/themes/modern/appearance/index.php
+#: oc-admin/themes/modern/appearance/view.php
+#: oc-admin/themes/modern/appearance/widgets.php
+#: oc-includes/osclass/classes/AdminMenu.php
 msgid "Appearance"
 msgstr ""
 
-#: oc-admin/themes/modern/upgrade/index.php:49
+#: oc-admin/themes/modern/upgrade/index.php
 msgid "Applied %s updates."
 msgstr ""
 
-#: oc-admin/themes/modern/upgrade/index.php:48
+#: oc-admin/themes/modern/upgrade/index.php
 msgid "Applied one update."
 msgstr ""
 
-#: oc-admin/themes/modern/fields/index.php:152
-#: oc-admin/themes/modern/fields/index.php:275
+#: oc-admin/themes/modern/fields/index.php
 msgid "Applies to"
 msgstr ""
 
-#: oc-admin/themes/modern/parts/ui.php:652
+#: oc-admin/themes/modern/parts/ui.php
 msgid "Apply"
 msgstr ""
 
-#: oc-admin/themes/modern/items/index.php:335
-#: oc-admin/themes/modern/users/index.php:281
+#: oc-admin/themes/modern/items/index.php
+#: oc-admin/themes/modern/users/index.php
 msgid "Apply filters"
 msgstr ""
 
-#: oc-admin/themes/modern/categories/iframe.php:44
+#: oc-admin/themes/modern/categories/iframe.php
 msgid "Apply the expiration and price changes to all subcategories"
 msgstr ""
 
-#: oc-includes/osclass/helpers/hUtils.php:327
+#: oc-includes/osclass/helpers/hUtils.php
 msgid "Apr"
 msgstr ""
 
-#: oc-includes/osclass/helpers/hUtils.php:312
+#: oc-includes/osclass/helpers/hUtils.php
 msgid "April"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/submissions.php:38
+#: oc-admin/themes/modern/fields/submissions.php
 msgid "Archived"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminAdmins.php:382
+#: oc-includes/osclass/classes/controller/admin/CAdminAdmins.php
 msgid "Are you sure you want to %s the selected admins?"
 msgstr ""
 
-#: oc-admin/themes/modern/users/alerts.php:60
-#: oc-admin/themes/modern/users/alerts.php:65
-#: oc-admin/themes/modern/users/alerts.php:70
+#: oc-admin/themes/modern/users/alerts.php
 msgid "Are you sure you want to %s the selected alerts?"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php:559
+#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php
 msgid "Are you sure you want to %s the selected ban rules?"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminItemComments.php:276
-#: oc-includes/osclass/classes/controller/admin/CAdminItemComments.php:284
-#: oc-includes/osclass/classes/controller/admin/CAdminItemComments.php:292
-#: oc-includes/osclass/classes/controller/admin/CAdminItemComments.php:300
-#: oc-includes/osclass/classes/controller/admin/CAdminItemComments.php:308
+#: oc-includes/osclass/classes/controller/admin/CAdminItemComments.php
 msgid "Are you sure you want to %s the selected comments?"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/currencies.php:65
+#: oc-admin/themes/modern/settings/currencies.php
 msgid "Are you sure you want to %s the selected currencies?"
 msgstr ""
 
-#: oc-admin/themes/modern/items/reported.php:65
+#: oc-admin/themes/modern/items/reported.php
 msgid "Are you sure you want to %s the selected items?"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsKeywordBlock.php:96
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsKeywordBlock.php
 msgid "Are you sure you want to %s the selected keywords?"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php:570
-#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php:578
-#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php:586
-#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php:594
-#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php:602
+#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php
 msgid "Are you sure you want to %s the selected languages?"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminItems.php:1005
-#: oc-includes/osclass/classes/controller/admin/CAdminItems.php:1013
-#: oc-includes/osclass/classes/controller/admin/CAdminItems.php:1021
-#: oc-includes/osclass/classes/controller/admin/CAdminItems.php:1029
-#: oc-includes/osclass/classes/controller/admin/CAdminItems.php:1037
-#: oc-includes/osclass/classes/controller/admin/CAdminItems.php:973
-#: oc-includes/osclass/classes/controller/admin/CAdminItems.php:981
-#: oc-includes/osclass/classes/controller/admin/CAdminItems.php:989
-#: oc-includes/osclass/classes/controller/admin/CAdminItems.php:997
+#: oc-includes/osclass/classes/controller/admin/CAdminItems.php
 msgid "Are you sure you want to %s the selected listings?"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminPages.php:321
+#: oc-includes/osclass/classes/controller/admin/CAdminPages.php
 msgid "Are you sure you want to %s the selected pages?"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php:717
-#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php:725
-#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php:733
-#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php:741
-#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php:749
-#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php:759
+#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php
 msgid "Are you sure you want to %s the selected users?"
 msgstr ""
 
-#: oc-admin/themes/modern/items/reported.php:69
+#: oc-admin/themes/modern/items/reported.php
 msgid "Are you sure you want to clear all the reportings of the selected items?"
 msgstr ""
 
-#: oc-admin/themes/modern/items/reported.php:68
+#: oc-admin/themes/modern/items/reported.php
 msgid ""
 "Are you sure you want to clear the deduplicated reports (and all "
 "reportings) of the selected items? This also resets their report-threshold "
 "auto-block state."
 msgstr ""
 
-#: oc-admin/themes/modern/items/reported.php:72
+#: oc-admin/themes/modern/items/reported.php
 msgid ""
 "Are you sure you want to clear the duplicated reportings of the selected "
 "items?"
 msgstr ""
 
-#: oc-admin/themes/modern/items/reported.php:73
+#: oc-admin/themes/modern/items/reported.php
 msgid "Are you sure you want to clear the expired reportings of the selected items?"
 msgstr ""
 
-#: oc-admin/themes/modern/items/reported.php:71
+#: oc-admin/themes/modern/items/reported.php
 msgid ""
 "Are you sure you want to clear the misclassified reportings of the selected "
 "items?"
 msgstr ""
 
-#: oc-admin/themes/modern/items/reported.php:74
+#: oc-admin/themes/modern/items/reported.php
 msgid ""
 "Are you sure you want to clear the offensive reportings of the selected "
 "items?"
 msgstr ""
 
-#: oc-admin/themes/modern/items/reported.php:70
+#: oc-admin/themes/modern/items/reported.php
 msgid "Are you sure you want to clear the spam reportings of the selected items?"
 msgstr ""
 
-#: oc-admin/themes/modern/users/frm.php:444
+#: oc-admin/themes/modern/users/frm.php
 msgid "Are you sure you want to delete this alert?"
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:13
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Art - Collectibles"
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:80
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Arts - Entertainment - Publishing"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/keywordBlock_frm.php:74
+#: oc-admin/themes/modern/settings/keywordBlock_frm.php
 msgid ""
 "At least %d characters. Matched as a whole word unless \"Substring\" is "
 "checked below."
 msgstr ""
 
-#: oc-includes/osclass/install-functions.php:122
+#: oc-includes/osclass/install-functions.php
 msgid ""
 "At least PHP %s (PHP %s or higher recommended) is required to run "
 "Shopclass. "
 msgstr ""
 
-#: oc-admin/themes/modern/items/settings.php:264
+#: oc-admin/themes/modern/items/settings.php
 msgid "Attach %s images per listing"
 msgstr ""
 
-#: oc-admin/themes/modern/items/settings.php:259
+#: oc-admin/themes/modern/items/settings.php
 msgid "Attach images"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/index.php:104
+#: oc-admin/themes/modern/fields/index.php
 msgid ""
 "Attached directly to %d categories, outside any form: %s. Drag it into a "
 "form to manage it here."
 msgstr ""
 
-#: oc-includes/osclass/classes/datatables/MediaDataTable.php:94
+#: oc-includes/osclass/classes/datatables/MediaDataTable.php
 msgid "Attached to"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/index.php:326
+#: oc-admin/themes/modern/settings/index.php
 msgid "Attachments"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/spamNbots.php:257
+#: oc-admin/themes/modern/settings/spamNbots.php
 msgid "Attempts per account"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/spamNbots.php:247
+#: oc-admin/themes/modern/settings/spamNbots.php
 msgid "Attempts per address"
 msgstr ""
 
-#: oc-includes/osclass/helpers/hUtils.php:331
+#: oc-includes/osclass/helpers/hUtils.php
 msgid "Aug"
 msgstr ""
 
-#: oc-includes/osclass/helpers/hUtils.php:316
+#: oc-includes/osclass/helpers/hUtils.php
 msgid "August"
 msgstr ""
 
-#: oc-admin/themes/modern/appearance/index.php:117
-#: oc-admin/themes/modern/appearance/index.php:178
-#: oc-admin/themes/modern/comments/frm.php:63
-#: oc-admin/themes/modern/stats/comments.php:140
-#: oc-includes/osclass/classes/datatables/CommentsDataTable.php:83
+#: oc-admin/themes/modern/appearance/index.php
+#: oc-admin/themes/modern/comments/frm.php
+#: oc-admin/themes/modern/stats/comments.php
+#: oc-includes/osclass/classes/datatables/CommentsDataTable.php
 msgid "Author"
 msgstr ""
 
-#: oc-admin/themes/modern/parts/market.php:368
+#: oc-admin/themes/modern/parts/market.php
 msgid "Author (A–Z)"
 msgstr ""
 
-#: oc-admin/themes/modern/comments/frm.php:74
+#: oc-admin/themes/modern/comments/frm.php
 msgid "Author's e-mail"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/spamNbots.php:103
+#: oc-admin/themes/modern/settings/spamNbots.php
 msgid "Automatic"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/index.php:337
+#: oc-admin/themes/modern/settings/index.php
 msgid "Automatic cron process"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/spamNbots.php:112
+#: oc-admin/themes/modern/settings/spamNbots.php
 msgid ""
 "Automatic prefers reCAPTCHA whenever its site and secret keys below are "
 "set; clear "
 msgstr ""
 
-#: oc-admin/themes/modern/settings/keywordBlock.php:142
+#: oc-admin/themes/modern/settings/keywordBlock.php
 msgid "Automatically hide a listing once enough distinct visitors have reported it"
 msgstr ""
 
-#: oc-admin/themes/modern/billing/package.php:74
-#: oc-admin/themes/modern/settings/billing.php:153
+#: oc-admin/themes/modern/billing/package.php
+#: oc-admin/themes/modern/settings/billing.php
 msgid "Availability"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/cache.php:169
+#: oc-admin/themes/modern/tools/cache.php
 msgid "Available"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/group_iframe.php:54
+#: oc-admin/themes/modern/fields/group_iframe.php
 msgid "Available as a block (place this form on pages and layouts)"
 msgstr ""
 
-#: oc-admin/themes/modern/appearance/index.php:124
+#: oc-admin/themes/modern/appearance/index.php
 msgid "Available themes"
 msgstr ""
 
-#: oc-admin/themes/modern/appearance/widgets.php:148
+#: oc-admin/themes/modern/appearance/widgets.php
 msgid "Available widgets"
 msgstr ""
 
-#: oc-admin/themes/modern/users/frm.php:254
+#: oc-admin/themes/modern/users/frm.php
 msgid "Avatar"
 msgstr ""
 
-#: oc-admin/themes/modern/stats/users.php:241
+#: oc-admin/themes/modern/stats/users.php
 msgid "Avg. items per user"
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:55
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Babysitter - Nanny"
 msgstr ""
 
-#: oc-admin/gui/forgot_password.php:41
-#: oc-admin/gui/forgot_password.php:42
-#: oc-admin/gui/login.php:70
-#: oc-admin/gui/login.php:71
-#: oc-admin/gui/recover.php:34
-#: oc-admin/gui/recover.php:35
+#: oc-admin/gui/forgot_password.php
+#: oc-admin/gui/login.php
+#: oc-admin/gui/recover.php
 msgid "Back to %s"
 msgstr ""
 
-#: oc-admin/themes/modern/billing/order.php:102
+#: oc-admin/themes/modern/billing/order.php
 msgid "Back to orders"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/storage.php:274
+#: oc-admin/themes/modern/settings/storage.php
 msgid ""
 "Backfill existing images between local disk and remote storage. Each action "
 "queues "
 msgstr ""
 
-#: oc-admin/themes/modern/settings/storage.php:284
+#: oc-admin/themes/modern/settings/storage.php
 msgid ""
 "Backfills every image still on local disk to the active remote storage "
 "backend. "
 msgstr ""
 
-#: oc-admin/themes/modern/settings/media.php:350
+#: oc-admin/themes/modern/settings/media.php
 msgid "Background Color"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/media.php:357
+#: oc-admin/themes/modern/settings/media.php
 msgid "Background Hexadecimal color value"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/backup.php:27
-#: oc-admin/themes/modern/tools/backup.php:36
+#: oc-admin/themes/modern/tools/backup.php
 msgid "Backup"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/backup.php:56
+#: oc-admin/themes/modern/tools/backup.php
 msgid "Backup Method"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/backup.php:61
+#: oc-admin/themes/modern/tools/backup.php
 msgid "Backup SQL (download file)"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/backup.php:60
+#: oc-admin/themes/modern/tools/backup.php
 msgid "Backup SQL (store on server)"
 msgstr ""
 
-#: oc-includes/osclass/classes/AdminMenu.php:433
+#: oc-includes/osclass/classes/AdminMenu.php
 msgid "Backup data"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/backup.php:62
+#: oc-admin/themes/modern/tools/backup.php
 msgid "Backup files (store on server)"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/backup.php:42
+#: oc-admin/themes/modern/tools/backup.php
 msgid "Backup folder"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:250
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "Backups, imports and upgrades run inside %s. Raise it if they time out."
 msgstr ""
 
-#: oc-admin/themes/modern/stats/reports.php:67
+#: oc-admin/themes/modern/stats/reports.php
 msgid "Bad category"
 msgstr ""
 
-#: oc-admin/themes/modern/billing/credits.php:55
-#: oc-admin/themes/modern/billing/wallet.php:116
+#: oc-admin/themes/modern/billing/credits.php
+#: oc-admin/themes/modern/billing/wallet.php
 msgid "Balance"
 msgstr ""
 
-#: oc-admin/themes/modern/billing/order.php:125
-#: oc-admin/themes/modern/billing/wallet.php:68
+#: oc-admin/themes/modern/billing/order.php
+#: oc-admin/themes/modern/billing/wallet.php
 msgid "Balance after"
 msgstr ""
 
-#: oc-admin/themes/modern/billing/order.php:71
+#: oc-admin/themes/modern/billing/order.php
 msgid "Balance now"
 msgstr ""
 
-#: oc-admin/themes/modern/users/ban_frm.php:80
-#: oc-includes/osclass/classes/datatables/BanRulesDataTable.php:63
+#: oc-admin/themes/modern/users/ban_frm.php
+#: oc-includes/osclass/classes/datatables/BanRulesDataTable.php
 msgid "Ban name / Reason"
 msgstr ""
 
-#: oc-includes/osclass/classes/AdminMenu.php:118
+#: oc-includes/osclass/classes/AdminMenu.php
 msgid "Ban rules"
 msgstr ""
 
-#: oc-admin/themes/modern/users/ban.php:135
+#: oc-admin/themes/modern/users/ban.php
 msgid ""
 "Ban rules block registration, listings or comments matching an IP or e-mail "
 "pattern."
 msgstr ""
 
-#: oc-admin/themes/modern/settings/billing.php:167
+#: oc-admin/themes/modern/settings/billing.php
 msgid "Bank details, or wherever a buyer sends the money. Shown to the "
 msgstr ""
 
-#: oc-admin/themes/modern/settings/billing.php:145
+#: oc-admin/themes/modern/settings/billing.php
 msgid "Bank transfer"
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:14
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Barter"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/comments.php:111
+#: oc-admin/themes/modern/settings/comments.php
 msgid ""
 "Before a comment appears, comment author must have at least %s previously "
 "approved comments"
 msgstr ""
 
-#: oc-includes/osclass/installer/gui/install.php:116
+#: oc-includes/osclass/installer/gui/install.php
 msgid "Before we begin, let's make sure your server has everything it needs."
 msgstr ""
 
-#: oc-admin/themes/modern/billing/credits.php:14
-#: oc-admin/themes/modern/billing/credits.php:15
-#: oc-admin/themes/modern/billing/index.php:16
-#: oc-admin/themes/modern/billing/index.php:17
-#: oc-admin/themes/modern/billing/order.php:16
-#: oc-admin/themes/modern/billing/order.php:17
-#: oc-admin/themes/modern/billing/package.php:14
-#: oc-admin/themes/modern/billing/package.php:15
-#: oc-admin/themes/modern/billing/packages.php:14
-#: oc-admin/themes/modern/billing/packages.php:15
-#: oc-admin/themes/modern/billing/wallet.php:14
-#: oc-admin/themes/modern/billing/wallet.php:15
-#: oc-admin/themes/modern/settings/billing.php:30
-#: oc-includes/osclass/classes/AdminMenu.php:194
-#: oc-includes/osclass/classes/AdminMenu.php:409
+#: oc-admin/themes/modern/billing/credits.php
+#: oc-admin/themes/modern/billing/index.php
+#: oc-admin/themes/modern/billing/order.php
+#: oc-admin/themes/modern/billing/package.php
+#: oc-admin/themes/modern/billing/packages.php
+#: oc-admin/themes/modern/billing/wallet.php
+#: oc-admin/themes/modern/settings/billing.php
+#: oc-includes/osclass/classes/AdminMenu.php
 msgid "Billing"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/billing.php:15
+#: oc-admin/themes/modern/settings/billing.php
 msgid "Billing settings"
 msgstr ""
 
-#: oc-admin/themes/modern/comments/frm.php:99
-#: oc-admin/themes/modern/items/index.php:299
-#: oc-admin/themes/modern/users/index.php:259
-#: oc-includes/osclass/classes/controller/admin/CAdminItemComments.php:301
-#: oc-includes/osclass/classes/controller/admin/CAdminItemComments.php:303
-#: oc-includes/osclass/classes/controller/admin/CAdminItems.php:1000
-#: oc-includes/osclass/classes/controller/admin/CAdminItems.php:582
-#: oc-includes/osclass/classes/controller/admin/CAdminItems.php:998
-#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php:116
-#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php:742
-#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php:744
-#: oc-includes/osclass/classes/datatables/CommentsDataTable.php:140
-#: oc-includes/osclass/classes/datatables/ItemsDataTable.php:260
-#: oc-includes/osclass/classes/datatables/UsersDataTable.php:227
+#: oc-admin/themes/modern/comments/frm.php
+#: oc-admin/themes/modern/items/index.php
+#: oc-admin/themes/modern/users/index.php
+#: oc-includes/osclass/classes/controller/admin/CAdminItemComments.php
+#: oc-includes/osclass/classes/controller/admin/CAdminItems.php
+#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php
+#: oc-includes/osclass/classes/datatables/CommentsDataTable.php
+#: oc-includes/osclass/classes/datatables/ItemsDataTable.php
+#: oc-includes/osclass/classes/datatables/UsersDataTable.php
 msgid "Block"
 msgstr ""
 
-#: oc-admin/themes/modern/comments/frm.php:95
-#: oc-includes/osclass/classes/datatables/CommentsDataTable.php:228
-#: oc-includes/osclass/classes/datatables/ItemsDataTable.php:450
-#: oc-includes/osclass/classes/datatables/UsersDataTable.php:308
+#: oc-admin/themes/modern/comments/frm.php
+#: oc-includes/osclass/classes/datatables/CommentsDataTable.php
+#: oc-includes/osclass/classes/datatables/ItemsDataTable.php
+#: oc-includes/osclass/classes/datatables/UsersDataTable.php
 msgid "Blocked"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/keywordBlock.php:206
+#: oc-admin/themes/modern/settings/keywordBlock.php
 msgid "Blocked keywords"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/cleanup.php:27
+#: oc-admin/themes/modern/tools/cleanup.php
 msgid "Blocked listings"
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:37
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Boats - Ships"
 msgstr ""
 
-#: oc-includes/osclass/classes/form/PageForm.php:108
+#: oc-includes/osclass/classes/form/PageForm.php
 msgid "Body"
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:15
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Books - Magazines"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/media.php:393
-#: oc-admin/themes/modern/settings/media.php:429
+#: oc-admin/themes/modern/settings/media.php
 msgid "Bottom Left"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/media.php:395
-#: oc-admin/themes/modern/settings/media.php:431
+#: oc-admin/themes/modern/settings/media.php
 msgid "Bottom Right"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/index.php:386
+#: oc-admin/themes/modern/settings/index.php
 msgid "Branch - big changes"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/comments.php:124
+#: oc-admin/themes/modern/settings/comments.php
 msgid "Break comments into pages with %s comments per page"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/storage.php:295
+#: oc-admin/themes/modern/settings/storage.php
 msgid ""
 "Brings every remote image back to local disk and switches it back to local "
 "storage. "
 msgstr ""
 
-#: oc-admin/themes/modern/settings/keywordBlock_frm.php:94
+#: oc-admin/themes/modern/settings/keywordBlock_frm.php
 msgid ""
 "Broader and riskier — leave unchecked unless you specifically need to catch "
 "a fragment inside longer words."
 msgstr ""
 
-#: oc-admin/themes/modern/appearance/index.php:84
-#: oc-admin/themes/modern/plugins/index.php:72
+#: oc-admin/themes/modern/appearance/index.php
+#: oc-admin/themes/modern/plugins/index.php
 msgid "Browse"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/billing.php:356
+#: oc-admin/themes/modern/settings/billing.php
 msgid "Browse plugins"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/storage.php:130
+#: oc-admin/themes/modern/settings/storage.php
 msgid "Bucket"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/index.php:49
+#: oc-admin/themes/modern/fields/index.php
 msgid ""
 "Build reusable forms by dragging fields from the palette on the right into "
 "a form on the left. "
 msgstr ""
 
-#: oc-admin/themes/modern/items/reported.php:63
-#: oc-admin/themes/modern/parts/ui.php:640
-#: oc-admin/themes/modern/parts/ui.php:676
-#: oc-admin/themes/modern/settings/currencies.php:62
-#: oc-admin/themes/modern/settings/keywordBlock.php:261
-#: oc-admin/themes/modern/users/alerts.php:57
-#: oc-admin/themes/modern/users/ban.php:163
-#: oc-includes/osclass/classes/controller/admin/CAdminAdmins.php:378
-#: oc-includes/osclass/classes/controller/admin/CAdminItemComments.php:272
-#: oc-includes/osclass/classes/controller/admin/CAdminItems.php:969
-#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php:566
-#: oc-includes/osclass/classes/controller/admin/CAdminPages.php:317
-#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php:555
-#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php:713
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsKeywordBlock.php:92
+#: oc-admin/themes/modern/items/reported.php
+#: oc-admin/themes/modern/parts/ui.php
+#: oc-admin/themes/modern/settings/currencies.php
+#: oc-admin/themes/modern/settings/keywordBlock.php
+#: oc-admin/themes/modern/users/alerts.php
+#: oc-admin/themes/modern/users/ban.php
+#: oc-includes/osclass/classes/controller/admin/CAdminAdmins.php
+#: oc-includes/osclass/classes/controller/admin/CAdminItemComments.php
+#: oc-includes/osclass/classes/controller/admin/CAdminItems.php
+#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php
+#: oc-includes/osclass/classes/controller/admin/CAdminPages.php
+#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsKeywordBlock.php
 msgid "Bulk actions"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/billing.php:200
+#: oc-admin/themes/modern/settings/billing.php
 msgid "Bump price (credits)"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/billing.php:191
+#: oc-admin/themes/modern/settings/billing.php
 msgid "Bump to top"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/billing.php:186
+#: oc-admin/themes/modern/settings/billing.php
 msgid ""
 "Bump, highlight and urgent are optional item upgrades, each priced and "
 "switched "
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminPlugins.php:415
-#: oc-includes/osclass/classes/controller/admin/CAdminPlugins.php:418
+#: oc-includes/osclass/classes/controller/admin/CAdminPlugins.php
 msgid "By"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:360
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid ""
 "By default Shopclass uses web URLs which have question marks and lots of "
 "numbers in them. "
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:17
+#: oc-includes/osclass/installer/basic_data.php
 msgid "CDs - Records"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/cache.php:62
-#: oc-admin/themes/modern/tools/cache.php:67
-#: oc-includes/osclass/classes/AdminMenu.php:447
+#: oc-admin/themes/modern/tools/cache.php
+#: oc-includes/osclass/classes/AdminMenu.php
 msgid "Cache"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:571
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "Caching through the %s driver."
 msgstr ""
 
-#: oc-admin/themes/modern/tools/category.php:44
+#: oc-admin/themes/modern/tools/category.php
 msgid "Calculate category stats"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/locations.php:99
+#: oc-admin/themes/modern/tools/locations.php
 msgid "Calculate location stats"
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:16
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Cameras - Camera Accessories"
 msgstr ""
 
-#: oc-includes/osclass/install-functions.php:600
+#: oc-includes/osclass/install-functions.php
 msgid "Can't copy config-sample.php. Check if the root directory is writable."
 msgstr ""
 
-#: oc-admin/themes/modern/parts/market.php:260
+#: oc-admin/themes/modern/parts/market.php
 msgid "Can't install"
 msgstr ""
 
-#: oc-admin/themes/modern/languages/add.php:45
+#: oc-admin/themes/modern/languages/add.php
 msgid "Can't install a new language"
 msgstr ""
 
-#: oc-admin/themes/modern/appearance/add.php:47
+#: oc-admin/themes/modern/appearance/add.php
 msgid "Can't install a new theme"
 msgstr ""
 
-#: oc-admin/themes/modern/parts/market.php:260
+#: oc-admin/themes/modern/parts/market.php
 msgid "Can't update"
 msgstr ""
 
-#: oc-includes/osclass/install-functions.php:589
+#: oc-includes/osclass/install-functions.php
 msgid "Can't write in config.php file. Check if the file is writable."
 msgstr ""
 
-#: oc-admin/themes/modern/admins/frm.php:134
-#: oc-admin/themes/modern/appearance/page-block-form.php:94
-#: oc-admin/themes/modern/billing/order.php:216
-#: oc-admin/themes/modern/billing/packages.php:102
-#: oc-admin/themes/modern/categories/iframe.php:56
-#: oc-admin/themes/modern/categories/index.php:157
-#: oc-admin/themes/modern/categories/index.php:220
-#: oc-admin/themes/modern/comments/frm.php:111
-#: oc-admin/themes/modern/fields/group_iframe.php:75
-#: oc-admin/themes/modern/fields/iframe.php:279
-#: oc-admin/themes/modern/fields/index.php:819
-#: oc-admin/themes/modern/fields/index.php:829
-#: oc-admin/themes/modern/fields/submissions.php:254
-#: oc-admin/themes/modern/fields/submissions.php:264
-#: oc-admin/themes/modern/items/frm.php:317
-#: oc-admin/themes/modern/languages/index.php:124
-#: oc-admin/themes/modern/pages/frm.php:312
-#: oc-admin/themes/modern/parts/media-picker.php:39
-#: oc-admin/themes/modern/parts/ui.php:680
-#: oc-admin/themes/modern/parts/ui.php:829
-#: oc-admin/themes/modern/plugins/index.php:170
-#: oc-admin/themes/modern/settings/currency_form.php:151
-#: oc-admin/themes/modern/settings/keywordBlock.php:265
-#: oc-admin/themes/modern/settings/keywordBlock_frm.php:101
-#: oc-admin/themes/modern/settings/locations.php:125
-#: oc-admin/themes/modern/settings/media.php:460
-#: oc-admin/themes/modern/users/ban.php:167
-#: oc-admin/themes/modern/users/frm.php:448
+#: oc-admin/themes/modern/admins/frm.php
+#: oc-admin/themes/modern/appearance/page-block-form.php
+#: oc-admin/themes/modern/billing/order.php
+#: oc-admin/themes/modern/billing/packages.php
+#: oc-admin/themes/modern/categories/iframe.php
+#: oc-admin/themes/modern/categories/index.php
+#: oc-admin/themes/modern/comments/frm.php
+#: oc-admin/themes/modern/fields/group_iframe.php
+#: oc-admin/themes/modern/fields/iframe.php
+#: oc-admin/themes/modern/fields/index.php
+#: oc-admin/themes/modern/fields/submissions.php
+#: oc-admin/themes/modern/items/frm.php
+#: oc-admin/themes/modern/languages/index.php
+#: oc-admin/themes/modern/pages/frm.php
+#: oc-admin/themes/modern/parts/media-picker.php
+#: oc-admin/themes/modern/parts/ui.php
+#: oc-admin/themes/modern/plugins/index.php
+#: oc-admin/themes/modern/settings/currency_form.php
+#: oc-admin/themes/modern/settings/keywordBlock.php
+#: oc-admin/themes/modern/settings/keywordBlock_frm.php
+#: oc-admin/themes/modern/settings/locations.php
+#: oc-admin/themes/modern/settings/media.php
+#: oc-admin/themes/modern/users/ban.php
+#: oc-admin/themes/modern/users/frm.php
 msgid "Cancel"
 msgstr ""
 
-#: oc-admin/themes/modern/billing/index.php:39
-#: oc-admin/themes/modern/billing/order.php:40
+#: oc-admin/themes/modern/billing/index.php
+#: oc-admin/themes/modern/billing/order.php
 msgid "Cancelled"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/mailserver.php:157
+#: oc-admin/themes/modern/settings/mailserver.php
 msgid "Cannot be sure that Apache Module <b>mod_ssl</b> is loaded."
 msgstr ""
 
-#: oc-admin/themes/modern/plugins/add.php:47
+#: oc-admin/themes/modern/plugins/add.php
 msgid "Cannot install new plugin"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/spamNbots.php:84
+#: oc-admin/themes/modern/settings/spamNbots.php
 msgid "Captcha"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/spamNbots.php:129
+#: oc-admin/themes/modern/settings/spamNbots.php
 msgid "Captcha is currently off: you forced a provider but its keys are empty. "
 msgstr ""
 
-#: oc-admin/themes/modern/settings/spamNbots.php:98
+#: oc-admin/themes/modern/settings/spamNbots.php
 msgid "Captcha provider"
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:35
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Car Parts"
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:66
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Carpool"
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:34
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Cars"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/iframe.php:206
+#: oc-admin/themes/modern/fields/iframe.php
 msgid "Cascading options"
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:56
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Casting - Auditions"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php:1287
+#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php
 msgid "Catalog refresh is disabled on this deployment."
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php:1306
+#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php
 msgid "Catalog refreshed."
 msgstr ""
 
-#: oc-admin/themes/modern/categories/index.php:140
-#: oc-admin/themes/modern/categories/index.php:26
-#: oc-includes/osclass/classes/AdminMenu.php:77
+#: oc-admin/themes/modern/categories/index.php
+#: oc-includes/osclass/classes/AdminMenu.php
 msgid "Categories"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/index.php:509
-#: oc-admin/themes/modern/fields/index.php:762
+#: oc-admin/themes/modern/fields/index.php
 msgid "Categories & name"
 msgstr ""
 
-#: oc-admin/themes/modern/categories/index.php:176
+#: oc-admin/themes/modern/categories/index.php
 msgid "Categories are the sections people browse and file listings under. "
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:179
-#: oc-admin/themes/modern/settings/permalinks.php:180
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid "Categories url: this field is required"
 msgstr ""
 
-#: oc-admin/themes/modern/items/frm.php:192
-#: oc-admin/themes/modern/items/index.php:224
-#: oc-admin/themes/modern/parts/market.php:353
-#: oc-includes/osclass/classes/datatables/ItemsDataTable.php:89
+#: oc-admin/themes/modern/items/frm.php
+#: oc-admin/themes/modern/items/index.php
+#: oc-admin/themes/modern/parts/market.php
+#: oc-includes/osclass/classes/datatables/ItemsDataTable.php
 msgid "Category"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:416
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid "Category URL:"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/advanced.php:65
+#: oc-admin/themes/modern/settings/advanced.php
 msgid "Category based"
 msgstr ""
 
-#: oc-includes/osclass/classes/utility/Utils.php:265
+#: oc-includes/osclass/classes/utility/Utils.php
 msgid "Category id is not a valid integer"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/index.php:312
+#: oc-admin/themes/modern/settings/index.php
 msgid "Category settings"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/category.php:27
-#: oc-admin/themes/modern/tools/category.php:34
+#: oc-admin/themes/modern/tools/category.php
 msgid "Category stats"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php:773
+#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php
 msgid "Category updated correctly"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php:777
+#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php
 msgid "Category updated correctly, but some titles are empty"
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:18
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Cell Phones - Accessories"
 msgstr ""
 
-#: oc-admin/themes/modern/users/frm.php:236
+#: oc-admin/themes/modern/users/frm.php
 msgid "Cell phone"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/media.php:387
-#: oc-admin/themes/modern/settings/media.php:423
+#: oc-admin/themes/modern/settings/media.php
 msgid "Centre"
 msgstr ""
 
-#: oc-admin/themes/modern/billing/order.php:124
-#: oc-admin/themes/modern/billing/wallet.php:67
+#: oc-admin/themes/modern/billing/order.php
+#: oc-admin/themes/modern/billing/wallet.php
 msgid "Change"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/advanced.php:40
+#: oc-admin/themes/modern/settings/advanced.php
 msgid "Change advanced configuration of your Shopclass. "
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:315
-#: oc-admin/themes/modern/settings/permalinks.php:316
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid "Change email confirm url: this field is required"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:307
-#: oc-admin/themes/modern/settings/permalinks.php:308
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid "Change email url: this field is required"
 msgstr ""
 
-#: oc-includes/osclass/classes/Breadcrumb.php:60
-#: oc-includes/osclass/functions.php:213
+#: oc-includes/osclass/classes/Breadcrumb.php
+#: oc-includes/osclass/functions.php
 msgid "Change my email"
 msgstr ""
 
-#: oc-includes/osclass/classes/Breadcrumb.php:62
-#: oc-includes/osclass/functions.php:219
+#: oc-includes/osclass/classes/Breadcrumb.php
+#: oc-includes/osclass/functions.php
 msgid "Change my password"
 msgstr ""
 
-#: oc-includes/osclass/classes/Breadcrumb.php:61
-#: oc-includes/osclass/functions.php:216
+#: oc-includes/osclass/classes/Breadcrumb.php
+#: oc-includes/osclass/functions.php
 msgid "Change my username"
 msgstr ""
 
-#: oc-admin/gui/forgot_password.php:39
+#: oc-admin/gui/forgot_password.php
 msgid "Change password"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:303
-#: oc-admin/themes/modern/settings/permalinks.php:304
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid "Change password url: this field is required"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/index.php:102
+#: oc-admin/themes/modern/settings/index.php
 msgid ""
 "Change the basic configuration of your Shopclass. From here, you can modify "
 "variables such as the site’s name, "
 msgstr ""
 
-#: oc-includes/osclass/classes/EmailVariables.php:66
+#: oc-includes/osclass/classes/EmailVariables.php
 msgid "Change user password link"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:311
-#: oc-admin/themes/modern/settings/permalinks.php:312
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid "Change username url: this field is required"
 msgstr ""
 
-#: oc-includes/osclass/classes/Breadcrumb.php:65
-#: oc-includes/osclass/classes/controller/admin/CAdminLogin.php:217
+#: oc-includes/osclass/classes/Breadcrumb.php
+#: oc-includes/osclass/classes/controller/admin/CAdminLogin.php
 msgid "Change your password"
 msgstr ""
 
-#: oc-admin/themes/modern/appearance/index.php:23
+#: oc-admin/themes/modern/appearance/index.php
 msgid ""
 "Change your site's look and feel by activating a theme among those "
 "available. "
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:296
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "Check"
 msgstr ""
 
-#: oc-includes/osclass/installer/gui/install.php:174
+#: oc-includes/osclass/installer/gui/install.php
 msgid "Check again"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/group_iframe.php:61
-#: oc-admin/themes/modern/fields/iframe.php:236
-#: oc-admin/themes/modern/plugins/configuration.php:74
+#: oc-admin/themes/modern/fields/group_iframe.php
+#: oc-admin/themes/modern/fields/iframe.php
+#: oc-admin/themes/modern/plugins/configuration.php
 msgid "Check all"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/keywordBlock.php:119
+#: oc-admin/themes/modern/settings/keywordBlock.php
 msgid "Check new and edited listings against the keyword blocklist below"
 msgstr ""
 
-#: oc-admin/themes/modern/parts/market.php:378
-#: oc-admin/themes/modern/parts/market.php:454
+#: oc-admin/themes/modern/parts/market.php
 msgid "Check now"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/upgrade.php:125
+#: oc-admin/themes/modern/tools/upgrade.php
 msgid "Check release notes"
 msgstr ""
 
-#: oc-includes/osclass/installer/gui/install.php:34
+#: oc-includes/osclass/installer/gui/install.php
 msgid "Check server"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/upgrade.php:195
+#: oc-admin/themes/modern/tools/upgrade.php
 msgid ""
 "Check to see if you're using the latest version of Shopclass. If you're "
 "not, "
 msgstr ""
 
-#: oc-admin/themes/modern/settings/index.php:441
+#: oc-admin/themes/modern/settings/index.php
 msgid "Check updates"
 msgstr ""
 
-#: oc-includes/osclass/helpers/hItems.php:1454
+#: oc-includes/osclass/helpers/hItems.php
 msgid "Check with seller"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php:927
-#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php:931
-#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php:935
+#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php
 msgid "Checked updates"
 msgstr ""
 
-#: oc-admin/themes/modern/parts/market.php:609
+#: oc-admin/themes/modern/parts/market.php
 msgid "Checking…"
 msgstr ""
 
-#: oc-includes/osclass/install-functions.php:1103
+#: oc-includes/osclass/install-functions.php
 msgid "Cheers,"
 msgstr ""
 
-#: oc-admin/gui/login.php:47
+#: oc-admin/gui/login.php
 msgid "Choose Language"
 msgstr ""
 
-#: oc-admin/themes/modern/items/index.php:274
-#: oc-admin/themes/modern/items/index.php:289
-#: oc-admin/themes/modern/items/index.php:304
-#: oc-admin/themes/modern/items/index.php:319
-#: oc-admin/themes/modern/users/index.php:212
-#: oc-admin/themes/modern/users/index.php:264
+#: oc-admin/themes/modern/items/index.php
+#: oc-admin/themes/modern/users/index.php
 msgid "Choose an option"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/backup.php:59
+#: oc-admin/themes/modern/tools/backup.php
 msgid "Choose backup method"
 msgstr ""
 
-#: oc-admin/themes/modern/functions.php:348
+#: oc-admin/themes/modern/functions.php
 msgid "Choose image"
 msgstr ""
 
-#: oc-includes/osclass/classes/form/ItemForm.php:1175
-#: oc-includes/osclass/classes/form/ItemForm.php:954
+#: oc-includes/osclass/classes/form/ItemForm.php
 msgid "Choose one category"
 msgstr ""
 
-#: oc-includes/osclass/installer/gui/install-target.php:93
+#: oc-includes/osclass/installer/gui/install-target.php
 msgid "Choose the country your visitors are mostly in. You can change this later."
 msgstr ""
 
-#: oc-admin/themes/modern/settings/locations.php:103
+#: oc-admin/themes/modern/settings/locations.php
 msgid "Cities"
 msgstr ""
 
-#: oc-admin/themes/modern/items/frm.php:269
-#: oc-admin/themes/modern/items/index.php:248
-#: oc-admin/themes/modern/settings/locations.php:142
-#: oc-admin/themes/modern/users/frm.php:304
-#: oc-admin/themes/modern/users/index.php:248
+#: oc-admin/themes/modern/items/frm.php
+#: oc-admin/themes/modern/items/index.php
+#: oc-admin/themes/modern/settings/locations.php
+#: oc-admin/themes/modern/users/frm.php
+#: oc-admin/themes/modern/users/index.php
 msgid "City"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/locations.php:143
+#: oc-admin/themes/modern/settings/locations.php
 msgid "City Name"
 msgstr ""
 
-#: oc-admin/themes/modern/items/frm.php:273
-#: oc-admin/themes/modern/users/frm.php:310
+#: oc-admin/themes/modern/items/frm.php
+#: oc-admin/themes/modern/users/frm.php
 msgid "City area"
 msgstr ""
 
-#: oc-includes/osclass/classes/form/ItemForm.php:1193
+#: oc-includes/osclass/classes/form/ItemForm.php
 msgid "City area: enter at least 3 characters"
 msgstr ""
 
-#: oc-includes/osclass/classes/form/ItemForm.php:1194
+#: oc-includes/osclass/classes/form/ItemForm.php
 msgid "City area: no more than 50 characters"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/advanced.php:74
+#: oc-admin/themes/modern/settings/advanced.php
 msgid "City based"
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:6
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Classes"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/cleanup.php:15
-#: oc-admin/themes/modern/tools/cleanup.php:38
-#: oc-includes/osclass/classes/AdminMenu.php:454
+#: oc-admin/themes/modern/tools/cleanup.php
+#: oc-includes/osclass/classes/AdminMenu.php
 msgid "Cleanup"
 msgstr ""
 
-#: oc-admin/themes/modern/billing/index.php:80
+#: oc-admin/themes/modern/billing/index.php
 msgid "Clear"
 msgstr ""
 
-#: oc-admin/themes/modern/items/reported.php:69
-#: oc-includes/osclass/classes/datatables/ItemsDataTable.php:691
+#: oc-admin/themes/modern/items/reported.php
+#: oc-includes/osclass/classes/datatables/ItemsDataTable.php
 msgid "Clear All"
 msgstr ""
 
-#: oc-admin/themes/modern/items/reported.php:72
-#: oc-includes/osclass/classes/datatables/ItemsDataTable.php:704
+#: oc-admin/themes/modern/items/reported.php
+#: oc-includes/osclass/classes/datatables/ItemsDataTable.php
 msgid "Clear Duplicated"
 msgstr ""
 
-#: oc-admin/themes/modern/items/reported.php:73
-#: oc-includes/osclass/classes/datatables/ItemsDataTable.php:713
+#: oc-admin/themes/modern/items/reported.php
+#: oc-includes/osclass/classes/datatables/ItemsDataTable.php
 msgid "Clear Expired"
 msgstr ""
 
-#: oc-includes/osclass/classes/datatables/ItemsDataTable.php:698
+#: oc-includes/osclass/classes/datatables/ItemsDataTable.php
 msgid "Clear Misclassified"
 msgstr ""
 
-#: oc-admin/themes/modern/items/reported.php:71
+#: oc-admin/themes/modern/items/reported.php
 msgid "Clear Missclassified"
 msgstr ""
 
-#: oc-admin/themes/modern/items/reported.php:74
-#: oc-includes/osclass/classes/datatables/ItemsDataTable.php:708
+#: oc-admin/themes/modern/items/reported.php
+#: oc-includes/osclass/classes/datatables/ItemsDataTable.php
 msgid "Clear Offensive"
 msgstr ""
 
-#: oc-admin/themes/modern/items/reported.php:70
-#: oc-includes/osclass/classes/datatables/ItemsDataTable.php:694
+#: oc-admin/themes/modern/items/reported.php
+#: oc-includes/osclass/classes/datatables/ItemsDataTable.php
 msgid "Clear Spam"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/cache.php:78
+#: oc-admin/themes/modern/tools/cache.php
 msgid "Clear cache"
 msgstr ""
 
-#: oc-admin/themes/modern/billing/index.php:102
+#: oc-admin/themes/modern/billing/index.php
 msgid "Clear filter"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/logs.php:145
+#: oc-admin/themes/modern/tools/logs.php
 msgid "Clear log"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/spamNbots.php:289
+#: oc-admin/themes/modern/settings/spamNbots.php
 msgid "Clear now"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/spamNbots.php:286
+#: oc-admin/themes/modern/settings/spamNbots.php
 msgid "Clear recorded attempts"
 msgstr ""
 
-#: oc-admin/themes/modern/items/reported.php:68
-#: oc-includes/osclass/classes/datatables/ItemsDataTable.php:689
+#: oc-admin/themes/modern/items/reported.php
+#: oc-includes/osclass/classes/datatables/ItemsDataTable.php
 msgid "Clear reports"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/logs.php:152
+#: oc-admin/themes/modern/tools/logs.php
 msgid "Clear the activity log?"
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:81
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Clerical - Administrative"
 msgstr ""
 
-#: oc-includes/osclass/classes/form/ItemForm.php:1560
+#: oc-includes/osclass/classes/form/ItemForm.php
 msgid "Click, or drop images here, to upload"
 msgstr ""
 
-#: oc-admin/themes/modern/categories/index.php:203
-#: oc-admin/themes/modern/emails/frm.php:176
-#: oc-admin/themes/modern/fields/submissions.php:245
-#: oc-admin/themes/modern/media/index.php:401
-#: oc-admin/themes/modern/parts/header.php:115
-#: oc-admin/themes/modern/parts/market.php:520
-#: oc-admin/themes/modern/parts/market.php:585
-#: oc-includes/osclass/classes/form/ItemForm.php:1589
+#: oc-admin/themes/modern/categories/index.php
+#: oc-admin/themes/modern/emails/frm.php
+#: oc-admin/themes/modern/fields/submissions.php
+#: oc-admin/themes/modern/media/index.php
+#: oc-admin/themes/modern/parts/header.php
+#: oc-admin/themes/modern/parts/market.php
+#: oc-includes/osclass/classes/form/ItemForm.php
 msgid "Close"
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:19
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Clothing"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/spamNbots.php:105
+#: oc-admin/themes/modern/settings/spamNbots.php
 msgid "Cloudflare Turnstile"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/currencies.php:75
-#: oc-admin/themes/modern/settings/currencies.php:87
+#: oc-admin/themes/modern/settings/currencies.php
 msgid "Code"
 msgstr ""
 
-#: oc-admin/themes/modern/parts/header.php:52
+#: oc-admin/themes/modern/parts/header.php
 msgid "Collapse"
 msgstr ""
 
-#: oc-admin/themes/modern/categories/index.php:169
+#: oc-admin/themes/modern/categories/index.php
 msgid "Collapse all"
 msgstr ""
 
-#: oc-admin/themes/modern/parts/header.php:50
+#: oc-admin/themes/modern/parts/header.php
 msgid "Collapse or expand the menu"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/index.php:502
-#: oc-admin/themes/modern/fields/index.php:754
+#: oc-admin/themes/modern/fields/index.php
 msgid "Collapse or expand this form"
 msgstr ""
 
-#: oc-admin/themes/modern/appearance/widgets.php:89
+#: oc-admin/themes/modern/appearance/widgets.php
 msgid "Collapse or expand this section"
 msgstr ""
 
-#: oc-admin/themes/modern/comments/frm.php:104
-#: oc-admin/themes/modern/stats/comments.php:141
-#: oc-includes/osclass/classes/datatables/CommentsDataTable.php:84
+#: oc-admin/themes/modern/comments/frm.php
+#: oc-admin/themes/modern/stats/comments.php
+#: oc-includes/osclass/classes/datatables/CommentsDataTable.php
 msgid "Comment"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/comments.php:71
-#: oc-admin/themes/modern/settings/comments.php:83
+#: oc-admin/themes/modern/settings/comments.php
 msgid "Comment Settings"
 msgstr ""
 
-#: oc-admin/themes/modern/stats/comments.php:101
-#: oc-admin/themes/modern/stats/comments.php:43
+#: oc-admin/themes/modern/stats/comments.php
 msgid "Comment Statistics"
 msgstr ""
 
-#: oc-includes/osclass/classes/EmailVariables.php:53
+#: oc-includes/osclass/classes/EmailVariables.php
 msgid "Comment author email"
 msgstr ""
 
-#: oc-includes/osclass/classes/EmailVariables.php:52
+#: oc-includes/osclass/classes/EmailVariables.php
 msgid "Comment author name"
 msgstr ""
 
-#: oc-includes/osclass/classes/EmailVariables.php:56
+#: oc-includes/osclass/classes/EmailVariables.php
 msgid "Comment body"
 msgstr ""
 
-#: oc-includes/osclass/classes/EmailVariables.php:55
+#: oc-includes/osclass/classes/EmailVariables.php
 msgid "Comment text content"
 msgstr ""
 
-#: oc-includes/osclass/classes/EmailVariables.php:54
+#: oc-includes/osclass/classes/EmailVariables.php
 msgid "Comment title"
 msgstr ""
 
-#: oc-includes/osclass/classes/form/CommentForm.php:121
+#: oc-includes/osclass/classes/form/CommentForm.php
 msgid "Comment: this field is required"
 msgstr ""
 
-#: oc-admin/themes/modern/comments/index.php:18
-#: oc-admin/themes/modern/comments/index.php:39
-#: oc-admin/themes/modern/stats/comments.php:118
-#: oc-admin/themes/modern/stats/comments.php:70
-#: oc-includes/osclass/classes/AdminMenu.php:260
-#: oc-includes/osclass/classes/AdminMenu.php:354
-#: oc-includes/osclass/classes/AdminMenu.php:70
+#: oc-admin/themes/modern/comments/index.php
+#: oc-admin/themes/modern/stats/comments.php
+#: oc-includes/osclass/classes/AdminMenu.php
 msgid "Comments"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/comments.php:33
+#: oc-admin/themes/modern/settings/comments.php
 msgid "Comments per page: this field is required"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/comments.php:34
+#: oc-admin/themes/modern/settings/comments.php
 msgid "Comments per page: this field must only contain numeric characters"
 msgstr ""
 
-#: oc-admin/themes/modern/main/index.php:168
+#: oc-admin/themes/modern/main/index.php
 msgid "Comments to moderate"
 msgstr ""
 
-#: oc-admin/themes/modern/comments/index.php:90
+#: oc-admin/themes/modern/comments/index.php
 msgid "Comments visitors leave on listings appear here for approval."
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:9
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Community"
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:67
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Community Activities"
 msgstr ""
 
-#: oc-includes/osclass/classes/upgrade/Osclass.php:133
+#: oc-includes/osclass/classes/upgrade/Osclass.php
 msgid "Community discussions"
 msgstr ""
 
-#: oc-includes/osclass/classes/form/UserForm.php:374
+#: oc-includes/osclass/classes/form/UserForm.php
 msgid "Company"
 msgstr ""
 
-#: oc-admin/themes/modern/parts/market.php:576
+#: oc-admin/themes/modern/parts/market.php
 msgid "Compatibility"
 msgstr ""
 
-#: oc-includes/osclass/classes/market/Compatibility.php:162
-#: oc-includes/osclass/classes/market/Compatibility.php:183
+#: oc-includes/osclass/classes/market/Compatibility.php
 msgid "Compatibility not declared"
 msgstr ""
 
-#: oc-includes/osclass/classes/market/Compatibility.php:99
+#: oc-includes/osclass/classes/market/Compatibility.php
 msgid "Compatibility with this Shopclass version has not been declared."
 msgstr ""
 
-#: oc-includes/osclass/classes/market/Compatibility.php:164
+#: oc-includes/osclass/classes/market/Compatibility.php
 msgid "Compatible with %s.x"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/locations.php:87
+#: oc-admin/themes/modern/tools/locations.php
 msgid "Complete"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/media.php:187
+#: oc-admin/themes/modern/settings/media.php
 msgid "Compression quality for saved JPEGs, from 1 (smallest file) to "
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:57
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Computer"
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:41
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Computer - Multimedia Classes"
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:20
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Computers - Hardware"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/iframe.php:161
+#: oc-admin/themes/modern/fields/iframe.php
 msgid "Conditional logic"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminPlugins.php:369
+#: oc-includes/osclass/classes/controller/admin/CAdminPlugins.php
 msgid "Configure"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/storage.php:81
+#: oc-admin/themes/modern/settings/storage.php
 msgid ""
 "Configure S3-compatible object storage for listing images. When enabled, "
 "uploads are moved to your "
 msgstr ""
 
-#: oc-admin/themes/modern/settings/sitemap.php:16
+#: oc-admin/themes/modern/settings/sitemap.php
 msgid ""
 "Configure the XML sitemap: how many URLs go in each file, which extra "
 "location pages to "
 msgstr ""
 
-#: oc-admin/themes/modern/tools/cache.php:47
+#: oc-admin/themes/modern/tools/cache.php
 msgid "Configured through the OSC_CACHE constant."
 msgstr ""
 
-#: oc-admin/themes/modern/admins/frm.php:110
+#: oc-admin/themes/modern/admins/frm.php
 msgid "Confirm new password"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/upgrade.php:170
+#: oc-admin/themes/modern/tools/upgrade.php
 msgid "Congratulations! Your Shopclass installation is up to date!"
 msgstr ""
 
-#: oc-includes/osclass/installer/gui/install.php:35
+#: oc-includes/osclass/installer/gui/install.php
 msgid "Connect database"
 msgstr ""
 
-#: oc-includes/osclass/installer/gui/install-database.php:25
+#: oc-includes/osclass/installer/gui/install-database.php
 msgid "Connect your database"
 msgstr ""
 
-#: oc-includes/osclass/install-functions.php:446
+#: oc-includes/osclass/install-functions.php
 msgid "Connected to %s. Ready to install."
 msgstr ""
 
-#: oc-includes/osclass/install-functions.php:406
+#: oc-includes/osclass/install-functions.php
 msgid "Connected to the server. The database %s will be created during install."
 msgstr ""
 
-#: oc-includes/osclass/install-functions.php:436
+#: oc-includes/osclass/install-functions.php
 msgid "Connected, but this database already has Shopclass tables with that "
 msgstr ""
 
-#: oc-admin/themes/modern/settings/storage.php:227
+#: oc-admin/themes/modern/settings/storage.php
 msgid "Connection test"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:497
-#: oc-includes/osclass/classes/Breadcrumb.php:67
-#: oc-includes/osclass/classes/controller/CWebContact.php:99
-#: oc-includes/osclass/functions.php:224
+#: oc-admin/themes/modern/settings/permalinks.php
+#: oc-includes/osclass/classes/Breadcrumb.php
+#: oc-includes/osclass/classes/controller/CWebContact.php
+#: oc-includes/osclass/functions.php
 msgid "Contact"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/index.php:324
+#: oc-admin/themes/modern/settings/index.php
 msgid "Contact Settings"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/index.php:130
+#: oc-admin/themes/modern/settings/index.php
 msgid "Contact e-mail"
 msgstr ""
 
-#: oc-includes/osclass/installer/gui/install-target.php:86
+#: oc-includes/osclass/installer/gui/install-target.php
 msgid "Contact email"
 msgstr ""
 
-#: oc-admin/themes/modern/users/ban_frm.php:75
-#: oc-admin/themes/modern/users/frm.php:198
+#: oc-admin/themes/modern/users/ban_frm.php
+#: oc-admin/themes/modern/users/frm.php
 msgid "Contact info"
 msgstr ""
 
-#: oc-includes/osclass/classes/EmailVariables.php:72
-#: oc-includes/osclass/classes/EmailVariables.php:82
+#: oc-includes/osclass/classes/EmailVariables.php
 msgid "Contact name"
 msgstr ""
 
-#: oc-admin/themes/modern/items/settings.php:145
-#: oc-includes/osclass/classes/Breadcrumb.php:51
+#: oc-admin/themes/modern/items/settings.php
+#: oc-includes/osclass/classes/Breadcrumb.php
 msgid "Contact publisher"
 msgstr ""
 
-#: oc-includes/osclass/functions.php:114
+#: oc-includes/osclass/functions.php
 msgid "Contact seller"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:215
-#: oc-admin/themes/modern/settings/permalinks.php:216
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid "Contact url: this field is required"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:495
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid "Contact, feed &amp; language"
 msgstr ""
 
-#: oc-includes/osclass/classes/AdminMenu.php:351
+#: oc-includes/osclass/classes/AdminMenu.php
 msgid "Content"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:658
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "Content path"
 msgstr ""
 
-#: oc-includes/osclass/installer/gui/install-database.php:108
-#: oc-includes/osclass/installer/gui/install.php:176
+#: oc-includes/osclass/installer/gui/install-database.php
+#: oc-includes/osclass/installer/gui/install.php
 msgid "Continue"
 msgstr ""
 
-#: oc-includes/osclass/classes/upgrade/Osclass.php:131
+#: oc-includes/osclass/classes/upgrade/Osclass.php
 msgid "Continue with upgrade"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/billing.php:206
+#: oc-admin/themes/modern/settings/billing.php
 msgid "Cooldown (hours)"
 msgstr ""
 
-#: oc-includes/osclass/installer/gui/install.php:42
+#: oc-includes/osclass/installer/gui/install.php
 msgid "Copied"
 msgstr ""
 
-#: oc-includes/osclass/installer/gui/install-finish.php:66
-#: oc-includes/osclass/installer/gui/install-finish.php:83
+#: oc-includes/osclass/installer/gui/install-finish.php
 msgid "Copy"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/index.php:381
+#: oc-admin/themes/modern/settings/index.php
 msgid "Core updates"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/billing.php:148
+#: oc-admin/themes/modern/settings/billing.php
 msgid "Core's built-in payment method — no card processor, no API keys. A buyer "
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php:917
-#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php:921
+#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php
 msgid "Could not check for updates"
 msgstr ""
 
-#: oc-admin/themes/modern/parts/market.php:311
+#: oc-admin/themes/modern/parts/market.php
 msgid "Could not reach the catalog: %s."
 msgstr ""
 
-#: oc-admin/themes/modern/parts/market.php:309
+#: oc-admin/themes/modern/parts/market.php
 msgid "Could not refresh the catalog: %s. Showing the last successful results."
 msgstr ""
 
-#: oc-admin/themes/modern/appearance/widgets.php:245
+#: oc-admin/themes/modern/appearance/widgets.php
 msgid "Could not save the new order. Reload and try again."
 msgstr ""
 
-#: oc-admin/themes/modern/pages/frm.php:545
+#: oc-admin/themes/modern/pages/frm.php
 msgid "Could not save the new widget order. Reloading the page."
 msgstr ""
 
-#: oc-includes/AjaxUploader.php:85
+#: oc-includes/AjaxUploader.php
 msgid "Could not save uploaded file. File already exists"
 msgstr ""
 
-#: oc-includes/osclass/installer/gui/install.php:43
+#: oc-includes/osclass/installer/gui/install.php
 msgid "Couldn't copy. Select the text and copy it manually."
 msgstr ""
 
-#: oc-admin/themes/modern/parts/market.php:616
+#: oc-admin/themes/modern/parts/market.php
 msgid "Couldn't load details for this package."
 msgstr ""
 
-#: oc-admin/themes/modern/tools/cleanup.php:125
+#: oc-admin/themes/modern/tools/cleanup.php
 msgid "Count crawler visits as views"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/spamNbots.php:233
+#: oc-admin/themes/modern/settings/spamNbots.php
 msgid "Count failed attempts and refuse further ones past the limits below"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/cleanup.php:114
+#: oc-admin/themes/modern/tools/cleanup.php
 msgid "Count listing views"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/locations.php:41
+#: oc-admin/themes/modern/settings/locations.php
 msgid "Countries"
 msgstr ""
 
-#: oc-admin/themes/modern/items/frm.php:261
-#: oc-admin/themes/modern/items/index.php:232
-#: oc-admin/themes/modern/settings/locations.php:144
-#: oc-admin/themes/modern/stats/users.php:96
-#: oc-admin/themes/modern/users/frm.php:292
-#: oc-admin/themes/modern/users/index.php:226
-#: oc-includes/osclass/installer/gui/install-target.php:96
+#: oc-admin/themes/modern/items/frm.php
+#: oc-admin/themes/modern/items/index.php
+#: oc-admin/themes/modern/settings/locations.php
+#: oc-admin/themes/modern/stats/users.php
+#: oc-admin/themes/modern/users/frm.php
+#: oc-admin/themes/modern/users/index.php
+#: oc-includes/osclass/installer/gui/install-target.php
 msgid "Country"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/advanced.php:68
+#: oc-admin/themes/modern/settings/advanced.php
 msgid "Country based"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/locations.php:145
+#: oc-admin/themes/modern/settings/locations.php
 msgid "Country code"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/locations.php:146
+#: oc-admin/themes/modern/settings/locations.php
 msgid "Country name"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/submissions.php:211
+#: oc-admin/themes/modern/fields/submissions.php
 msgid "Create a form"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/submissions.php:209
+#: oc-admin/themes/modern/fields/submissions.php
 msgid "Create a form and place it on a page to start collecting submissions."
 msgstr ""
 
-#: oc-includes/osclass/classes/Breadcrumb.php:66
-#: oc-includes/osclass/functions.php:192
+#: oc-includes/osclass/classes/Breadcrumb.php
+#: oc-includes/osclass/functions.php
 msgid "Create a new account"
 msgstr ""
 
-#: oc-admin/themes/modern/pages/index.php:100
-#: oc-admin/themes/modern/pages/index.php:25
+#: oc-admin/themes/modern/pages/index.php
 msgid "Create page"
 msgstr ""
 
-#: oc-includes/osclass/installer/gui/install-database.php:82
+#: oc-includes/osclass/installer/gui/install-database.php
 msgid "Create the database"
 msgstr ""
 
-#: oc-admin/themes/modern/billing/order.php:89
+#: oc-admin/themes/modern/billing/order.php
 msgid "Created"
 msgstr ""
 
-#: oc-admin/themes/modern/billing/order.php:111
+#: oc-admin/themes/modern/billing/order.php
 msgid "Credit movements"
 msgstr ""
 
-#: oc-admin/themes/modern/billing/credits.php:29
-#: oc-admin/themes/modern/billing/index.php:117
-#: oc-admin/themes/modern/billing/order.php:60
-#: oc-admin/themes/modern/billing/package.php:63
-#: oc-admin/themes/modern/billing/packages.php:43
-#: oc-includes/osclass/classes/AdminMenu.php:216
+#: oc-admin/themes/modern/billing/credits.php
+#: oc-admin/themes/modern/billing/index.php
+#: oc-admin/themes/modern/billing/order.php
+#: oc-admin/themes/modern/billing/package.php
+#: oc-admin/themes/modern/billing/packages.php
+#: oc-includes/osclass/classes/AdminMenu.php
 msgid "Credits"
 msgstr ""
 
-#: oc-admin/themes/modern/billing/order.php:116
+#: oc-admin/themes/modern/billing/order.php
 msgid "Credits are added the moment this order is paid."
 msgstr ""
 
-#: oc-admin/themes/modern/billing/credits.php:16
+#: oc-admin/themes/modern/billing/credits.php
 msgid ""
 "Credits are what users spend on paid features. They are added when an order "
 "is "
 msgstr ""
 
-#: oc-admin/themes/modern/billing/wallet.php:40
+#: oc-admin/themes/modern/billing/wallet.php
 msgid "Credits — %s"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/index.php:335
+#: oc-admin/themes/modern/settings/index.php
 msgid "Cron Settings"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:553
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "Cron has run recently — update checks, alerts and cleanup are firing."
 msgstr ""
 
-#: oc-admin/themes/modern/settings/billing.php:367
-#: oc-admin/themes/modern/settings/currencies.php:18
-#: oc-admin/themes/modern/settings/currencies.php:52
-#: oc-includes/osclass/classes/AdminMenu.php:91
+#: oc-admin/themes/modern/settings/billing.php
+#: oc-admin/themes/modern/settings/currencies.php
+#: oc-includes/osclass/classes/AdminMenu.php
 msgid "Currencies"
 msgstr ""
 
-#: oc-admin/themes/modern/billing/package.php:57
-#: oc-admin/themes/modern/settings/billing.php:126
+#: oc-admin/themes/modern/billing/package.php
+#: oc-admin/themes/modern/settings/billing.php
 msgid "Currency"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/currency_form.php:114
+#: oc-admin/themes/modern/settings/currency_form.php
 msgid "Currency Code"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/currency_form.php:29
-#: oc-admin/themes/modern/settings/currency_form.php:30
-#: oc-admin/themes/modern/settings/currency_form.php:31
+#: oc-admin/themes/modern/settings/currency_form.php
 msgid "Currency code: this field is required"
 msgstr ""
 
-#: oc-admin/themes/modern/languages/frm.php:73
+#: oc-admin/themes/modern/languages/frm.php
 msgid "Currency format"
 msgstr ""
 
-#: oc-includes/osclass/classes/form/LanguageForm.php:199
+#: oc-includes/osclass/classes/form/LanguageForm.php
 msgid "Currency format: this field is required"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/currency_form.php:137
+#: oc-admin/themes/modern/settings/currency_form.php
 msgid "Currency symbol"
 msgstr ""
 
-#: oc-includes/osclass/classes/form/ItemForm.php:1178
-#: oc-includes/osclass/classes/form/ItemForm.php:957
+#: oc-includes/osclass/classes/form/ItemForm.php
 msgid "Currency: make your selection"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:196
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "Current PHP values"
 msgstr ""
 
-#: oc-admin/themes/modern/users/frm.php:259
+#: oc-admin/themes/modern/users/frm.php
 msgid "Current avatar"
 msgstr ""
 
-#: oc-includes/osclass/classes/EmailVariables.php:49
+#: oc-includes/osclass/classes/EmailVariables.php
 msgid "Current date"
 msgstr ""
 
-#: oc-admin/themes/modern/appearance/index.php:96
+#: oc-admin/themes/modern/appearance/index.php
 msgid "Current theme"
 msgstr ""
 
-#: oc-admin/themes/modern/languages/frm.php:43
+#: oc-admin/themes/modern/languages/frm.php
 msgid "Current version"
 msgstr ""
 
-#: oc-admin/themes/modern/appearance/widgets.php:121
-#: oc-admin/themes/modern/pages/frm.php:221
-#: oc-includes/osclass/classes/controller/admin/CAdminAppearance.php:219
-#: oc-includes/osclass/classes/controller/admin/CAdminAppearance.php:248
+#: oc-admin/themes/modern/appearance/widgets.php
+#: oc-admin/themes/modern/pages/frm.php
+#: oc-includes/osclass/classes/controller/admin/CAdminAppearance.php
 msgid "Custom HTML"
 msgstr ""
 
-#: oc-admin/themes/modern/appearance/add_widget.php:165
+#: oc-admin/themes/modern/appearance/add_widget.php
 msgid "Custom HTML (legacy)"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/mailserver.php:101
+#: oc-admin/themes/modern/settings/mailserver.php
 msgid "Custom Server"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/index.php:230
+#: oc-admin/themes/modern/settings/index.php
 msgid "Custom date format"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/keywordBlock.php:100
-#: oc-includes/osclass/classes/datatables/KeywordBlocksDataTable.php:97
-#: oc-includes/osclass/classes/form/KeywordBlockForm.php:42
+#: oc-admin/themes/modern/settings/keywordBlock.php
+#: oc-includes/osclass/classes/datatables/KeywordBlocksDataTable.php
+#: oc-includes/osclass/classes/form/KeywordBlockForm.php
 msgid "Custom fields"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/searches.php:39
+#: oc-admin/themes/modern/settings/searches.php
 msgid "Custom number: this field cannot be left empty"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/searches.php:38
+#: oc-admin/themes/modern/settings/searches.php
 msgid "Custom number: this field must only contain numeric characters"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/sitemap.php:92
+#: oc-admin/themes/modern/settings/sitemap.php
 msgid "Custom sitemap URLs"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/index.php:267
+#: oc-admin/themes/modern/settings/index.php
 msgid "Custom time format"
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:82
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Customer Service"
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:21
+#: oc-includes/osclass/installer/basic_data.php
 msgid "DVD"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/sitemap.php:38
+#: oc-admin/themes/modern/settings/sitemap.php
 msgid "Daily"
 msgstr ""
 
-#: oc-admin/themes/modern/main/index.php:47
-#: oc-admin/themes/modern/main/index.php:48
-#: oc-includes/osclass/classes/AdminMenu.php:51
-#: oc-includes/osclass/classes/Breadcrumb.php:54
-#: oc-includes/osclass/functions.php:198
-#: oc-includes/osclass/helpers/hUtils.php:393
+#: oc-admin/themes/modern/main/index.php
+#: oc-includes/osclass/classes/AdminMenu.php
+#: oc-includes/osclass/classes/Breadcrumb.php
+#: oc-includes/osclass/functions.php
+#: oc-includes/osclass/helpers/hUtils.php
 msgid "Dashboard"
 msgstr ""
 
-#: oc-includes/osclass/installer/gui/install-database.php:93
+#: oc-includes/osclass/installer/gui/install-database.php
 msgid "Database admin password"
 msgstr ""
 
-#: oc-includes/osclass/installer/gui/install-database.php:89
+#: oc-includes/osclass/installer/gui/install-database.php
 msgid "Database admin username"
 msgstr ""
 
-#: oc-includes/osclass/installer/gui/install-database.php:47
+#: oc-includes/osclass/installer/gui/install-database.php
 msgid "Database name"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:633
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "Database server"
 msgstr ""
 
-#: oc-admin/themes/modern/billing/index.php:119
-#: oc-admin/themes/modern/billing/order.php:126
-#: oc-admin/themes/modern/billing/wallet.php:70
-#: oc-admin/themes/modern/main/index.php:110
-#: oc-admin/themes/modern/settings/index.php:210
-#: oc-admin/themes/modern/stats/comments.php:69
-#: oc-admin/themes/modern/stats/items.php:88
-#: oc-admin/themes/modern/stats/items.php:90
-#: oc-admin/themes/modern/stats/items.php:96
-#: oc-admin/themes/modern/stats/items.php:98
-#: oc-admin/themes/modern/stats/reports.php:64
-#: oc-admin/themes/modern/stats/users.php:77
-#: oc-includes/osclass/classes/datatables/AlertsDataTable.php:62
-#: oc-includes/osclass/classes/datatables/CommentsDataTable.php:85
-#: oc-includes/osclass/classes/datatables/ItemsDataTable.php:659
-#: oc-includes/osclass/classes/datatables/ItemsDataTable.php:91
-#: oc-includes/osclass/classes/datatables/LogsDataTable.php:65
-#: oc-includes/osclass/classes/datatables/MediaDataTable.php:96
-#: oc-includes/osclass/classes/datatables/UsersDataTable.php:78
+#: oc-admin/themes/modern/billing/index.php
+#: oc-admin/themes/modern/billing/order.php
+#: oc-admin/themes/modern/billing/wallet.php
+#: oc-admin/themes/modern/main/index.php
+#: oc-admin/themes/modern/settings/index.php
+#: oc-admin/themes/modern/stats/comments.php
+#: oc-admin/themes/modern/stats/items.php
+#: oc-admin/themes/modern/stats/reports.php
+#: oc-admin/themes/modern/stats/users.php
+#: oc-includes/osclass/classes/datatables/AlertsDataTable.php
+#: oc-includes/osclass/classes/datatables/CommentsDataTable.php
+#: oc-includes/osclass/classes/datatables/ItemsDataTable.php
+#: oc-includes/osclass/classes/datatables/LogsDataTable.php
+#: oc-includes/osclass/classes/datatables/MediaDataTable.php
+#: oc-includes/osclass/classes/datatables/UsersDataTable.php
 msgid "Date"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/index.php:206
+#: oc-admin/themes/modern/settings/index.php
 msgid "Date & time format"
 msgstr ""
 
-#: oc-admin/themes/modern/languages/frm.php:97
+#: oc-admin/themes/modern/languages/frm.php
 msgid "Date format"
 msgstr ""
 
-#: oc-includes/osclass/classes/form/LanguageForm.php:206
+#: oc-includes/osclass/classes/form/LanguageForm.php
 msgid "Date format: this field is required"
 msgstr ""
 
-#: oc-includes/osclass/classes/EmailVariables.php:68
+#: oc-includes/osclass/classes/EmailVariables.php
 msgid "Date time"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebContact.php:82
+#: oc-includes/osclass/classes/controller/CWebContact.php
 msgid "Date: %s at %s"
 msgstr ""
 
-#: oc-admin/themes/modern/comments/frm.php:87
-#: oc-admin/themes/modern/users/alerts.php:66
-#: oc-admin/themes/modern/users/alerts.php:67
-#: oc-includes/osclass/classes/controller/admin/CAdminItemComments.php:293
-#: oc-includes/osclass/classes/controller/admin/CAdminItemComments.php:295
-#: oc-includes/osclass/classes/controller/admin/CAdminItems.php:573
-#: oc-includes/osclass/classes/controller/admin/CAdminItems.php:990
-#: oc-includes/osclass/classes/controller/admin/CAdminItems.php:992
-#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php:107
-#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php:726
-#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php:728
-#: oc-includes/osclass/classes/datatables/AlertsDataTable.php:137
-#: oc-includes/osclass/classes/datatables/CommentsDataTable.php:155
-#: oc-includes/osclass/classes/datatables/ItemsDataTable.php:251
-#: oc-includes/osclass/classes/datatables/UsersDataTable.php:220
+#: oc-admin/themes/modern/comments/frm.php
+#: oc-admin/themes/modern/users/alerts.php
+#: oc-includes/osclass/classes/controller/admin/CAdminItemComments.php
+#: oc-includes/osclass/classes/controller/admin/CAdminItems.php
+#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php
+#: oc-includes/osclass/classes/datatables/AlertsDataTable.php
+#: oc-includes/osclass/classes/datatables/CommentsDataTable.php
+#: oc-includes/osclass/classes/datatables/ItemsDataTable.php
+#: oc-includes/osclass/classes/datatables/UsersDataTable.php
 msgid "Deactivate"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/storage.php:256
+#: oc-admin/themes/modern/settings/storage.php
 msgid "Dead-lettered jobs (past the retry ceiling):"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:587
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "Debug mode"
 msgstr ""
 
-#: oc-includes/osclass/helpers/hUtils.php:335
+#: oc-includes/osclass/helpers/hUtils.php
 msgid "Dec"
 msgstr ""
 
-#: oc-includes/osclass/helpers/hUtils.php:320
+#: oc-includes/osclass/helpers/hUtils.php
 msgid "December"
 msgstr ""
 
-#: oc-admin/themes/modern/billing/package.php:54
+#: oc-admin/themes/modern/billing/package.php
 msgid "Decimal currency, e.g. 9.99."
 msgstr ""
 
-#: oc-admin/themes/modern/languages/frm.php:85
+#: oc-admin/themes/modern/languages/frm.php
 msgid "Decimal point"
 msgstr ""
 
-#: oc-includes/osclass/classes/form/LanguageForm.php:204
+#: oc-includes/osclass/classes/form/LanguageForm.php
 msgid "Decimal point: this field is required"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/comments.php:86
+#: oc-admin/themes/modern/settings/comments.php
 msgid "Default comment settings"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/index.php:149
+#: oc-admin/themes/modern/settings/index.php
 msgid "Default currency"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/index.php:136
+#: oc-admin/themes/modern/settings/index.php
 msgid "Default language"
 msgstr ""
 
-#: oc-admin/themes/modern/pages/frm.php:329
+#: oc-admin/themes/modern/pages/frm.php
 msgid "Default template"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/iframe.php:132
+#: oc-admin/themes/modern/fields/iframe.php
 msgid "Default value"
 msgstr ""
 
-#: oc-admin/themes/modern/admins/index.php:97
-#: oc-admin/themes/modern/appearance/index.php:166
-#: oc-admin/themes/modern/appearance/widgets.php:191
-#: oc-admin/themes/modern/billing/packages.php:103
-#: oc-admin/themes/modern/billing/packages.php:73
-#: oc-admin/themes/modern/categories/index.php:123
-#: oc-admin/themes/modern/comments/index.php:108
-#: oc-admin/themes/modern/fields/index.php:820
-#: oc-admin/themes/modern/fields/index.php:830
-#: oc-admin/themes/modern/fields/submissions.php:172
-#: oc-admin/themes/modern/fields/submissions.php:255
-#: oc-admin/themes/modern/items/index.php:345
-#: oc-admin/themes/modern/items/reported.php:125
-#: oc-admin/themes/modern/items/reported.php:66
-#: oc-admin/themes/modern/items/reported.php:67
-#: oc-admin/themes/modern/languages/index.php:135
-#: oc-admin/themes/modern/media/index.php:362
-#: oc-admin/themes/modern/media/index.php:363
-#: oc-admin/themes/modern/pages/frm.php:271
-#: oc-admin/themes/modern/pages/index.php:121
-#: oc-admin/themes/modern/parts/ui.php:682
-#: oc-admin/themes/modern/parts/ui.php:833
-#: oc-admin/themes/modern/plugins/index.php:211
-#: oc-admin/themes/modern/settings/currencies.php:110
-#: oc-admin/themes/modern/settings/currencies.php:42
-#: oc-admin/themes/modern/settings/currencies.php:66
-#: oc-admin/themes/modern/settings/currencies.php:67
-#: oc-admin/themes/modern/settings/keywordBlock.php:256
-#: oc-admin/themes/modern/settings/keywordBlock.php:266
-#: oc-admin/themes/modern/settings/locations.php:147
-#: oc-admin/themes/modern/settings/locations.php:63
-#: oc-admin/themes/modern/settings/locations.php:66
-#: oc-admin/themes/modern/users/alerts.php:127
-#: oc-admin/themes/modern/users/alerts.php:71
-#: oc-admin/themes/modern/users/alerts.php:72
-#: oc-admin/themes/modern/users/ban.php:158
-#: oc-admin/themes/modern/users/ban.php:168
-#: oc-admin/themes/modern/users/frm.php:401
-#: oc-admin/themes/modern/users/frm.php:449
-#: oc-admin/themes/modern/users/index.php:292
-#: oc-includes/osclass/classes/controller/admin/CAdminAdmins.php:339
-#: oc-includes/osclass/classes/controller/admin/CAdminAdmins.php:383
-#: oc-includes/osclass/classes/controller/admin/CAdminAdmins.php:385
-#: oc-includes/osclass/classes/controller/admin/CAdminItemComments.php:277
-#: oc-includes/osclass/classes/controller/admin/CAdminItemComments.php:279
-#: oc-includes/osclass/classes/controller/admin/CAdminItems.php:974
-#: oc-includes/osclass/classes/controller/admin/CAdminItems.php:976
-#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php:511
-#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php:603
-#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php:605
-#: oc-includes/osclass/classes/controller/admin/CAdminPages.php:322
-#: oc-includes/osclass/classes/controller/admin/CAdminPages.php:324
-#: oc-includes/osclass/classes/controller/admin/CAdminPlugins.php:398
-#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php:560
-#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php:562
-#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php:750
-#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php:752
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsKeywordBlock.php:97
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsKeywordBlock.php:99
-#: oc-includes/osclass/classes/datatables/AlertsDataTable.php:132
-#: oc-includes/osclass/classes/datatables/BanRulesDataTable.php:131
-#: oc-includes/osclass/classes/datatables/CommentsDataTable.php:149
-#: oc-includes/osclass/classes/datatables/ItemsDataTable.php:292
-#: oc-includes/osclass/classes/datatables/ItemsDataTable.php:721
-#: oc-includes/osclass/classes/datatables/KeywordBlocksDataTable.php:120
-#: oc-includes/osclass/classes/datatables/MediaDataTable.php:165
-#: oc-includes/osclass/classes/datatables/PagesDataTable.php:93
-#: oc-includes/osclass/classes/datatables/UsersDataTable.php:211
-#: oc-includes/osclass/classes/form/ItemForm.php:1316
-#: oc-includes/osclass/classes/form/ItemForm.php:1547
-#: oc-includes/osclass/classes/form/ItemForm.php:1554
-#: oc-includes/osclass/classes/form/ItemForm.php:1588
+#: oc-admin/themes/modern/admins/index.php
+#: oc-admin/themes/modern/appearance/index.php
+#: oc-admin/themes/modern/appearance/widgets.php
+#: oc-admin/themes/modern/billing/packages.php
+#: oc-admin/themes/modern/categories/index.php
+#: oc-admin/themes/modern/comments/index.php
+#: oc-admin/themes/modern/fields/index.php
+#: oc-admin/themes/modern/fields/submissions.php
+#: oc-admin/themes/modern/items/index.php
+#: oc-admin/themes/modern/items/reported.php
+#: oc-admin/themes/modern/languages/index.php
+#: oc-admin/themes/modern/media/index.php
+#: oc-admin/themes/modern/pages/frm.php
+#: oc-admin/themes/modern/pages/index.php
+#: oc-admin/themes/modern/parts/ui.php
+#: oc-admin/themes/modern/plugins/index.php
+#: oc-admin/themes/modern/settings/currencies.php
+#: oc-admin/themes/modern/settings/keywordBlock.php
+#: oc-admin/themes/modern/settings/locations.php
+#: oc-admin/themes/modern/users/alerts.php
+#: oc-admin/themes/modern/users/ban.php
+#: oc-admin/themes/modern/users/frm.php
+#: oc-admin/themes/modern/users/index.php
+#: oc-includes/osclass/classes/controller/admin/CAdminAdmins.php
+#: oc-includes/osclass/classes/controller/admin/CAdminItemComments.php
+#: oc-includes/osclass/classes/controller/admin/CAdminItems.php
+#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php
+#: oc-includes/osclass/classes/controller/admin/CAdminPages.php
+#: oc-includes/osclass/classes/controller/admin/CAdminPlugins.php
+#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsKeywordBlock.php
+#: oc-includes/osclass/classes/datatables/AlertsDataTable.php
+#: oc-includes/osclass/classes/datatables/BanRulesDataTable.php
+#: oc-includes/osclass/classes/datatables/CommentsDataTable.php
+#: oc-includes/osclass/classes/datatables/ItemsDataTable.php
+#: oc-includes/osclass/classes/datatables/KeywordBlocksDataTable.php
+#: oc-includes/osclass/classes/datatables/MediaDataTable.php
+#: oc-includes/osclass/classes/datatables/PagesDataTable.php
+#: oc-includes/osclass/classes/datatables/UsersDataTable.php
+#: oc-includes/osclass/classes/form/ItemForm.php
 msgid "Delete"
 msgstr ""
 
-#: oc-admin/themes/modern/billing/packages.php:92
+#: oc-admin/themes/modern/billing/packages.php
 msgid "Delete \"%s\"?"
 msgstr ""
 
-#: oc-admin/themes/modern/categories/index.php:122
+#: oc-admin/themes/modern/categories/index.php
 msgid "Delete %s"
 msgstr ""
 
-#: oc-admin/themes/modern/categories/index.php:154
+#: oc-admin/themes/modern/categories/index.php
 msgid ""
 "Delete <strong>%1$s</strong>? This permanently removes it, its %2$d "
 "subcategories, and all %3$d listings filed under them. This cannot be "
 "undone."
 msgstr ""
 
-#: oc-admin/themes/modern/categories/index.php:153
+#: oc-admin/themes/modern/categories/index.php
 msgid ""
 "Delete <strong>%s</strong>? This permanently removes the category and every "
 "listing filed under it. This cannot be undone."
 msgstr ""
 
-#: oc-admin/themes/modern/categories/index.php:155
+#: oc-admin/themes/modern/categories/index.php
 msgid ""
 "Delete <strong>%s</strong>? This permanently removes the category. This "
 "cannot be undone."
 msgstr ""
 
-#: oc-admin/themes/modern/plugins/index.php:207
+#: oc-admin/themes/modern/plugins/index.php
 msgid "Delete Plugin"
 msgstr ""
 
-#: oc-admin/themes/modern/admins/index.php:95
+#: oc-admin/themes/modern/admins/index.php
 msgid "Delete admin"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/storage.php:216
+#: oc-admin/themes/modern/settings/storage.php
 msgid "Delete after upload"
 msgstr ""
 
-#: oc-admin/themes/modern/users/alerts.php:125
-#: oc-admin/themes/modern/users/frm.php:442
+#: oc-admin/themes/modern/users/alerts.php
+#: oc-admin/themes/modern/users/frm.php
 msgid "Delete alert"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/submissions.php:114
-#: oc-admin/themes/modern/fields/submissions.php:265
+#: oc-admin/themes/modern/fields/submissions.php
 msgid "Delete all"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/logs.php:154
+#: oc-admin/themes/modern/tools/logs.php
 msgid "Delete all entries"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/submissions.php:260
+#: oc-admin/themes/modern/fields/submissions.php
 msgid "Delete all submissions"
 msgstr ""
 
-#: oc-admin/themes/modern/categories/index.php:152
-#: oc-admin/themes/modern/categories/index.php:156
-#: oc-admin/themes/modern/categories/index.php:215
-#: oc-admin/themes/modern/categories/index.php:221
+#: oc-admin/themes/modern/categories/index.php
 msgid "Delete category"
 msgstr ""
 
-#: oc-admin/themes/modern/comments/index.php:106
+#: oc-admin/themes/modern/comments/index.php
 msgid "Delete comment"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/currencies.php:108
+#: oc-admin/themes/modern/settings/currencies.php
 msgid "Delete currency"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/index.php:815
+#: oc-admin/themes/modern/fields/index.php
 msgid "Delete field"
 msgstr ""
 
-#: oc-admin/themes/modern/media/index.php:388
+#: oc-admin/themes/modern/media/index.php
 msgid "Delete file"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/index.php:510
-#: oc-admin/themes/modern/fields/index.php:764
-#: oc-admin/themes/modern/fields/index.php:825
+#: oc-admin/themes/modern/fields/index.php
 msgid "Delete form"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/keywordBlock.php:254
+#: oc-admin/themes/modern/settings/keywordBlock.php
 msgid "Delete keyword"
 msgstr ""
 
-#: oc-admin/themes/modern/languages/index.php:133
+#: oc-admin/themes/modern/languages/index.php
 msgid "Delete language"
 msgstr ""
 
-#: oc-admin/themes/modern/items/index.php:343
-#: oc-admin/themes/modern/items/reported.php:123
+#: oc-admin/themes/modern/items/index.php
+#: oc-admin/themes/modern/items/reported.php
 msgid "Delete listing"
 msgstr ""
 
-#: oc-includes/osclass/classes/EmailVariables.php:64
+#: oc-includes/osclass/classes/EmailVariables.php
 msgid "Delete listing link"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:255
-#: oc-admin/themes/modern/settings/permalinks.php:256
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid "Delete listing resource url: this field is required"
 msgstr ""
 
-#: oc-includes/osclass/classes/EmailVariables.php:65
+#: oc-includes/osclass/classes/EmailVariables.php
 msgid "Delete listing url"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:251
-#: oc-admin/themes/modern/settings/permalinks.php:252
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid "Delete listing url: this field is required"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/cleanup.php:160
+#: oc-admin/themes/modern/tools/cleanup.php
 msgid "Delete matching items"
 msgstr ""
 
-#: oc-admin/themes/modern/pages/index.php:119
+#: oc-admin/themes/modern/pages/index.php
 msgid "Delete page"
 msgstr ""
 
-#: oc-admin/themes/modern/users/ban.php:156
+#: oc-admin/themes/modern/users/ban.php
 msgid "Delete rule"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/locations.php:148
+#: oc-admin/themes/modern/settings/locations.php
 msgid "Delete selected locations"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/submissions.php:250
+#: oc-admin/themes/modern/fields/submissions.php
 msgid "Delete submission"
 msgstr ""
 
-#: oc-admin/themes/modern/appearance/index.php:215
+#: oc-admin/themes/modern/appearance/index.php
 msgid "Delete theme"
 msgstr ""
 
-#: oc-admin/themes/modern/media/index.php:385
+#: oc-admin/themes/modern/media/index.php
 msgid "Delete this file?"
 msgstr ""
 
-#: oc-admin/themes/modern/pages/frm.php:270
+#: oc-admin/themes/modern/pages/frm.php
 msgid "Delete this widget?"
 msgstr ""
 
-#: oc-admin/themes/modern/users/index.php:290
+#: oc-admin/themes/modern/users/index.php
 msgid "Delete user"
 msgstr ""
 
-#: oc-admin/themes/modern/appearance/widgets.php:129
-#: oc-admin/themes/modern/appearance/widgets.php:189
+#: oc-admin/themes/modern/appearance/widgets.php
 msgid "Delete widget"
 msgstr ""
 
-#: oc-admin/themes/modern/billing/index.php:138
+#: oc-admin/themes/modern/billing/index.php
 msgid "Deleted user"
 msgstr ""
 
-#: oc-admin/themes/modern/categories/index.php:37
+#: oc-admin/themes/modern/categories/index.php
 msgid ""
 "Deleting a category also deletes every listing filed under it and its "
 "subcategories."
 msgstr ""
 
-#: oc-admin/themes/modern/fields/index.php:826
+#: oc-admin/themes/modern/fields/index.php
 msgid ""
 "Deleting the form keeps its fields (they return to the palette) but removes "
 "the form and its category assignment. Continue?"
 msgstr ""
 
-#: oc-admin/themes/modern/appearance/index.php:115
-#: oc-admin/themes/modern/appearance/index.php:181
-#: oc-admin/themes/modern/languages/frm.php:61
-#: oc-admin/themes/modern/languages/index.php:61
-#: oc-admin/themes/modern/languages/index.php:78
-#: oc-admin/themes/modern/plugins/index.php:125
-#: oc-admin/themes/modern/plugins/index.php:97
-#: oc-admin/themes/modern/settings/currencies.php:77
-#: oc-admin/themes/modern/settings/currencies.php:91
-#: oc-includes/osclass/classes/form/CategoryForm.php:217
-#: oc-includes/osclass/classes/form/ItemForm.php:375
-#: oc-includes/osclass/classes/form/PageForm.php:242
-#: oc-includes/osclass/classes/form/admin/Item.php:180
-#: oc-includes/osclass/emails.php:1136
-#: oc-includes/osclass/emails.php:1141
-#: oc-includes/osclass/emails.php:1243
-#: oc-includes/osclass/emails.php:1248
-#: oc-includes/osclass/emails.php:1364
-#: oc-includes/osclass/emails.php:1369
+#: oc-admin/themes/modern/appearance/index.php
+#: oc-admin/themes/modern/languages/frm.php
+#: oc-admin/themes/modern/languages/index.php
+#: oc-admin/themes/modern/plugins/index.php
+#: oc-admin/themes/modern/settings/currencies.php
+#: oc-includes/osclass/classes/form/CategoryForm.php
+#: oc-includes/osclass/classes/form/ItemForm.php
+#: oc-includes/osclass/classes/form/PageForm.php
+#: oc-includes/osclass/classes/form/admin/Item.php
+#: oc-includes/osclass/emails.php
 msgid "Description"
 msgstr ""
 
-#: oc-admin/themes/modern/appearance/add_widget.php:155
+#: oc-admin/themes/modern/appearance/add_widget.php
 msgid "Description (for internal purposes only)"
 msgstr ""
 
-#: oc-admin/themes/modern/items/settings.php:225
+#: oc-admin/themes/modern/items/settings.php
 msgid "Description length"
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:104
+#: oc-includes/osclass/installer/basic_data.php
 msgid ""
 "Description of the example ad. Insert here some usefull description of your "
 "ad."
 msgstr ""
 
-#: oc-admin/themes/modern/settings/keywordBlock.php:99
-#: oc-includes/osclass/classes/datatables/KeywordBlocksDataTable.php:95
-#: oc-includes/osclass/classes/form/KeywordBlockForm.php:40
+#: oc-admin/themes/modern/settings/keywordBlock.php
+#: oc-includes/osclass/classes/datatables/KeywordBlocksDataTable.php
+#: oc-includes/osclass/classes/form/KeywordBlockForm.php
 msgid "Description only"
 msgstr ""
 
-#: oc-admin/themes/modern/appearance/add_widget.php:326
-#: oc-includes/osclass/classes/form/LanguageForm.php:198
+#: oc-admin/themes/modern/appearance/add_widget.php
+#: oc-includes/osclass/classes/form/LanguageForm.php
 msgid "Description: this field is required"
 msgstr ""
 
-#: oc-includes/osclass/classes/datatables/LogsDataTable.php:69
+#: oc-includes/osclass/classes/datatables/LogsDataTable.php
 msgid "Details"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:369
+#: oc-admin/themes/modern/tools/system-info.php
 msgid ""
 "Detects the true type of an uploaded file. Without it, upload validation is "
 "weaker."
 msgstr ""
 
-#: oc-admin/themes/modern/languages/frm.php:67
+#: oc-admin/themes/modern/languages/frm.php
 msgid "Direction"
 msgstr ""
 
-#: oc-admin/themes/modern/categories/index.php:118
-#: oc-admin/themes/modern/categories/index.php:163
-#: oc-admin/themes/modern/users/frm.php:406
-#: oc-includes/osclass/classes/controller/admin/CAdminPlugins.php:377
+#: oc-admin/themes/modern/categories/index.php
+#: oc-admin/themes/modern/users/frm.php
+#: oc-includes/osclass/classes/controller/admin/CAdminPlugins.php
 msgid "Disable"
 msgstr ""
 
-#: oc-admin/themes/modern/categories/index.php:115
+#: oc-admin/themes/modern/categories/index.php
 msgid "Disable %s"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php:579
-#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php:581
+#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php
 msgid "Disable (Website)"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php:505
-#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php:595
-#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php:597
+#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php
 msgid "Disable (oc-admin)"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php:500
+#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php
 msgid "Disable (website)"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/maintenance.php:51
+#: oc-admin/themes/modern/tools/maintenance.php
 msgid "Disable maintenance mode"
 msgstr ""
 
-#: oc-admin/themes/modern/billing/packages.php:64
-#: oc-admin/themes/modern/categories/index.php:105
-#: oc-admin/themes/modern/categories/index.php:161
-#: oc-admin/themes/modern/settings/index.php:384
-#: oc-includes/osclass/classes/controller/admin/CAdminPlugins.php:431
-#: oc-includes/osclass/classes/utility/SystemInfo.php:270
-#: oc-includes/osclass/classes/utility/SystemInfo.php:280
-#: oc-includes/osclass/classes/utility/SystemInfo.php:290
-#: oc-includes/osclass/classes/utility/SystemInfo.php:300
-#: oc-includes/osclass/classes/utility/SystemInfo.php:310
+#: oc-admin/themes/modern/billing/packages.php
+#: oc-admin/themes/modern/categories/index.php
+#: oc-admin/themes/modern/settings/index.php
+#: oc-includes/osclass/classes/controller/admin/CAdminPlugins.php
+#: oc-includes/osclass/classes/utility/SystemInfo.php
 msgid "Disabled"
 msgstr ""
 
-#: oc-includes/osclass/helpers/hMessages.php:107
-#: oc-includes/osclass/installer/gui/install-finish.php:34
+#: oc-includes/osclass/helpers/hMessages.php
+#: oc-includes/osclass/installer/gui/install-finish.php
 msgid "Dismiss"
 msgstr ""
 
-#: oc-admin/themes/modern/parts/market.php:615
-#: oc-includes/osclass/installer/gui/install.php:250
+#: oc-admin/themes/modern/parts/market.php
+#: oc-includes/osclass/installer/gui/install.php
 msgid "Documentation"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/index.php:284
+#: oc-admin/themes/modern/settings/index.php
 msgid "Documentation on date and time formatting"
 msgstr ""
 
-#: oc-includes/osclass/installer/gui/install.php:105
-#: oc-includes/osclass/installer/gui/install.php:37
+#: oc-includes/osclass/installer/gui/install.php
 msgid "Done"
 msgstr ""
 
-#: oc-includes/osclass/classes/datatables/PagesDataTable.php:110
+#: oc-includes/osclass/classes/datatables/PagesDataTable.php
 msgid "Down"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/storage.php:292
+#: oc-admin/themes/modern/settings/storage.php
 msgid "Download all remote images back to local (offline copy)"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/storage.php:331
+#: oc-admin/themes/modern/settings/storage.php
 msgid "Download every remote image back to local disk?"
 msgstr ""
 
-#: oc-includes/osclass/classes/market/Installer.php:200
+#: oc-includes/osclass/classes/market/Installer.php
 msgid "Download failed, or the downloaded file did not match the expected checksum."
 msgstr ""
 
-#: oc-admin/themes/modern/languages/index.php:31
+#: oc-admin/themes/modern/languages/index.php
 msgid "Download language"
 msgstr ""
 
-#: oc-admin/themes/modern/parts/market.php:535
-#: oc-admin/themes/modern/parts/market.php:575
+#: oc-admin/themes/modern/parts/market.php
 msgid "Downloads"
 msgstr ""
 
-#: oc-admin/themes/modern/parts/market.php:372
+#: oc-admin/themes/modern/parts/market.php
 msgid ""
 "Downloads are GitHub's cumulative count of release-asset downloads — "
 "includes CI, mirrors, bots and repeat downloads. Not an install count."
 msgstr ""
 
-#: oc-admin/themes/modern/fields/index.php:514
-#: oc-admin/themes/modern/fields/index.php:774
+#: oc-admin/themes/modern/fields/index.php
 msgid "Drag a field here, or use “Add field”."
 msgstr ""
 
-#: oc-admin/themes/modern/appearance/widgets.php:150
+#: oc-admin/themes/modern/appearance/widgets.php
 msgid ""
 "Drag a type into a section on the left to add it there. You can place the "
 "same type as many times as you like."
 msgstr ""
 
-#: oc-admin/themes/modern/appearance/widgets.php:160
+#: oc-admin/themes/modern/appearance/widgets.php
 msgid "Drag into a section"
 msgstr ""
 
-#: oc-admin/themes/modern/categories/index.php:72
+#: oc-admin/themes/modern/categories/index.php
 msgid "Drag to reorder"
 msgstr ""
 
-#: oc-admin/themes/modern/appearance/widgets.php:118
+#: oc-admin/themes/modern/appearance/widgets.php
 msgid "Drag to reorder or move, or focus and use the arrow keys"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/index.php:679
-#: oc-admin/themes/modern/fields/index.php:95
+#: oc-admin/themes/modern/fields/index.php
 msgid "Drag to reorder, or focus and use the arrow keys"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/cache.php:153
-#: oc-admin/themes/modern/tools/cache.php:178
+#: oc-admin/themes/modern/tools/cache.php
 msgid "Driver"
 msgstr ""
 
-#: oc-admin/themes/modern/appearance/widgets.php:138
+#: oc-admin/themes/modern/appearance/widgets.php
 msgid "Drop a widget type here"
 msgstr ""
 
-#: oc-admin/themes/modern/stats/reports.php:66
-#: oc-includes/osclass/classes/datatables/ItemsDataTable.php:656
+#: oc-admin/themes/modern/stats/reports.php
+#: oc-includes/osclass/classes/datatables/ItemsDataTable.php
 msgid "Duplicated"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/billing.php:312
+#: oc-admin/themes/modern/settings/billing.php
 msgid "Duration (days)"
 msgstr ""
 
-#: oc-admin/themes/modern/stats/users.php:210
+#: oc-admin/themes/modern/stats/users.php
 msgid "E-Mail"
 msgstr ""
 
-#: oc-admin/gui/recover.php:27
-#: oc-admin/themes/modern/admins/index.php:46
-#: oc-admin/themes/modern/admins/index.php:61
-#: oc-admin/themes/modern/items/frm.php:235
-#: oc-admin/themes/modern/users/frm.php:230
-#: oc-includes/osclass/classes/datatables/AlertsDataTable.php:60
-#: oc-includes/osclass/classes/datatables/UsersDataTable.php:75
+#: oc-admin/gui/recover.php
+#: oc-admin/themes/modern/admins/index.php
+#: oc-admin/themes/modern/items/frm.php
+#: oc-admin/themes/modern/users/frm.php
+#: oc-includes/osclass/classes/datatables/AlertsDataTable.php
+#: oc-includes/osclass/classes/datatables/UsersDataTable.php
 msgid "E-mail"
 msgstr ""
 
-#: oc-admin/themes/modern/admins/frm.php:82
+#: oc-admin/themes/modern/admins/frm.php
 msgid "E-mail <em>(required)</em>"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/comments.php:135
+#: oc-admin/themes/modern/settings/comments.php
 msgid "E-mail admin whenever"
 msgstr ""
 
-#: oc-admin/themes/modern/users/ban_frm.php:93
-#: oc-includes/osclass/classes/datatables/BanRulesDataTable.php:65
+#: oc-admin/themes/modern/users/ban_frm.php
+#: oc-includes/osclass/classes/datatables/BanRulesDataTable.php
 msgid "E-mail rule"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/comments.php:145
+#: oc-admin/themes/modern/settings/comments.php
 msgid "E-mail user whenever"
 msgstr ""
 
-#: oc-includes/osclass/classes/Dependencies.php:84
+#: oc-includes/osclass/classes/Dependencies.php
 msgid "ERROR: Some dependencies could not be loaded (%s)"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/storage.php:322
+#: oc-admin/themes/modern/settings/storage.php
 msgid ""
 "Each image still on local disk is queued for upload to the active remote "
 "backend. "
 msgstr ""
 
-#: oc-admin/themes/modern/settings/storage.php:332
+#: oc-admin/themes/modern/settings/storage.php
 msgid ""
 "Each remote image is queued for download and switched back to local "
 "storage. "
 msgstr ""
 
-#: oc-admin/themes/modern/appearance/widgets.php:80
+#: oc-admin/themes/modern/appearance/widgets.php
 msgid ""
 "Each section is a place your theme renders widgets. Drag a type in from the "
 "right, and drag widgets to reorder them or move them between sections."
 msgstr ""
 
-#: oc-admin/themes/modern/billing/packages.php:69
-#: oc-admin/themes/modern/categories/index.php:110
-#: oc-admin/themes/modern/pages/frm.php:261
-#: oc-admin/themes/modern/pages/frm.php:264
-#: oc-admin/themes/modern/settings/currencies.php:38
-#: oc-admin/themes/modern/settings/locations.php:151
-#: oc-admin/themes/modern/settings/locations.php:69
-#: oc-includes/osclass/classes/controller/admin/CAdminAdmins.php:336
-#: oc-includes/osclass/classes/controller/admin/CAdminEmails.php:139
-#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php:495
-#: oc-includes/osclass/classes/datatables/BanRulesDataTable.php:128
-#: oc-includes/osclass/classes/datatables/CommentsDataTable.php:152
-#: oc-includes/osclass/classes/datatables/ItemsDataTable.php:289
-#: oc-includes/osclass/classes/datatables/ItemsDataTable.php:718
-#: oc-includes/osclass/classes/datatables/KeywordBlocksDataTable.php:117
-#: oc-includes/osclass/classes/datatables/PagesDataTable.php:89
-#: oc-includes/osclass/classes/datatables/UsersDataTable.php:208
+#: oc-admin/themes/modern/billing/packages.php
+#: oc-admin/themes/modern/categories/index.php
+#: oc-admin/themes/modern/pages/frm.php
+#: oc-admin/themes/modern/settings/currencies.php
+#: oc-admin/themes/modern/settings/locations.php
+#: oc-includes/osclass/classes/controller/admin/CAdminAdmins.php
+#: oc-includes/osclass/classes/controller/admin/CAdminEmails.php
+#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php
+#: oc-includes/osclass/classes/datatables/BanRulesDataTable.php
+#: oc-includes/osclass/classes/datatables/CommentsDataTable.php
+#: oc-includes/osclass/classes/datatables/ItemsDataTable.php
+#: oc-includes/osclass/classes/datatables/KeywordBlocksDataTable.php
+#: oc-includes/osclass/classes/datatables/PagesDataTable.php
+#: oc-includes/osclass/classes/datatables/UsersDataTable.php
 msgid "Edit"
 msgstr ""
 
-#: oc-admin/themes/modern/billing/package.php:34
-#: oc-admin/themes/modern/categories/index.php:109
+#: oc-admin/themes/modern/billing/package.php
+#: oc-admin/themes/modern/categories/index.php
 msgid "Edit %s"
 msgstr ""
 
-#: oc-admin/themes/modern/admins/frm.php:26
+#: oc-admin/themes/modern/admins/frm.php
 msgid "Edit admin"
 msgstr ""
 
-#: oc-admin/themes/modern/categories/iframe.php:21
-#: oc-admin/themes/modern/categories/index.php:164
-#: oc-admin/themes/modern/categories/index.php:199
+#: oc-admin/themes/modern/categories/iframe.php
+#: oc-admin/themes/modern/categories/index.php
 msgid "Edit category"
 msgstr ""
 
-#: oc-admin/themes/modern/comments/frm.php:21
-#: oc-admin/themes/modern/comments/frm.php:33
+#: oc-admin/themes/modern/comments/frm.php
 msgid "Edit comment"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/currency_form.php:78
+#: oc-admin/themes/modern/settings/currency_form.php
 msgid "Edit currency"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/iframe.php:73
+#: oc-admin/themes/modern/fields/iframe.php
 msgid "Edit custom field"
 msgstr ""
 
-#: oc-admin/themes/modern/emails/frm.php:123
-#: oc-admin/themes/modern/emails/frm.php:20
+#: oc-admin/themes/modern/emails/frm.php
 msgid "Edit email template"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/index.php:116
-#: oc-admin/themes/modern/fields/index.php:683
+#: oc-admin/themes/modern/fields/index.php
 msgid "Edit field"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/group_iframe.php:32
+#: oc-admin/themes/modern/fields/group_iframe.php
 msgid "Edit field group"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/keywordBlock_frm.php:25
+#: oc-admin/themes/modern/settings/keywordBlock_frm.php
 msgid "Edit keyword"
 msgstr ""
 
-#: oc-admin/themes/modern/languages/frm.php:19
-#: oc-admin/themes/modern/languages/frm.php:33
+#: oc-admin/themes/modern/languages/frm.php
 msgid "Edit language"
 msgstr ""
 
-#: oc-admin/themes/modern/items/frm.php:39
+#: oc-admin/themes/modern/items/frm.php
 msgid "Edit listing"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:247
-#: oc-admin/themes/modern/settings/permalinks.php:248
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid "Edit listing url: this field is required"
 msgstr ""
 
-#: oc-admin/themes/modern/pages/frm.php:56
+#: oc-admin/themes/modern/pages/frm.php
 msgid "Edit page"
 msgstr ""
 
-#: oc-admin/themes/modern/parts/header.php:91
+#: oc-admin/themes/modern/parts/header.php
 msgid "Edit profile"
 msgstr ""
 
-#: oc-admin/themes/modern/users/ban_frm.php:28
+#: oc-admin/themes/modern/users/ban_frm.php
 msgid "Edit rule"
 msgstr ""
 
-#: oc-admin/themes/modern/billing/wallet.php:44
-#: oc-admin/themes/modern/comments/frm.php:69
-#: oc-admin/themes/modern/users/frm.php:32
+#: oc-admin/themes/modern/billing/wallet.php
+#: oc-admin/themes/modern/comments/frm.php
+#: oc-admin/themes/modern/users/frm.php
 msgid "Edit user"
 msgstr ""
 
-#: oc-admin/themes/modern/appearance/add_widget.php:120
-#: oc-admin/themes/modern/appearance/add_widget.php:28
-#: oc-admin/themes/modern/appearance/widgets.php:126
-#: oc-admin/themes/modern/pages/frm.php:453
+#: oc-admin/themes/modern/appearance/add_widget.php
+#: oc-admin/themes/modern/appearance/widgets.php
+#: oc-admin/themes/modern/pages/frm.php
 msgid "Edit widget"
 msgstr ""
 
-#: oc-includes/osclass/classes/Breadcrumb.php:49
-#: oc-includes/osclass/functions.php:108
+#: oc-includes/osclass/classes/Breadcrumb.php
+#: oc-includes/osclass/functions.php
 msgid "Edit your listing"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/index.php:274
+#: oc-admin/themes/modern/fields/index.php
 msgid "Editing this field changes it in every form that uses it."
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:83
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Education - Training"
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:22
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Electronics"
 msgstr ""
 
-#: oc-admin/themes/modern/billing/credits.php:54
-#: oc-admin/themes/modern/items/index.php:116
-#: oc-admin/themes/modern/items/index.php:260
-#: oc-admin/themes/modern/users/index.php:180
-#: oc-includes/osclass/classes/AdminMenu.php:380
+#: oc-admin/themes/modern/billing/credits.php
+#: oc-admin/themes/modern/items/index.php
+#: oc-admin/themes/modern/users/index.php
+#: oc-includes/osclass/classes/AdminMenu.php
 msgid "Email"
 msgstr ""
 
-#: oc-includes/osclass/classes/EmailVariables.php:70
+#: oc-includes/osclass/classes/EmailVariables.php
 msgid "Email of the friend who wants send"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php:836
-#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php:858
+#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php
 msgid "Email sent successfully"
 msgstr ""
 
-#: oc-admin/themes/modern/emails/index.php:18
-#: oc-includes/osclass/classes/AdminMenu.php:383
+#: oc-admin/themes/modern/emails/index.php
+#: oc-includes/osclass/classes/AdminMenu.php
 msgid "Email templates"
 msgstr ""
 
-#: oc-admin/themes/modern/emails/index.php:52
+#: oc-admin/themes/modern/emails/index.php
 msgid "Email templates are registered by the core and by installed plugins."
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebContact.php:79
+#: oc-includes/osclass/classes/controller/CWebContact.php
 msgid "Email: %s"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/index.php:44
-#: oc-includes/osclass/classes/form/AdminForm.php:130
-#: oc-includes/osclass/classes/form/CommentForm.php:126
-#: oc-includes/osclass/classes/form/ContactForm.php:147
-#: oc-includes/osclass/classes/form/ItemForm.php:1186
-#: oc-includes/osclass/classes/form/ItemForm.php:965
-#: oc-includes/osclass/classes/form/SendFriendForm.php:118
-#: oc-includes/osclass/classes/form/UserForm.php:419
-#: oc-includes/osclass/classes/form/UserForm.php:472
+#: oc-admin/themes/modern/settings/index.php
+#: oc-includes/osclass/classes/form/AdminForm.php
+#: oc-includes/osclass/classes/form/CommentForm.php
+#: oc-includes/osclass/classes/form/ContactForm.php
+#: oc-includes/osclass/classes/form/ItemForm.php
+#: oc-includes/osclass/classes/form/SendFriendForm.php
+#: oc-includes/osclass/classes/form/UserForm.php
 msgid "Email: this field is required"
 msgstr ""
 
-#: oc-admin/themes/modern/emails/index.php:27
+#: oc-admin/themes/modern/emails/index.php
 msgid "Emails templates"
 msgstr ""
 
-#: oc-admin/themes/modern/categories/index.php:118
-#: oc-admin/themes/modern/categories/index.php:162
-#: oc-admin/themes/modern/users/frm.php:410
-#: oc-includes/osclass/classes/controller/admin/CAdminPlugins.php:381
+#: oc-admin/themes/modern/categories/index.php
+#: oc-admin/themes/modern/users/frm.php
+#: oc-includes/osclass/classes/controller/admin/CAdminPlugins.php
 msgid "Enable"
 msgstr ""
 
-#: oc-admin/themes/modern/categories/index.php:115
+#: oc-admin/themes/modern/categories/index.php
 msgid "Enable %s"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php:571
-#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php:573
+#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php
 msgid "Enable (Website)"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php:506
-#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php:587
-#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php:589
+#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php
 msgid "Enable (oc-admin)"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php:500
+#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php
 msgid "Enable (website)"
 msgstr ""
 
-#: oc-admin/themes/modern/items/settings.php:241
+#: oc-admin/themes/modern/items/settings.php
 msgid "Enable TinyMCE on frontend"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/billing.php:42
+#: oc-admin/themes/modern/settings/billing.php
 msgid "Enable billing"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:370
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid "Enable friendly urls"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/maintenance.php:52
+#: oc-admin/themes/modern/tools/maintenance.php
 msgid "Enable maintenance mode"
 msgstr ""
 
-#: oc-admin/themes/modern/items/settings.php:166
+#: oc-admin/themes/modern/items/settings.php
 msgid "Enable the \"send to a friend\" form"
 msgstr ""
 
-#: oc-admin/themes/modern/billing/packages.php:64
-#: oc-admin/themes/modern/categories/index.php:105
-#: oc-admin/themes/modern/categories/index.php:160
-#: oc-admin/themes/modern/tools/cleanup.php:49
-#: oc-includes/osclass/classes/utility/SystemInfo.php:268
-#: oc-includes/osclass/classes/utility/SystemInfo.php:278
-#: oc-includes/osclass/classes/utility/SystemInfo.php:288
-#: oc-includes/osclass/classes/utility/SystemInfo.php:298
-#: oc-includes/osclass/classes/utility/SystemInfo.php:308
+#: oc-admin/themes/modern/billing/packages.php
+#: oc-admin/themes/modern/categories/index.php
+#: oc-admin/themes/modern/tools/cleanup.php
+#: oc-includes/osclass/classes/utility/SystemInfo.php
 msgid "Enabled"
 msgstr ""
 
-#: oc-admin/themes/modern/languages/index.php:63
-#: oc-admin/themes/modern/languages/index.php:82
+#: oc-admin/themes/modern/languages/index.php
 msgid "Enabled (oc-admin)"
 msgstr ""
 
-#: oc-admin/themes/modern/languages/index.php:62
-#: oc-admin/themes/modern/languages/index.php:80
+#: oc-admin/themes/modern/languages/index.php
 msgid "Enabled (website)"
 msgstr ""
 
-#: oc-admin/themes/modern/languages/frm.php:116
+#: oc-admin/themes/modern/languages/frm.php
 msgid "Enabled for the backoffice (oc-admin)"
 msgstr ""
 
-#: oc-admin/themes/modern/languages/frm.php:112
+#: oc-admin/themes/modern/languages/frm.php
 msgid "Enabled for the public website"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/cleanup.php:151
+#: oc-admin/themes/modern/tools/cleanup.php
 msgid "Enabled rules also run automatically once a day."
 msgstr ""
 
-#: oc-admin/themes/modern/settings/billing.php:110
+#: oc-admin/themes/modern/settings/billing.php
 msgid "Enabled with a price of 0 means every seller can feature a listing for free."
 msgstr ""
 
-#: oc-admin/themes/modern/settings/billing.php:87
+#: oc-admin/themes/modern/settings/billing.php
 msgid "Enabled with a price of 0 means every seller can raise their "
 msgstr ""
 
-#: oc-admin/themes/modern/settings/mailserver.php:150
+#: oc-admin/themes/modern/settings/mailserver.php
 msgid "Encryption"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:372
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "Encrypts outgoing mail over TLS and secures tokens."
 msgstr ""
 
-#: oc-admin/themes/modern/settings/storage.php:144
+#: oc-admin/themes/modern/settings/storage.php
 msgid "Endpoint"
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:84
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Engineering - Architecture"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/locations.php:152
+#: oc-admin/themes/modern/settings/locations.php
 msgid "Enter"
 msgstr ""
 
-#: oc-includes/osclass/install-location.php:75
+#: oc-includes/osclass/install-location.php
 msgid "Enter a valid contact email address."
 msgstr ""
 
-#: oc-includes/osclass/installer/gui/install-target.php:88
+#: oc-includes/osclass/installer/gui/install-target.php
 msgid "Enter a valid email address."
 msgstr ""
 
-#: oc-includes/osclass/classes/form/FieldForm.php:857
+#: oc-includes/osclass/classes/form/FieldForm.php
 msgid "Enter field name"
 msgstr ""
 
-#: oc-includes/osclass/classes/form/admin/Item.php:251
+#: oc-includes/osclass/classes/form/admin/Item.php
 msgid "Enter price"
 msgstr ""
 
-#: oc-includes/osclass/installer/gui/install-database.php:27
+#: oc-includes/osclass/installer/gui/install-database.php
 msgid ""
 "Enter the database details from your hosting account. If you're not sure, "
 "your host's control panel or welcome email usually has them."
 msgstr ""
 
-#: oc-includes/osclass/classes/form/PageForm.php:201
-#: oc-includes/osclass/classes/form/admin/Item.php:148
+#: oc-includes/osclass/classes/form/PageForm.php
+#: oc-includes/osclass/classes/form/admin/Item.php
 msgid "Enter title here"
 msgstr ""
 
-#: oc-includes/osclass/classes/form/UserForm.php:207
+#: oc-includes/osclass/classes/form/UserForm.php
 msgid "Enter user description"
 msgstr ""
 
-#: oc-includes/osclass/classes/form/AlertForm.php:59
+#: oc-includes/osclass/classes/form/AlertForm.php
 msgid "Enter your e-mail"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/cache.php:126
+#: oc-admin/themes/modern/tools/cache.php
 msgid "Entries"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:625
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "Environment"
 msgstr ""
 
-#: oc-includes/osclass/functions.php:125
+#: oc-includes/osclass/functions.php
 msgid "Error"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminAppearance.php:358
+#: oc-includes/osclass/classes/controller/admin/CAdminAppearance.php
 msgid "Error loading theme custom file"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php:1007
-#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php:1043
+#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php
 msgid "Error occurred while upgrading osclass Database."
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:58
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Event Services"
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:68
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Events"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:371
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "Every ajax response, and every stored preference."
 msgstr ""
 
-#: oc-admin/themes/modern/billing/wallet.php:58
+#: oc-admin/themes/modern/billing/wallet.php
 msgid "Every change to this balance is written down here and never edited, "
 msgstr ""
 
-#: oc-admin/themes/modern/fields/index.php:277
+#: oc-admin/themes/modern/fields/index.php
 msgid "Every field is already in this form."
 msgstr ""
 
-#: oc-admin/themes/modern/media/index.php:278
+#: oc-admin/themes/modern/media/index.php
 msgid "Every image uploaded across listings, users and pages collects here. "
 msgstr ""
 
-#: oc-admin/themes/modern/media/index.php:19
+#: oc-admin/themes/modern/media/index.php
 msgid ""
 "Every image uploaded across your site — listing photos, user avatars and "
 "page images — in one "
 msgstr ""
 
-#: oc-admin/themes/modern/parts/market.php:459
+#: oc-admin/themes/modern/parts/market.php
 msgid "Every installed plugin is up to date."
 msgstr ""
 
-#: oc-admin/themes/modern/parts/market.php:459
+#: oc-admin/themes/modern/parts/market.php
 msgid "Every installed theme is up to date."
 msgstr ""
 
-#: oc-admin/themes/modern/billing/index.php:18
+#: oc-admin/themes/modern/billing/index.php
 msgid "Every payment taken on this site, whichever payment plugin handled it. "
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:33
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Everything Else"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/cache.php:131
+#: oc-admin/themes/modern/tools/cache.php
 msgid "Evictions"
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:103
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Example Ad"
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:105
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Example author"
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:109
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Example city"
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:107
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Example country"
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:113
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Example page title"
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:108
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Example region"
 msgstr ""
 
-#: oc-admin/themes/modern/categories/index.php:168
+#: oc-admin/themes/modern/categories/index.php
 msgid "Expand all"
 msgstr ""
 
-#: oc-admin/themes/modern/items/frm.php:289
+#: oc-admin/themes/modern/items/frm.php
 msgid "Expiration"
 msgstr ""
 
-#: oc-admin/themes/modern/categories/iframe.php:36
+#: oc-admin/themes/modern/categories/iframe.php
 msgid "Expiration (days)"
 msgstr ""
 
-#: oc-includes/osclass/classes/datatables/ItemsDataTable.php:662
-#: oc-includes/osclass/classes/datatables/ItemsDataTable.php:94
+#: oc-includes/osclass/classes/datatables/ItemsDataTable.php
 msgid "Expiration date"
 msgstr ""
 
-#: oc-admin/themes/modern/stats/reports.php:69
-#: oc-includes/osclass/classes/datatables/ItemsDataTable.php:471
-#: oc-includes/osclass/classes/datatables/ItemsDataTable.php:657
+#: oc-admin/themes/modern/stats/reports.php
+#: oc-includes/osclass/classes/datatables/ItemsDataTable.php
 msgid "Expired"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/cleanup.php:24
+#: oc-admin/themes/modern/tools/cleanup.php
 msgid "Expired listings"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/billing.php:333
+#: oc-admin/themes/modern/settings/billing.php
 msgid "Extra days"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/billing.php:318
+#: oc-admin/themes/modern/settings/billing.php
 msgid "Extra listing runtime"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/billing.php:275
+#: oc-admin/themes/modern/settings/billing.php
 msgid "Extra photos"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/billing.php:81
+#: oc-admin/themes/modern/settings/billing.php
 msgid "Extra slots"
 msgstr ""
 
-#: oc-admin/themes/modern/billing/index.php:37
-#: oc-admin/themes/modern/billing/order.php:38
+#: oc-admin/themes/modern/billing/index.php
+#: oc-admin/themes/modern/billing/order.php
 msgid "Failed"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/spamNbots.php:217
+#: oc-admin/themes/modern/settings/spamNbots.php
 msgid ""
 "Failed sign-ins and password-reset requests are counted per visitor address "
 "and per account "
 msgstr ""
 
-#: oc-admin/themes/modern/settings/spamNbots.php:261
+#: oc-admin/themes/modern/settings/spamNbots.php
 msgid "Failures against one account name, from anywhere. This "
 msgstr ""
 
-#: oc-admin/themes/modern/settings/spamNbots.php:251
+#: oc-admin/themes/modern/settings/spamNbots.php
 msgid "Failures from one visitor address, across every account "
 msgstr ""
 
-#: oc-admin/themes/modern/settings/billing.php:120
+#: oc-admin/themes/modern/settings/billing.php
 msgid "Featured listing duration (days)"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/billing.php:114
+#: oc-admin/themes/modern/settings/billing.php
 msgid "Featured listing price (credits)"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/billing.php:104
+#: oc-admin/themes/modern/settings/billing.php
 msgid "Featured listings"
 msgstr ""
 
-#: oc-includes/osclass/helpers/hUtils.php:325
+#: oc-includes/osclass/helpers/hUtils.php
 msgid "Feb"
 msgstr ""
 
-#: oc-includes/osclass/helpers/hUtils.php:310
+#: oc-includes/osclass/helpers/hUtils.php
 msgid "February"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:504
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid "Feed"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:219
-#: oc-admin/themes/modern/settings/permalinks.php:220
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid "Feed url: this field is required"
 msgstr ""
 
-#: oc-includes/osclass/installer/gui/install.php:251
+#: oc-includes/osclass/installer/gui/install.php
 msgid "Feedback"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:367
+#: oc-admin/themes/modern/tools/system-info.php
 msgid ""
 "Fetches update checks and talks to the market and remote services. Without "
 "it, those downloads fail."
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:479
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "Fewer uploads allowed than photos offered"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/submissions.php:147
-#: oc-admin/themes/modern/fields/submissions.php:185
+#: oc-admin/themes/modern/fields/submissions.php
 msgid "Field"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/index.php:693
+#: oc-admin/themes/modern/fields/index.php
 msgid "Field could not be added"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/index.php:790
+#: oc-admin/themes/modern/fields/index.php
 msgid "Fields"
 msgstr ""
 
-#: oc-includes/osclass/classes/datatables/MediaDataTable.php:90
+#: oc-includes/osclass/classes/datatables/MediaDataTable.php
 msgid "File"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/import.php:44
+#: oc-admin/themes/modern/tools/import.php
 msgid "File (.sql)"
 msgstr ""
 
-#: oc-includes/AjaxUploader.php:79
-#: oc-includes/AjaxUploader.php:94
+#: oc-includes/AjaxUploader.php
 msgid "File has an invalid extension, it should be one of %s."
 msgstr ""
 
-#: oc-includes/AjaxUploader.php:65
+#: oc-includes/AjaxUploader.php
 msgid "File is empty"
 msgstr ""
 
-#: oc-includes/AjaxUploader.php:68
+#: oc-includes/AjaxUploader.php
 msgid "File is too large"
 msgstr ""
 
-#: oc-includes/osclass/install-functions.php:384
+#: oc-includes/osclass/install-functions.php
 msgid "Fill in the host, database name and username first."
 msgstr ""
 
-#: oc-admin/themes/modern/billing/index.php:78
+#: oc-admin/themes/modern/billing/index.php
 msgid "Filter"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/iframe.php:219
+#: oc-admin/themes/modern/fields/iframe.php
 msgid "Filter this field's options by the value of a parent field."
 msgstr ""
 
-#: oc-admin/themes/modern/items/index.php:205
-#: oc-admin/themes/modern/users/index.php:169
+#: oc-admin/themes/modern/items/index.php
+#: oc-admin/themes/modern/users/index.php
 msgid "Filters"
 msgstr ""
 
-#: oc-admin/themes/modern/items/index.php:128
-#: oc-admin/themes/modern/tools/logs.php:95
-#: oc-admin/themes/modern/users/alerts.php:42
-#: oc-admin/themes/modern/users/index.php:101
+#: oc-admin/themes/modern/items/index.php
+#: oc-admin/themes/modern/tools/logs.php
+#: oc-admin/themes/modern/users/alerts.php
+#: oc-admin/themes/modern/users/index.php
 msgid "Find"
 msgstr ""
 
-#: oc-includes/osclass/classes/Pagination.php:106
+#: oc-includes/osclass/classes/Pagination.php
 msgid "First page"
 msgstr ""
 
-#: oc-includes/osclass/install-functions.php:165
+#: oc-includes/osclass/install-functions.php
 msgid "Folder <code>oc-content/downloads</code> exists"
 msgstr ""
 
-#: oc-includes/osclass/install-functions.php:185
+#: oc-includes/osclass/install-functions.php
 msgid "Folder <code>oc-content/languages</code> folder exists"
 msgstr ""
 
-#: oc-includes/osclass/install-functions.php:146
+#: oc-includes/osclass/install-functions.php
 msgid "Folder <code>oc-content/uploads</code> exists"
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:23
+#: oc-includes/osclass/installer/basic_data.php
 msgid "For Babies - Infants"
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:4
+#: oc-includes/osclass/installer/basic_data.php
 msgid "For sale"
 msgstr ""
 
-#: oc-admin/themes/modern/admins/frm.php:124
+#: oc-admin/themes/modern/admins/frm.php
 msgid "For security, type <b>your current password</b>"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/media.php:167
+#: oc-admin/themes/modern/settings/media.php
 msgid "Force JPEG"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/media.php:172
+#: oc-admin/themes/modern/settings/media.php
 msgid "Force JPEG extension."
 msgstr ""
 
-#: oc-admin/themes/modern/settings/media.php:192
+#: oc-admin/themes/modern/settings/media.php
 msgid "Force aspect"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/media.php:197
+#: oc-admin/themes/modern/settings/media.php
 msgid "Force image aspect."
 msgstr ""
 
-#: oc-admin/themes/modern/settings/searches.php:123
+#: oc-admin/themes/modern/settings/searches.php
 msgid "Forever"
 msgstr ""
 
-#: oc-admin/gui/login.php:59
+#: oc-admin/gui/login.php
 msgid "Forgot your password?"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/submissions.php:93
+#: oc-admin/themes/modern/fields/submissions.php
 msgid "Form"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/index.php:659
+#: oc-admin/themes/modern/fields/index.php
 msgid "Form could not be created"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/index.php:47
-#: oc-admin/themes/modern/fields/index.php:737
-#: oc-admin/themes/modern/fields/submissions.php:79
-#: oc-includes/osclass/classes/AdminMenu.php:172
+#: oc-admin/themes/modern/fields/index.php
+#: oc-admin/themes/modern/fields/submissions.php
+#: oc-includes/osclass/classes/AdminMenu.php
 msgid "Forms"
 msgstr ""
 
-#: oc-admin/themes/modern/functions.php:100
-#: oc-admin/themes/modern/functions.php:101
-#: oc-includes/osclass/installer/gui/install.php:252
+#: oc-admin/themes/modern/functions.php
+#: oc-includes/osclass/installer/gui/install.php
 msgid "Forums"
 msgstr ""
 
-#: oc-includes/osclass/helpers/hItems.php:1457
+#: oc-includes/osclass/helpers/hItems.php
 msgid "Free"
 msgstr ""
 
-#: oc-admin/themes/modern/main/index.php:279
-#: oc-admin/themes/modern/tools/system-info.php:512
+#: oc-admin/themes/modern/main/index.php
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "Free disk space"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/billing.php:69
+#: oc-admin/themes/modern/settings/billing.php
 msgid "Free listings per seller"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/media.php:252
+#: oc-admin/themes/modern/settings/media.php
 msgid ""
 "Freetype library is required. How to <a target=\"_blank\" "
 "href=\"%s\">install/configure</a>"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/sitemap.php:105
-#: oc-admin/themes/modern/settings/sitemap.php:137
-#: oc-admin/themes/modern/settings/sitemap.php:148
+#: oc-admin/themes/modern/settings/sitemap.php
 msgid "Frequency"
 msgstr ""
 
-#: oc-includes/osclass/helpers/hUtils.php:347
+#: oc-includes/osclass/helpers/hUtils.php
 msgid "Fri"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/index.php:182
-#: oc-includes/osclass/helpers/hUtils.php:343
+#: oc-admin/themes/modern/settings/index.php
+#: oc-includes/osclass/helpers/hUtils.php
 msgid "Friday"
 msgstr ""
 
-#: oc-includes/osclass/classes/form/SendFriendForm.php:124
+#: oc-includes/osclass/classes/form/SendFriendForm.php
 msgid "Friend's email: this field is required"
 msgstr ""
 
-#: oc-includes/osclass/classes/form/SendFriendForm.php:121
+#: oc-includes/osclass/classes/form/SendFriendForm.php
 msgid "Friend's name: this field is required"
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:76
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Friendship - Activity Partners"
 msgstr ""
 
-#: oc-includes/osclass/helpers/hItems.php:1588
+#: oc-includes/osclass/helpers/hItems.php
 msgid "From"
 msgstr ""
 
-#: oc-admin/themes/modern/items/reported.php:19
+#: oc-admin/themes/modern/items/reported.php
 msgid ""
 "From here, you can edit or delete the listings reported by users (spam, "
 "misclassified, duplicate, expired, offensive). You can also delete the "
 "report if you consider it mistaken."
 msgstr ""
 
-#: oc-admin/themes/modern/settings/spamNbots.php:160
-#: oc-admin/themes/modern/settings/spamNbots.php:171
+#: oc-admin/themes/modern/settings/spamNbots.php
 msgid "From the Cloudflare dashboard &raquo; Turnstile."
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:404
-#: oc-admin/themes/modern/tools/system-info.php:412
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "GD"
 msgstr ""
 
-#: oc-includes/osclass/install-functions.php:134
+#: oc-includes/osclass/install-functions.php
 msgid "GD extension for PHP"
 msgstr ""
 
-#: oc-includes/osclass/install-functions.php:136
+#: oc-includes/osclass/install-functions.php
 msgid "GD extension is required. How to "
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:411
+#: oc-admin/themes/modern/tools/system-info.php
 msgid ""
 "GD is resizing your photos. It works and is fully supported — but it cannot "
 "read some formats (animated GIF frames, CMYK JPEGs) and resizes at lower "
@@ -3955,5438 +3675,5209 @@ msgid ""
 "extension is worth it."
 msgstr ""
 
-#: oc-admin/themes/modern/settings/mailserver.php:103
+#: oc-admin/themes/modern/settings/mailserver.php
 msgid "GMail Server"
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:24
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Garage Sale"
 msgstr ""
 
-#: oc-includes/osclass/classes/AdminMenu.php:325
+#: oc-includes/osclass/classes/AdminMenu.php
 msgid "General"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/index.php:101
-#: oc-admin/themes/modern/settings/index.php:111
+#: oc-admin/themes/modern/settings/index.php
 msgid "General Settings"
 msgstr ""
 
-#: oc-admin/gui/recover.php:32
+#: oc-admin/gui/recover.php
 msgid "Get new password"
 msgstr ""
 
-#: oc-includes/AjaxUploader.php:204
+#: oc-includes/AjaxUploader.php
 msgid "Getting content length is not supported."
 msgstr ""
 
-#: oc-admin/themes/modern/parts/market.php:409
-#: oc-admin/themes/modern/parts/market.php:537
+#: oc-admin/themes/modern/parts/market.php
 msgid ""
 "GitHub's cumulative release-asset downloads — includes CI, mirrors, bots "
 "and repeat downloads. Not an install count."
 msgstr ""
 
-#: oc-admin/themes/modern/billing/wallet.php:132
+#: oc-admin/themes/modern/billing/wallet.php
 msgid "Give %s credits without a payment — to settle something off-site, "
 msgstr ""
 
-#: oc-includes/osclass/installer/gui/install.php:76
+#: oc-includes/osclass/installer/gui/install.php
 msgid "Go to the admin panel"
 msgstr ""
 
-#: oc-includes/osclass/helpers/hPagination.php:177
+#: oc-includes/osclass/helpers/hPagination.php
 msgid "Go!"
 msgstr ""
 
-#: oc-admin/themes/modern/items/settings.php:284
+#: oc-admin/themes/modern/items/settings.php
 msgid "Google Maps"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/index.php:357
+#: oc-admin/themes/modern/settings/index.php
 msgid "Google Maps key"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/spamNbots.php:107
+#: oc-admin/themes/modern/settings/spamNbots.php
 msgid "Google reCAPTCHA"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/iframe.php:106
+#: oc-admin/themes/modern/fields/iframe.php
 msgid "Group"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/group_iframe.php:36
+#: oc-admin/themes/modern/fields/group_iframe.php
 msgid "Group name"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/group_iframe.php:97
+#: oc-admin/themes/modern/fields/group_iframe.php
 msgid "Group name is required."
 msgstr ""
 
-#: oc-admin/themes/modern/fields/iframe.php:116
+#: oc-admin/themes/modern/fields/iframe.php
 msgid ""
 "Grouped fields inherit their categories from the group and render as a "
 "section."
 msgstr ""
 
-#: oc-admin/themes/modern/appearance/add_widget.php:179
+#: oc-admin/themes/modern/appearance/add_widget.php
 msgid "HTML Code for the Widget"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:368
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "Handles non-Latin text throughout the site."
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:25
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Health - Beauty"
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:59
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Health - Beauty - Fitness"
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:85
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Healthcare"
 msgstr ""
 
-#: oc-admin/themes/modern/parts/ui.php:144
-#: oc-admin/themes/modern/parts/ui.php:145
+#: oc-admin/themes/modern/parts/ui.php
 msgid "Help"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/iframe.php:131
+#: oc-admin/themes/modern/fields/iframe.php
 msgid "Help text"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/upgrade.php:67
+#: oc-admin/themes/modern/tools/upgrade.php
 msgid "Hey, a new version %s is available for download. Check details below."
 msgstr ""
 
-#: oc-includes/osclass/install-functions.php:1091
+#: oc-includes/osclass/install-functions.php
 msgid "Hi %s,"
 msgstr ""
 
-#: oc-admin/themes/modern/comments/index.php:45
+#: oc-admin/themes/modern/comments/index.php
 msgid "Hidden comments"
 msgstr ""
 
-#: oc-includes/osclass/installer/gui/install.php:45
+#: oc-includes/osclass/installer/gui/install.php
 msgid "Hide password"
 msgstr ""
 
-#: oc-includes/osclass/helpers/hSearch.php:55
+#: oc-includes/osclass/helpers/hSearch.php
 msgid "Higher price first"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/billing.php:213
+#: oc-admin/themes/modern/settings/billing.php
 msgid "Highlight"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/billing.php:228
+#: oc-admin/themes/modern/settings/billing.php
 msgid "Highlight duration (days)"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/billing.php:222
+#: oc-admin/themes/modern/settings/billing.php
 msgid "Highlight price (credits)"
 msgstr ""
 
-#: oc-admin/themes/modern/upgrade/index.php:291
+#: oc-admin/themes/modern/upgrade/index.php
 msgid "Highlights from %s"
 msgstr ""
 
-#: oc-admin/themes/modern/billing/wallet.php:53
+#: oc-admin/themes/modern/billing/wallet.php
 msgid "History"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/cache.php:127
+#: oc-admin/themes/modern/tools/cache.php
 msgid "Hit rate"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/cache.php:128
+#: oc-admin/themes/modern/tools/cache.php
 msgid "Hits"
 msgstr ""
 
-#: oc-admin/themes/modern/items/settings.php:104
+#: oc-admin/themes/modern/items/settings.php
 msgid "Hold edited listings for admin moderation"
 msgstr ""
 
-#: oc-admin/themes/modern/items/settings.php:96
+#: oc-admin/themes/modern/items/settings.php
 msgid "Hold new listings for admin moderation"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/cache.php:21
+#: oc-admin/themes/modern/tools/cache.php
 msgid ""
 "Holds values for the length of a single request and is thrown away when it "
 "ends. Nothing carries over between page loads, so there is nothing to clear."
 msgstr ""
 
-#: oc-includes/osclass/classes/Breadcrumb.php:89
+#: oc-includes/osclass/classes/Breadcrumb.php
 msgid "Home"
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:26
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Home - Furniture - Garden Supplies"
 msgstr ""
 
-#: oc-admin/themes/modern/parts/market.php:612
+#: oc-admin/themes/modern/parts/market.php
 msgid "Homepage"
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:60
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Horoscopes - Tarot"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/advanced.php:82
-#: oc-includes/osclass/installer/gui/install-database.php:41
+#: oc-admin/themes/modern/settings/advanced.php
+#: oc-includes/osclass/installer/gui/install-database.php
 msgid "Host"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/mailserver.php:108
+#: oc-admin/themes/modern/settings/mailserver.php
 msgid "Hostname"
 msgstr ""
 
-#: oc-includes/osclass/classes/EmailVariables.php:50
+#: oc-includes/osclass/classes/EmailVariables.php
 msgid "Hour"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/sitemap.php:37
+#: oc-admin/themes/modern/settings/sitemap.php
 msgid "Hourly"
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:61
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Household - Domestic Help"
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:47
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Houses - Apartments for Rent"
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:46
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Houses - Apartments for Sale"
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:49
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Housing Swap"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:366
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "How Shopclass talks to the database — the site cannot run without it."
 msgstr ""
 
-#: oc-admin/themes/modern/settings/billing.php:210
+#: oc-admin/themes/modern/settings/billing.php
 msgid "How long a listing must wait before it can be bumped again."
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:179
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "How long one request may run. Backups and imports must finish inside it."
 msgstr ""
 
-#: oc-admin/themes/modern/settings/searches.php:95
+#: oc-admin/themes/modern/settings/searches.php
 msgid "How long queries are stored"
 msgstr ""
 
-#: oc-admin/themes/modern/billing/wallet.php:143
-#: oc-admin/themes/modern/billing/wallet.php:162
+#: oc-admin/themes/modern/billing/wallet.php
 msgid "How many credits"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:178
+#: oc-admin/themes/modern/tools/system-info.php
 msgid ""
 "How many files can ride in one upload — your photos-per-listing has to fit "
 "under this."
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:180
+#: oc-admin/themes/modern/tools/system-info.php
 msgid ""
 "How many form fields one request may carry. Large category trees and "
 "settings forms can approach it."
 msgstr ""
 
-#: oc-admin/themes/modern/settings/billing.php:73
+#: oc-admin/themes/modern/settings/billing.php
 msgid "How many of a seller's listings may be live "
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:175
+#: oc-admin/themes/modern/tools/system-info.php
 msgid ""
 "How much memory one request may use. Resizing a big photo is the hungriest "
 "thing Shopclass does."
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:220
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "How to change things"
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:86
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Human Resource"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/submissions.php:133
-#: oc-admin/themes/modern/fields/submissions.php:200
-#: oc-includes/osclass/classes/datatables/LogsDataTable.php:70
+#: oc-admin/themes/modern/fields/submissions.php
+#: oc-includes/osclass/classes/datatables/LogsDataTable.php
 msgid "IP"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebContact.php:83
+#: oc-includes/osclass/classes/controller/CWebContact.php
 msgid "IP Address: %s"
 msgstr ""
 
-#: oc-admin/themes/modern/users/ban_frm.php:86
-#: oc-includes/osclass/classes/datatables/BanRulesDataTable.php:64
+#: oc-admin/themes/modern/users/ban_frm.php
+#: oc-includes/osclass/classes/datatables/BanRulesDataTable.php
 msgid "IP rule"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/group_iframe.php:43
-#: oc-admin/themes/modern/fields/iframe.php:254
+#: oc-admin/themes/modern/fields/group_iframe.php
+#: oc-admin/themes/modern/fields/iframe.php
 msgid "Identifier name"
 msgstr ""
 
-#: oc-admin/themes/modern/items/settings.php:88
+#: oc-admin/themes/modern/items/settings.php
 msgid "If the value is set to zero, there is no wait period"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/comments.php:128
+#: oc-admin/themes/modern/settings/comments.php
 msgid "If the value is zero all comments are shown"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/comments.php:116
+#: oc-admin/themes/modern/settings/comments.php
 msgid "If the value is zero, an administrator must always approve comments"
 msgstr ""
 
-#: oc-admin/themes/modern/items/settings.php:268
+#: oc-admin/themes/modern/items/settings.php
 msgid "If the value is zero, it means an unlimited number of images is allowed"
 msgstr ""
 
-#: oc-admin/themes/modern/items/settings.php:122
+#: oc-admin/themes/modern/items/settings.php
 msgid "If the value is zero, it means that each listing must be validated"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/backup.php:47
+#: oc-admin/themes/modern/tools/backup.php
 msgid "If you don't specify a backup folder, the backup files will be "
 msgstr ""
 
-#: oc-admin/themes/modern/settings/spamNbots.php:178
+#: oc-admin/themes/modern/settings/spamNbots.php
 msgid ""
 "If you see a captcha widget below, the active provider is configured "
 "correctly"
 msgstr ""
 
-#: oc-admin/themes/modern/users/frm.php:335
+#: oc-admin/themes/modern/users/frm.php
 msgid ""
 "If you'd like to change the password, type a new one. Otherwise leave this "
 "blank"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/media.php:261
-#: oc-admin/themes/modern/settings/media.php:403
-#: oc-includes/osclass/classes/datatables/ItemsDataTable.php:86
+#: oc-admin/themes/modern/settings/media.php
+#: oc-includes/osclass/classes/datatables/ItemsDataTable.php
 msgid "Image"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/media.php:161
+#: oc-admin/themes/modern/settings/media.php
 msgid "Image may occupy more space than usual."
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:395
-#: oc-admin/themes/modern/tools/system-info.php:402
-#: oc-admin/themes/modern/tools/system-info.php:410
-#: oc-admin/themes/modern/tools/system-info.php:417
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "Image processing"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/media.php:132
+#: oc-admin/themes/modern/settings/media.php
 msgid "Image sizes"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/media.php:214
+#: oc-admin/themes/modern/settings/media.php
 msgid "ImageMagick"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/media.php:226
+#: oc-admin/themes/modern/settings/media.php
 msgid "ImageMagick library is not loaded"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:397
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "Imagick"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:396
+#: oc-admin/themes/modern/tools/system-info.php
 msgid ""
 "Imagick is installed and selected — the preferred library. It reads more "
 "formats and produces higher-quality resizes than GD."
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:403
+#: oc-admin/themes/modern/tools/system-info.php
 msgid ""
 "Imagick is installed but not selected, so GD is doing the work. Imagick "
 "handles more formats and resizes at higher quality — switch to it under %s."
 msgstr ""
 
-#: oc-admin/themes/modern/languages/index.php:125
-#: oc-admin/themes/modern/settings/keywordBlock.php:200
-#: oc-admin/themes/modern/settings/locations.php:153
-#: oc-admin/themes/modern/tools/import.php:27
-#: oc-admin/themes/modern/tools/import.php:36
+#: oc-admin/themes/modern/languages/index.php
+#: oc-admin/themes/modern/settings/keywordBlock.php
+#: oc-admin/themes/modern/settings/locations.php
+#: oc-admin/themes/modern/tools/import.php
 msgid "Import"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/storage.php:340
+#: oc-admin/themes/modern/settings/storage.php
 msgid "Import Better S3 settings?"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/locations.php:155
+#: oc-admin/themes/modern/settings/locations.php
 msgid "Import a country with its regions and cities. Countries you "
 msgstr ""
 
-#: oc-admin/themes/modern/languages/index.php:113
-#: oc-admin/themes/modern/languages/index.php:116
+#: oc-admin/themes/modern/languages/index.php
 msgid "Import a language"
 msgstr ""
 
-#: oc-admin/themes/modern/languages/index.php:114
+#: oc-admin/themes/modern/languages/index.php
 msgid "Import a language from our database. "
 msgstr ""
 
-#: oc-admin/themes/modern/languages/index.php:92
+#: oc-admin/themes/modern/languages/index.php
 msgid "Import a language from the catalog or upload a package to add one."
 msgstr ""
 
-#: oc-admin/themes/modern/tools/import.php:50
-#: oc-includes/osclass/classes/AdminMenu.php:440
+#: oc-admin/themes/modern/tools/import.php
+#: oc-includes/osclass/classes/AdminMenu.php
 msgid "Import data"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/keywordBlock.php:175
+#: oc-admin/themes/modern/settings/keywordBlock.php
 msgid "Import keyword list"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/locations.php:154
+#: oc-admin/themes/modern/settings/locations.php
 msgid "Import locations"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/locations.php:27
+#: oc-admin/themes/modern/settings/locations.php
 msgid "Import new"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/storage.php:343
+#: oc-admin/themes/modern/settings/storage.php
 msgid "Import settings"
 msgstr ""
 
-#: oc-includes/osclass/classes/forms/FormService.php:170
+#: oc-includes/osclass/classes/forms/FormService.php
 msgid "Imported fields"
 msgstr ""
 
-#: oc-includes/osclass/classes/forms/FormService.php:169
+#: oc-includes/osclass/classes/forms/FormService.php
 msgid "Imported fields %d"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/storage.php:307
+#: oc-admin/themes/modern/settings/storage.php
 msgid ""
 "Imports your Better S3 connection settings and marks images already "
 "uploaded to that "
 msgstr ""
 
-#: oc-admin/themes/modern/fields/index.php:273
+#: oc-admin/themes/modern/fields/index.php
 msgid "In %d forms"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:267
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "In config.php"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:233
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "In php.ini"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/cache.php:166
+#: oc-admin/themes/modern/tools/cache.php
 msgid "In use"
 msgstr ""
 
-#: oc-admin/themes/modern/parts/market.php:238
+#: oc-admin/themes/modern/parts/market.php
 msgid "In-app installs are disabled on this deployment."
 msgstr ""
 
-#: oc-admin/themes/modern/tools/upgrade.php:22
+#: oc-admin/themes/modern/tools/upgrade.php
 msgid "In-app updates are disabled"
 msgstr ""
 
-#: oc-admin/themes/modern/parts/market.php:291
+#: oc-admin/themes/modern/parts/market.php
 msgid ""
 "In-app updates are disabled on this deployment. Install and update by "
 "deploying a new image or file set; this screen is read-only."
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php:1015
-#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php:982
+#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php
 msgid ""
 "In-app updates are disabled on this installation. Update by deploying a "
 "newer container image; the database is migrated automatically on start."
 msgstr ""
 
-#: oc-admin/themes/modern/tools/cache.php:19
+#: oc-admin/themes/modern/tools/cache.php
 msgid "In-request only (default)"
 msgstr ""
 
-#: oc-admin/themes/modern/comments/frm.php:83
-#: oc-includes/osclass/classes/datatables/CommentsDataTable.php:235
-#: oc-includes/osclass/classes/datatables/ItemsDataTable.php:457
-#: oc-includes/osclass/classes/datatables/UsersDataTable.php:315
+#: oc-admin/themes/modern/comments/frm.php
+#: oc-includes/osclass/classes/datatables/CommentsDataTable.php
+#: oc-includes/osclass/classes/datatables/ItemsDataTable.php
+#: oc-includes/osclass/classes/datatables/UsersDataTable.php
 msgid "Inactive"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/sitemap.php:27
+#: oc-admin/themes/modern/settings/sitemap.php
 msgid "Include categories"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/sitemap.php:33
+#: oc-admin/themes/modern/settings/sitemap.php
 msgid "Include categories with cities"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/sitemap.php:32
+#: oc-admin/themes/modern/settings/sitemap.php
 msgid "Include categories with regions"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/sitemap.php:29
+#: oc-admin/themes/modern/settings/sitemap.php
 msgid "Include cities"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/sitemap.php:31
+#: oc-admin/themes/modern/settings/sitemap.php
 msgid "Include countries"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/sitemap.php:28
+#: oc-admin/themes/modern/settings/sitemap.php
 msgid "Include pages"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/sitemap.php:30
+#: oc-admin/themes/modern/settings/sitemap.php
 msgid "Include regions"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:299
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "Info"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:373
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "Input validation across the core."
 msgstr ""
 
-#: oc-admin/themes/modern/parts/market.php:417
-#: oc-includes/osclass/classes/controller/admin/CAdminPlugins.php:393
+#: oc-admin/themes/modern/parts/market.php
+#: oc-includes/osclass/classes/controller/admin/CAdminPlugins.php
 msgid "Install"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:261
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "Install a missing extension"
 msgstr ""
 
-#: oc-includes/osclass/classes/market/Installer.php:219
-#: oc-includes/osclass/classes/market/Installer.php:353
+#: oc-includes/osclass/classes/market/Installer.php
 msgid "Install failed: %s"
 msgstr ""
 
-#: oc-admin/themes/modern/plugins/index.php:19
+#: oc-admin/themes/modern/plugins/index.php
 msgid ""
 "Install or uninstall the plugins available in your installation. In some "
 "cases, "
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:262
+#: oc-admin/themes/modern/tools/system-info.php
 msgid ""
 "Install the OS package (for example %1$s or %2$s), make sure an %3$s line "
 "is present, and restart PHP. The Overview tab will flip to “installed”."
 msgstr ""
 
-#: oc-includes/osclass/installer/gui/install.php:84
+#: oc-includes/osclass/installer/gui/install.php
 msgid "Installation progress"
 msgstr ""
 
-#: oc-admin/themes/modern/parts/market.php:605
-#: oc-admin/themes/modern/plugins/index.php:71
+#: oc-admin/themes/modern/parts/market.php
+#: oc-admin/themes/modern/plugins/index.php
 msgid "Installed"
 msgstr ""
 
-#: oc-admin/themes/modern/parts/market.php:603
+#: oc-admin/themes/modern/parts/market.php
 msgid "Installing…"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:370
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "Installs and updates plugins and themes, and builds backups."
 msgstr ""
 
-#: oc-admin/themes/modern/emails/frm.php:136
-#: oc-admin/themes/modern/pages/frm.php:348
-#: oc-includes/osclass/classes/datatables/PagesDataTable.php:57
+#: oc-admin/themes/modern/emails/frm.php
+#: oc-admin/themes/modern/pages/frm.php
+#: oc-includes/osclass/classes/datatables/PagesDataTable.php
 msgid "Internal name"
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:87
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Internet"
 msgstr ""
 
-#: oc-includes/osclass/classes/upgrade/Upgrade.php:132
+#: oc-includes/osclass/classes/upgrade/Upgrade.php
 msgid "Invalid Zip package, it's not in valid format."
 msgstr ""
 
-#: oc-admin/themes/modern/settings/index.php:45
-#: oc-includes/osclass/classes/actions/ItemActions.php:1763
-#: oc-includes/osclass/classes/form/AdminForm.php:131
-#: oc-includes/osclass/classes/form/CommentForm.php:128
-#: oc-includes/osclass/classes/form/ContactForm.php:148
-#: oc-includes/osclass/classes/form/ItemForm.php:1187
-#: oc-includes/osclass/classes/form/ItemForm.php:966
-#: oc-includes/osclass/classes/form/SendFriendForm.php:119
-#: oc-includes/osclass/classes/form/UserForm.php:420
-#: oc-includes/osclass/classes/form/UserForm.php:473
+#: oc-admin/themes/modern/settings/index.php
+#: oc-includes/osclass/classes/actions/ItemActions.php
+#: oc-includes/osclass/classes/form/AdminForm.php
+#: oc-includes/osclass/classes/form/CommentForm.php
+#: oc-includes/osclass/classes/form/ContactForm.php
+#: oc-includes/osclass/classes/form/ItemForm.php
+#: oc-includes/osclass/classes/form/SendFriendForm.php
+#: oc-includes/osclass/classes/form/UserForm.php
 msgid "Invalid email address"
 msgstr ""
 
-#: oc-includes/osclass/classes/form/SendFriendForm.php:125
+#: oc-includes/osclass/classes/form/SendFriendForm.php
 msgid "Invalid friend's email address"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php:1341
-#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php:1439
-#: oc-includes/osclass/classes/market/Installer.php:136
-#: oc-includes/osclass/classes/market/Installer.php:90
+#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php
+#: oc-includes/osclass/classes/market/Installer.php
 msgid "Invalid package slug."
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php:1274
-#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php:1334
-#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php:1434
+#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php
 msgid "Invalid package type."
 msgstr ""
 
-#: oc-includes/osclass/classes/upgrade/Plugin.php:72
+#: oc-includes/osclass/classes/upgrade/Plugin.php
 msgid "Invalid plugin name."
 msgstr ""
 
-#: oc-includes/osclass/classes/upgrade/Plugin.php:87
+#: oc-includes/osclass/classes/upgrade/Plugin.php
 msgid "Invalid plugin update uri"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php:576
+#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php
 msgid "Invalid request"
 msgstr ""
 
-#: oc-includes/osclass/classes/upgrade/UpgradePackage.php:145
+#: oc-includes/osclass/classes/upgrade/UpgradePackage.php
 msgid "Invalid s_target_directory."
 msgstr ""
 
-#: oc-includes/osclass/classes/upgrade/Theme.php:66
-#: oc-includes/osclass/classes/upgrade/Theme.php:71
+#: oc-includes/osclass/classes/upgrade/Theme.php
 msgid "Invalid theme name."
 msgstr ""
 
-#: oc-includes/osclass/classes/upgrade/Theme.php:85
+#: oc-includes/osclass/classes/upgrade/Theme.php
 msgid "Invalid theme update uri"
 msgstr ""
 
-#: oc-includes/osclass/classes/upgrade/UpgradePackage.php:169
+#: oc-includes/osclass/classes/upgrade/UpgradePackage.php
 msgid "Invalid upgrade package info"
 msgstr ""
 
-#: oc-admin/themes/modern/items/frm.php:244
+#: oc-admin/themes/modern/items/frm.php
 msgid "Ip Address"
 msgstr ""
 
-#: oc-includes/osclass/classes/utility/Utils.php:52
+#: oc-includes/osclass/classes/utility/Utils.php
 msgid "Is allow_url_fopen enabled?"
 msgstr ""
 
-#: oc-admin/themes/modern/parts/market.php:614
+#: oc-admin/themes/modern/parts/market.php
 msgid "Issue tracker"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:435
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid "It always appear before the category, region or city url."
 msgstr ""
 
-#: oc-admin/themes/modern/items/frm.php:305
+#: oc-admin/themes/modern/items/frm.php
 msgid "It could be an integer (days from original publishing date "
 msgstr ""
 
-#: oc-admin/themes/modern/items/frm.php:294
+#: oc-admin/themes/modern/items/frm.php
 msgid "It could be an integer (days from original publishing date it will "
 msgstr ""
 
-#: oc-admin/themes/modern/settings/media.php:414
+#: oc-admin/themes/modern/settings/media.php
 msgid "It has to be a .PNG image"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/index.php:351
+#: oc-admin/themes/modern/settings/index.php
 msgid ""
 "It is <b>recommended</b> to have this option enabled, because some features "
 "require it."
 msgstr ""
 
-#: oc-admin/themes/modern/settings/searches.php:89
+#: oc-admin/themes/modern/settings/searches.php
 msgid "It may be useful to know what queries users make."
 msgstr ""
 
-#: oc-admin/themes/modern/settings/media.php:230
+#: oc-admin/themes/modern/settings/media.php
 msgid "It's faster and consumes less resources than GD library."
 msgstr ""
 
-#: oc-admin/themes/modern/items/index.php:119
-#: oc-admin/themes/modern/items/index.php:124
+#: oc-admin/themes/modern/items/index.php
 msgid "Item ID"
 msgstr ""
 
-#: oc-includes/osclass/classes/EmailVariables.php:58
+#: oc-includes/osclass/classes/EmailVariables.php
 msgid "Item expiration date"
 msgstr ""
 
-#: oc-admin/themes/modern/stats/items.php:89
-#: oc-includes/osclass/classes/datatables/UsersDataTable.php:79
+#: oc-admin/themes/modern/stats/items.php
+#: oc-includes/osclass/classes/datatables/UsersDataTable.php
 msgid "Items"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/media.php:179
+#: oc-admin/themes/modern/settings/media.php
 msgid "JPEG quality"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:371
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "JSON"
 msgstr ""
 
-#: oc-includes/osclass/helpers/hUtils.php:324
+#: oc-includes/osclass/helpers/hUtils.php
 msgid "Jan"
 msgstr ""
 
-#: oc-includes/osclass/helpers/hUtils.php:309
+#: oc-includes/osclass/helpers/hUtils.php
 msgid "January"
 msgstr ""
 
-#: oc-includes/osclass/installer/gui/install-target.php:52
+#: oc-includes/osclass/installer/gui/install-target.php
 msgid "JavaScript is required to complete this step."
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:27
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Jewelry - Watches"
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:11
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Jobs"
 msgstr ""
 
-#: oc-includes/osclass/helpers/hUtils.php:330
+#: oc-includes/osclass/helpers/hUtils.php
 msgid "Jul"
 msgstr ""
 
-#: oc-includes/osclass/helpers/hUtils.php:315
+#: oc-includes/osclass/helpers/hUtils.php
 msgid "July"
 msgstr ""
 
-#: oc-includes/osclass/helpers/hUtils.php:329
+#: oc-includes/osclass/helpers/hUtils.php
 msgid "Jun"
 msgstr ""
 
-#: oc-includes/osclass/helpers/hUtils.php:314
+#: oc-includes/osclass/helpers/hUtils.php
 msgid "June"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/cleanup.php:132
+#: oc-admin/themes/modern/tools/cleanup.php
 msgid "Keep daily statistics history for"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/logs.php:56
+#: oc-admin/themes/modern/tools/logs.php
 msgid "Keep entries for"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/storage.php:214
+#: oc-admin/themes/modern/settings/storage.php
 msgid "Keep local copies"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/media.php:160
+#: oc-admin/themes/modern/settings/media.php
 msgid "Keep original image, unaltered after uploading."
 msgstr ""
 
-#: oc-admin/themes/modern/settings/spamNbots.php:267
+#: oc-admin/themes/modern/settings/spamNbots.php
 msgid "Keep records for"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/spamNbots.php:27
+#: oc-admin/themes/modern/settings/spamNbots.php
 msgid ""
 "Keep spammers from publishing on your site by configuring reCAPTCHA and "
 "Akismet. "
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:182
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "Keeps compiled PHP in memory instead of recompiling every request."
 msgstr ""
 
-#: oc-admin/themes/modern/tools/cache.php:154
-#: oc-admin/themes/modern/tools/cache.php:181
+#: oc-admin/themes/modern/tools/cache.php
 msgid "Keeps data between requests"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/cleanup.php:94
+#: oc-admin/themes/modern/tools/cleanup.php
 msgid ""
 "Keeps each run bounded so it never times out; run again to clear a larger "
 "backlog."
 msgstr ""
 
-#: oc-admin/themes/modern/tools/cache.php:26
+#: oc-admin/themes/modern/tools/cache.php
 msgid ""
 "Keeps values in shared memory between requests. Fast, and local to this "
 "server."
 msgstr ""
 
-#: oc-admin/themes/modern/tools/cache.php:31
+#: oc-admin/themes/modern/tools/cache.php
 msgid ""
 "Keeps values on a memcached server, which can be shared by several web "
 "servers."
 msgstr ""
 
-#: oc-admin/themes/modern/tools/cache.php:194
+#: oc-admin/themes/modern/tools/cache.php
 msgid ""
 "Keys are namespaced to this install, so several sites can share one "
 "memcached server safely. Clearing, however, flushes the whole server — "
 "including any other site using it."
 msgstr ""
 
-#: oc-admin/themes/modern/settings/keywordBlock_frm.php:69
-#: oc-includes/osclass/classes/datatables/KeywordBlocksDataTable.php:47
+#: oc-admin/themes/modern/settings/keywordBlock_frm.php
+#: oc-includes/osclass/classes/datatables/KeywordBlocksDataTable.php
 msgid "Keyword"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/keywordBlock.php:105
-#: oc-admin/themes/modern/settings/keywordBlock.php:15
-#: oc-includes/osclass/classes/AdminMenu.php:368
+#: oc-admin/themes/modern/settings/keywordBlock.php
+#: oc-includes/osclass/classes/AdminMenu.php
 msgid "Keyword blocklist"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/keywordBlock.php:114
+#: oc-admin/themes/modern/settings/keywordBlock.php
 msgid "Keyword filter"
 msgstr ""
 
-#: oc-admin/themes/modern/items/index.php:121
-#: oc-admin/themes/modern/settings/keywordBlock.php:182
+#: oc-admin/themes/modern/items/index.php
+#: oc-admin/themes/modern/settings/keywordBlock.php
 msgid "Keywords"
 msgstr ""
 
-#: oc-admin/themes/modern/appearance/page-block-form.php:63
+#: oc-admin/themes/modern/appearance/page-block-form.php
 msgid "Label (for your reference)"
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:52
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Land"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:511
-#: oc-includes/osclass/emails.php:1131
-#: oc-includes/osclass/emails.php:1133
-#: oc-includes/osclass/emails.php:1238
-#: oc-includes/osclass/emails.php:1240
-#: oc-includes/osclass/emails.php:1359
-#: oc-includes/osclass/emails.php:1361
-#: oc-includes/osclass/installer/gui/install.php:123
+#: oc-admin/themes/modern/settings/permalinks.php
+#: oc-includes/osclass/emails.php
+#: oc-includes/osclass/installer/gui/install.php
 msgid "Language"
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:42
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Language Classes"
 msgstr ""
 
-#: oc-admin/themes/modern/languages/add.php:33
+#: oc-admin/themes/modern/languages/add.php
 msgid "Language package (.zip)"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/index.php:419
-#: oc-includes/osclass/functions.php:786
+#: oc-admin/themes/modern/settings/index.php
+#: oc-includes/osclass/functions.php
 msgid "Language updates"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:223
-#: oc-admin/themes/modern/settings/permalinks.php:224
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid "Language url: this field is required"
 msgstr ""
 
-#: oc-admin/themes/modern/languages/index.php:18
-#: oc-includes/osclass/classes/AdminMenu.php:339
+#: oc-admin/themes/modern/languages/index.php
+#: oc-includes/osclass/classes/AdminMenu.php
 msgid "Languages"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:176
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "Largest single file a visitor can upload."
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:468
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "Largest single upload"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:177
+#: oc-admin/themes/modern/tools/system-info.php
 msgid ""
 "Largest whole request. Must be at least upload_max_filesize, ideally a "
 "little more."
 msgstr ""
 
-#: oc-admin/themes/modern/stats/comments.php:29
-#: oc-admin/themes/modern/stats/comments.php:98
-#: oc-admin/themes/modern/stats/items.php:171
-#: oc-admin/themes/modern/stats/items.php:37
-#: oc-admin/themes/modern/stats/reports.php:101
-#: oc-admin/themes/modern/stats/reports.php:26
-#: oc-admin/themes/modern/stats/users.php:139
-#: oc-admin/themes/modern/stats/users.php:32
+#: oc-admin/themes/modern/stats/comments.php
+#: oc-admin/themes/modern/stats/items.php
+#: oc-admin/themes/modern/stats/reports.php
+#: oc-admin/themes/modern/stats/users.php
 msgid "Last 10 days"
 msgstr ""
 
-#: oc-admin/themes/modern/stats/comments.php:26
-#: oc-admin/themes/modern/stats/comments.php:96
-#: oc-admin/themes/modern/stats/items.php:169
-#: oc-admin/themes/modern/stats/items.php:34
-#: oc-admin/themes/modern/stats/reports.php:23
-#: oc-admin/themes/modern/stats/reports.php:99
-#: oc-admin/themes/modern/stats/users.php:137
-#: oc-admin/themes/modern/stats/users.php:29
+#: oc-admin/themes/modern/stats/comments.php
+#: oc-admin/themes/modern/stats/items.php
+#: oc-admin/themes/modern/stats/reports.php
+#: oc-admin/themes/modern/stats/users.php
 msgid "Last 10 months"
 msgstr ""
 
-#: oc-admin/themes/modern/stats/comments.php:23
-#: oc-admin/themes/modern/stats/comments.php:97
-#: oc-admin/themes/modern/stats/items.php:170
-#: oc-admin/themes/modern/stats/items.php:31
-#: oc-admin/themes/modern/stats/reports.php:100
-#: oc-admin/themes/modern/stats/reports.php:20
-#: oc-admin/themes/modern/stats/users.php:138
-#: oc-admin/themes/modern/stats/users.php:26
+#: oc-admin/themes/modern/stats/comments.php
+#: oc-admin/themes/modern/stats/items.php
+#: oc-admin/themes/modern/stats/reports.php
+#: oc-admin/themes/modern/stats/users.php
 msgid "Last 10 weeks"
 msgstr ""
 
-#: oc-admin/themes/modern/users/frm.php:208
+#: oc-admin/themes/modern/users/frm.php
 msgid "Last access"
 msgstr ""
 
-#: oc-admin/themes/modern/billing/credits.php:56
+#: oc-admin/themes/modern/billing/credits.php
 msgid "Last change"
 msgstr ""
 
-#: oc-admin/themes/modern/parts/market.php:341
+#: oc-admin/themes/modern/parts/market.php
 msgid "Last checked %s."
 msgstr ""
 
-#: oc-admin/themes/modern/settings/index.php:438
-#: oc-admin/themes/modern/settings/index.php:468
+#: oc-admin/themes/modern/settings/index.php
 msgid "Last checked on "
 msgstr ""
 
-#: oc-admin/themes/modern/settings/sitemap.php:118
-#: oc-admin/themes/modern/settings/sitemap.php:138
-#: oc-admin/themes/modern/settings/sitemap.php:151
+#: oc-admin/themes/modern/settings/sitemap.php
 msgid "Last modified"
 msgstr ""
 
-#: oc-includes/osclass/classes/Pagination.php:126
+#: oc-includes/osclass/classes/Pagination.php
 msgid "Last page"
 msgstr ""
 
-#: oc-admin/themes/modern/stats/comments.php:132
+#: oc-admin/themes/modern/stats/comments.php
 msgid "Latest comments on the web"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebSearch.php:691
+#: oc-includes/osclass/classes/controller/CWebSearch.php
 msgid "Latest listings added"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebSearch.php:693
+#: oc-includes/osclass/classes/controller/CWebSearch.php
 msgid "Latest listings added in"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/index.php:297
+#: oc-admin/themes/modern/settings/index.php
 msgid "Latest listings shown"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/index.php:52
+#: oc-admin/themes/modern/settings/index.php
 msgid "Latest listings shown: this field is required"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/index.php:53
+#: oc-admin/themes/modern/settings/index.php
 msgid "Latest listings shown: this field must only contain numeric characters"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/searches.php:82
-#: oc-includes/osclass/classes/AdminMenu.php:375
+#: oc-admin/themes/modern/settings/searches.php
+#: oc-includes/osclass/classes/AdminMenu.php
 msgid "Latest searches"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/searches.php:65
-#: oc-admin/themes/modern/settings/searches.php:74
+#: oc-admin/themes/modern/settings/searches.php
 msgid "Latest searches Settings"
 msgstr ""
 
-#: oc-admin/themes/modern/stats/users.php:203
+#: oc-admin/themes/modern/stats/users.php
 msgid "Latest users on the web"
 msgstr ""
 
-#: oc-includes/osclass/installer/gui/install-target.php:77
+#: oc-includes/osclass/installer/gui/install-target.php
 msgid "Leave blank and we'll generate a strong one for you."
 msgstr ""
 
-#: oc-admin/themes/modern/settings/storage.php:165
+#: oc-admin/themes/modern/settings/storage.php
 msgid "Leave blank to keep the currently saved secret key"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/storage.php:149
+#: oc-admin/themes/modern/settings/storage.php
 msgid ""
 "Leave the provider-specific placeholders (e.g. {region}, {account_id}) "
 "filled in "
 msgstr ""
 
-#: oc-includes/osclass/helpers/hForms.php:64
+#: oc-includes/osclass/helpers/hForms.php
 msgid "Leave this field empty"
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:88
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Legal"
 msgstr ""
 
-#: oc-admin/themes/modern/emails/frm.php:155
+#: oc-admin/themes/modern/emails/frm.php
 msgid "Legend"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:243
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "Let a listing carry more photos"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:249
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "Let long jobs finish"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/spamNbots.php:290
+#: oc-admin/themes/modern/settings/spamNbots.php
 msgid "Lets anyone currently refused try again straight away, "
 msgstr ""
 
-#: oc-includes/osclass/classes/AdminMenu.php:148
+#: oc-includes/osclass/classes/AdminMenu.php
 msgid "Library"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/spamNbots.php:228
+#: oc-admin/themes/modern/settings/spamNbots.php
 msgid "Limit sign-in attempts"
 msgstr ""
 
-#: oc-includes/osclass/classes/EmailVariables.php:42
+#: oc-includes/osclass/classes/EmailVariables.php
 msgid "Link for account validation."
 msgstr ""
 
-#: oc-includes/osclass/classes/EmailVariables.php:62
+#: oc-includes/osclass/classes/EmailVariables.php
 msgid "Link for edit listing"
 msgstr ""
 
-#: oc-includes/osclass/classes/EmailVariables.php:44
+#: oc-includes/osclass/classes/EmailVariables.php
 msgid "List of listings, used when send alerts"
 msgstr ""
 
-#: oc-admin/themes/modern/users/settings.php:75
+#: oc-admin/themes/modern/users/settings.php
 msgid "List of terms not allowed in usernames, separated by commas"
 msgstr ""
 
-#: oc-admin/themes/modern/comments/frm.php:32
-#: oc-admin/themes/modern/items/frm.php:34
-#: oc-admin/themes/modern/main/index.php:207
-#: oc-admin/themes/modern/main/index.php:220
-#: oc-admin/themes/modern/media/index.php:111
-#: oc-admin/themes/modern/media/index.php:240
+#: oc-admin/themes/modern/comments/frm.php
+#: oc-admin/themes/modern/items/frm.php
+#: oc-admin/themes/modern/main/index.php
+#: oc-admin/themes/modern/media/index.php
 msgid "Listing"
 msgstr ""
 
-#: oc-admin/themes/modern/items/settings.php:18
-#: oc-admin/themes/modern/items/settings.php:67
+#: oc-admin/themes/modern/items/settings.php
 msgid "Listing Settings"
 msgstr ""
 
-#: oc-admin/themes/modern/stats/items.php:174
-#: oc-admin/themes/modern/stats/items.php:51
+#: oc-admin/themes/modern/stats/items.php
 msgid "Listing Statistics"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:390
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid "Listing URL:"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:517
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid "Listing actions"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:547
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid "Listing activate"
 msgstr ""
 
-#: oc-includes/osclass/classes/EmailVariables.php:79
+#: oc-includes/osclass/classes/EmailVariables.php
 msgid "Listing city"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:533
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid "Listing contact"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:235
-#: oc-admin/themes/modern/settings/permalinks.php:236
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid "Listing contact url: this field is required"
 msgstr ""
 
-#: oc-includes/osclass/classes/EmailVariables.php:77
+#: oc-includes/osclass/classes/EmailVariables.php
 msgid "Listing country"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:561
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid "Listing delete"
 msgstr ""
 
-#: oc-includes/osclass/classes/EmailVariables.php:74
+#: oc-includes/osclass/classes/EmailVariables.php
 msgid "Listing description"
 msgstr ""
 
-#: oc-includes/osclass/classes/EmailVariables.php:75
+#: oc-includes/osclass/classes/EmailVariables.php
 msgid "Listing description in all languages"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:554
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid "Listing edit"
 msgstr ""
 
-#: oc-includes/osclass/classes/EmailVariables.php:61
+#: oc-includes/osclass/classes/EmailVariables.php
 msgid "Listing id"
 msgstr ""
 
-#: oc-includes/osclass/classes/EmailVariables.php:59
+#: oc-includes/osclass/classes/EmailVariables.php
 msgid "Listing list"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:519
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid "Listing mark"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:227
-#: oc-admin/themes/modern/settings/permalinks.php:228
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid "Listing mark url: this field is required"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:540
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid "Listing new"
 msgstr ""
 
-#: oc-includes/osclass/classes/EmailVariables.php:76
+#: oc-includes/osclass/classes/EmailVariables.php
 msgid "Listing price"
 msgstr ""
 
-#: oc-includes/osclass/classes/EmailVariables.php:78
+#: oc-includes/osclass/classes/EmailVariables.php
 msgid "Listing region"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:568
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid "Listing resource delete"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:526
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid "Listing send friend"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:231
-#: oc-admin/themes/modern/settings/permalinks.php:232
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid "Listing send friend url: this field is required"
 msgstr ""
 
-#: oc-admin/themes/modern/main/index.php:254
-#: oc-admin/themes/modern/tools/cleanup.php:101
+#: oc-admin/themes/modern/main/index.php
+#: oc-admin/themes/modern/tools/cleanup.php
 msgid "Listing statistics"
 msgstr ""
 
-#: oc-includes/osclass/classes/EmailVariables.php:60
+#: oc-includes/osclass/classes/EmailVariables.php
 msgid "Listing title"
 msgstr ""
 
-#: oc-includes/osclass/classes/EmailVariables.php:57
+#: oc-includes/osclass/classes/EmailVariables.php
 msgid "Listing url"
 msgstr ""
 
-#: oc-admin/themes/modern/categories/index.php:25
-#: oc-admin/themes/modern/comments/index.php:17
-#: oc-admin/themes/modern/items/index.php:17
-#: oc-admin/themes/modern/items/reported.php:17
-#: oc-admin/themes/modern/items/settings.php:17
-#: oc-admin/themes/modern/main/index.php:110
-#: oc-admin/themes/modern/main/index.php:154
-#: oc-admin/themes/modern/main/index.php:207
-#: oc-admin/themes/modern/main/index.php:220
-#: oc-admin/themes/modern/settings/currencies.php:17
-#: oc-admin/themes/modern/settings/locations.php:18
-#: oc-includes/osclass/classes/AdminMenu.php:239
-#: oc-includes/osclass/classes/AdminMenu.php:53
-#: oc-includes/osclass/classes/controller/admin/CAdminMedia.php:117
+#: oc-admin/themes/modern/categories/index.php
+#: oc-admin/themes/modern/comments/index.php
+#: oc-admin/themes/modern/items/index.php
+#: oc-admin/themes/modern/items/reported.php
+#: oc-admin/themes/modern/items/settings.php
+#: oc-admin/themes/modern/main/index.php
+#: oc-admin/themes/modern/settings/currencies.php
+#: oc-admin/themes/modern/settings/locations.php
+#: oc-includes/osclass/classes/AdminMenu.php
+#: oc-includes/osclass/classes/controller/admin/CAdminMedia.php
 msgid "Listings"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/keywordBlock.php:255
+#: oc-admin/themes/modern/settings/keywordBlock.php
 msgid ""
 "Listings already flagged by this keyword stay as they are; only future "
 "matching stops."
 msgstr ""
 
-#: oc-admin/themes/modern/main/index.php:183
+#: oc-admin/themes/modern/main/index.php
 msgid "Listings by category"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/keywordBlock.php:16
+#: oc-admin/themes/modern/settings/keywordBlock.php
 msgid ""
 "Listings containing a blocked keyword are quarantined (flagged spam and "
 "hidden) as soon as they "
 msgstr ""
 
-#: oc-admin/themes/modern/categories/index.php:95
+#: oc-admin/themes/modern/categories/index.php
 msgid "Listings in this category"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/cleanup.php:26
+#: oc-admin/themes/modern/tools/cleanup.php
 msgid "Listings marked as spam."
 msgstr ""
 
-#: oc-admin/themes/modern/tools/cleanup.php:25
+#: oc-admin/themes/modern/tools/cleanup.php
 msgid "Listings never activated from the confirmation email."
 msgstr ""
 
-#: oc-admin/themes/modern/tools/cleanup.php:24
+#: oc-admin/themes/modern/tools/cleanup.php
 msgid "Listings past their expiration date."
 msgstr ""
 
-#: oc-admin/themes/modern/settings/currencies.php:109
+#: oc-admin/themes/modern/settings/currencies.php
 msgid ""
 "Listings priced in this currency keep their stored amount but lose a way to "
 "display it consistently."
 msgstr ""
 
-#: oc-admin/themes/modern/items/index.php:185
+#: oc-admin/themes/modern/items/index.php
 msgid "Listings published by your users appear here, and you can post one yourself."
 msgstr ""
 
-#: oc-admin/themes/modern/items/reported.php:107
+#: oc-admin/themes/modern/items/reported.php
 msgid ""
 "Listings reported by visitors for spam, being misclassified, duplicate, "
 "expired, or offensive content show up here."
 msgstr ""
 
-#: oc-admin/themes/modern/settings/index.php:48
+#: oc-admin/themes/modern/settings/index.php
 msgid "Listings shown in RSS feed: this field is required"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/index.php:49
+#: oc-admin/themes/modern/settings/index.php
 msgid "Listings shown in RSS feed: this field must only contain numeric characters"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/cleanup.php:27
+#: oc-admin/themes/modern/tools/cleanup.php
 msgid "Listings that are disabled/blocked."
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:171
-#: oc-admin/themes/modern/settings/permalinks.php:172
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid "Listings url: this field is required"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/cleanup.php:23
+#: oc-admin/themes/modern/tools/cleanup.php
 msgid "Listings visitors have flagged as spam."
 msgstr ""
 
-#: oc-admin/themes/modern/stats/items.php:206
+#: oc-admin/themes/modern/stats/items.php
 msgid "Listings' views"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:388
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid "Listings, pages &amp; categories"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:187
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "Loaded PHP extensions"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/locations.php:157
+#: oc-admin/themes/modern/settings/locations.php
 msgid "Loading countries…"
 msgstr ""
 
-#: oc-admin/themes/modern/parts/market.php:560
+#: oc-admin/themes/modern/parts/market.php
 msgid "Loading details…"
 msgstr ""
 
-#: oc-admin/themes/modern/appearance/widgets.php:246
-#: oc-admin/themes/modern/fields/index.php:181
-#: oc-admin/themes/modern/parts/media-picker.php:32
+#: oc-admin/themes/modern/appearance/widgets.php
+#: oc-admin/themes/modern/fields/index.php
+#: oc-admin/themes/modern/parts/media-picker.php
 msgid "Loading…"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/storage.php:210
+#: oc-admin/themes/modern/settings/storage.php
 msgid "Local copies"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/storage.php:106
+#: oc-admin/themes/modern/settings/storage.php
 msgid "Local disk"
 msgstr ""
 
-#: oc-admin/themes/modern/items/frm.php:259
-#: oc-admin/themes/modern/users/frm.php:290
-#: oc-includes/osclass/classes/datatables/ItemsDataTable.php:90
-#: oc-includes/osclass/installer/gui/install-target.php:91
+#: oc-admin/themes/modern/items/frm.php
+#: oc-admin/themes/modern/users/frm.php
+#: oc-includes/osclass/classes/datatables/ItemsDataTable.php
+#: oc-includes/osclass/installer/gui/install-target.php
 msgid "Location"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/locations.php:77
-#: oc-admin/themes/modern/tools/locations.php:84
+#: oc-admin/themes/modern/tools/locations.php
 msgid "Location stats"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/locations.php:19
-#: oc-admin/themes/modern/settings/locations.php:33
-#: oc-includes/osclass/classes/AdminMenu.php:84
+#: oc-admin/themes/modern/settings/locations.php
+#: oc-includes/osclass/classes/AdminMenu.php
 msgid "Locations"
 msgstr ""
 
-#: oc-admin/gui/forgot_password.php:46
-#: oc-admin/gui/login.php:68
-#: oc-admin/gui/main.php:19
-#: oc-admin/gui/recover.php:39
-#: oc-includes/osclass/classes/controller/admin/CAdminLogin.php:258
+#: oc-admin/gui/forgot_password.php
+#: oc-admin/gui/login.php
+#: oc-admin/gui/main.php
+#: oc-admin/gui/recover.php
+#: oc-includes/osclass/classes/controller/admin/CAdminLogin.php
 msgid "Log in"
 msgstr ""
 
-#: oc-admin/themes/modern/items/settings.php:130
+#: oc-admin/themes/modern/items/settings.php
 msgid "Logged in users don't need to validate their listings"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/logs.php:37
+#: oc-admin/themes/modern/tools/logs.php
 msgid "Logging"
 msgstr ""
 
-#: oc-includes/osclass/classes/Breadcrumb.php:63
-#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php:124
-#: oc-includes/osclass/classes/datatables/UsersDataTable.php:216
-#: oc-includes/osclass/functions.php:188
+#: oc-includes/osclass/classes/Breadcrumb.php
+#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php
+#: oc-includes/osclass/classes/datatables/UsersDataTable.php
+#: oc-includes/osclass/functions.php
 msgid "Login"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:259
-#: oc-admin/themes/modern/settings/permalinks.php:260
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid "Login url: this field is required"
 msgstr ""
 
-#: oc-includes/osclass/functions.php:509
-#: oc-includes/osclass/helpers/hUtils.php:398
+#: oc-includes/osclass/functions.php
+#: oc-includes/osclass/helpers/hUtils.php
 msgid "Logout"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:267
-#: oc-admin/themes/modern/settings/permalinks.php:268
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid "Logout url: this field is required"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:522
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "Long tasks such as backups and imports must finish inside this."
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:71
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Lost And Found"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminLogin.php:149
+#: oc-includes/osclass/classes/controller/admin/CAdminLogin.php
 msgid "Lost your password"
 msgstr ""
 
-#: oc-admin/themes/modern/billing/package.php:71
+#: oc-admin/themes/modern/billing/package.php
 msgid "Lower numbers list first at checkout."
 msgstr ""
 
-#: oc-includes/osclass/helpers/hSearch.php:53
+#: oc-includes/osclass/helpers/hSearch.php
 msgid "Lower price first"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/mailserver.php:79
-#: oc-admin/themes/modern/settings/mailserver.php:89
+#: oc-admin/themes/modern/settings/mailserver.php
 msgid "Mail Settings"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/mailserver.php:115
+#: oc-admin/themes/modern/settings/mailserver.php
 msgid "Mail from"
 msgstr ""
 
-#: oc-includes/osclass/classes/AdminMenu.php:390
+#: oc-includes/osclass/classes/AdminMenu.php
 msgid "Mail server"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/maintenance.php:29
-#: oc-admin/themes/modern/tools/maintenance.php:37
-#: oc-includes/osclass/classes/AdminMenu.php:267
+#: oc-admin/themes/modern/tools/maintenance.php
+#: oc-includes/osclass/classes/AdminMenu.php
 msgid "Maintenance"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:607
-#: oc-includes/osclass/classes/AdminMenu.php:461
+#: oc-admin/themes/modern/tools/system-info.php
+#: oc-includes/osclass/classes/AdminMenu.php
 msgid "Maintenance mode"
 msgstr ""
 
-#: oc-includes/osclass/functions.php:910
+#: oc-includes/osclass/functions.php
 msgid "Maintenance mode is on — only signed-in admins can see the site right now."
 msgstr ""
 
-#: oc-admin/themes/modern/tools/maintenance.php:45
+#: oc-admin/themes/modern/tools/maintenance.php
 msgid "Maintenance mode is: <strong>%s</strong>"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/index.php:388
+#: oc-admin/themes/modern/settings/index.php
 msgid "Major - new features"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/sitemap.php:186
+#: oc-admin/themes/modern/settings/sitemap.php
 msgid "Make a backup before changing your robots.txt file."
 msgstr ""
 
-#: oc-includes/osclass/classes/form/ItemForm.php:1587
+#: oc-includes/osclass/classes/form/ItemForm.php
 msgid "Make primary image"
 msgstr ""
 
-#: oc-admin/themes/modern/languages/index.php:49
+#: oc-admin/themes/modern/languages/index.php
 msgid "Manage Languages"
 msgstr ""
 
-#: oc-admin/themes/modern/appearance/widgets.php:32
+#: oc-admin/themes/modern/appearance/widgets.php
 msgid "Manage Widgets"
 msgstr ""
 
-#: oc-admin/themes/modern/admins/index.php:34
+#: oc-admin/themes/modern/admins/index.php
 msgid "Manage admins"
 msgstr ""
 
-#: oc-admin/themes/modern/users/alerts.php:16
-#: oc-admin/themes/modern/users/alerts.php:29
+#: oc-admin/themes/modern/users/alerts.php
 msgid "Manage alerts"
 msgstr ""
 
-#: oc-admin/themes/modern/items/index.php:19
+#: oc-admin/themes/modern/items/index.php
 msgid ""
 "Manage all the listings on your site: edit, delete or block the latest "
 "listings published. You can also filter by several parameters: user, "
 "region, city, etc."
 msgstr ""
 
-#: oc-admin/themes/modern/users/ban.php:103
-#: oc-admin/themes/modern/users/ban.php:18
+#: oc-admin/themes/modern/users/ban.php
 msgid "Manage ban rules"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/index.php:48
-#: oc-admin/themes/modern/fields/index.php:706
-#: oc-includes/osclass/classes/AdminMenu.php:175
+#: oc-admin/themes/modern/fields/index.php
+#: oc-includes/osclass/classes/AdminMenu.php
 msgid "Manage forms"
 msgstr ""
 
-#: oc-admin/themes/modern/items/index.php:18
-#: oc-admin/themes/modern/items/index.php:83
-#: oc-includes/osclass/classes/AdminMenu.php:56
+#: oc-admin/themes/modern/items/index.php
+#: oc-includes/osclass/classes/AdminMenu.php
 msgid "Manage listings"
 msgstr ""
 
-#: oc-includes/osclass/functions.php:204
+#: oc-includes/osclass/functions.php
 msgid "Manage my alerts"
 msgstr ""
 
-#: oc-includes/osclass/functions.php:201
+#: oc-includes/osclass/functions.php
 msgid "Manage my listings"
 msgstr ""
 
-#: oc-admin/themes/modern/pages/index.php:65
+#: oc-admin/themes/modern/pages/index.php
 msgid "Manage pages"
 msgstr ""
 
-#: oc-admin/themes/modern/plugins/index.php:62
-#: oc-includes/osclass/classes/AdminMenu.php:313
+#: oc-admin/themes/modern/plugins/index.php
+#: oc-includes/osclass/classes/AdminMenu.php
 msgid "Manage plugins"
 msgstr ""
 
-#: oc-admin/themes/modern/comments/index.php:19
+#: oc-admin/themes/modern/comments/index.php
 msgid "Manage the comments that users publish on the listings on your site."
 msgstr ""
 
-#: oc-admin/themes/modern/settings/media.php:117
+#: oc-admin/themes/modern/settings/media.php
 msgid ""
 "Manage the options for the images users can upload along with their "
 "listings. You can limit their size, "
 msgstr ""
 
-#: oc-admin/themes/modern/users/settings.php:19
+#: oc-admin/themes/modern/users/settings.php
 msgid ""
 "Manage the options related to users on your site. Here, you can decide if "
 "users must register or if "
 msgstr ""
 
-#: oc-includes/osclass/classes/AdminMenu.php:292
+#: oc-includes/osclass/classes/AdminMenu.php
 msgid "Manage themes"
 msgstr ""
 
-#: oc-admin/themes/modern/users/index.php:18
-#: oc-admin/themes/modern/users/index.php:79
-#: oc-includes/osclass/classes/AdminMenu.php:111
+#: oc-admin/themes/modern/users/index.php
+#: oc-includes/osclass/classes/AdminMenu.php
 msgid "Manage users"
 msgstr ""
 
-#: oc-includes/osclass/classes/AdminMenu.php:299
+#: oc-includes/osclass/classes/AdminMenu.php
 msgid "Manage widgets"
 msgstr ""
 
-#: oc-includes/osclass/helpers/hUtils.php:396
+#: oc-includes/osclass/helpers/hUtils.php
 msgid "Manage your alerts"
 msgstr ""
 
-#: oc-includes/osclass/helpers/hUtils.php:395
+#: oc-includes/osclass/helpers/hUtils.php
 msgid "Manage your listings"
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:89
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Manual Labor"
 msgstr ""
 
-#: oc-admin/themes/modern/appearance/add.php:19
+#: oc-admin/themes/modern/appearance/add.php
 msgid "Manually add Shopclass themes in .zip format. If you prefer, "
 msgstr ""
 
-#: oc-admin/themes/modern/plugins/add.php:19
+#: oc-admin/themes/modern/plugins/add.php
 msgid "Manually upload Shopclass plugins in .zip format. If you prefer, "
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:90
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Manufacturing - Operations"
 msgstr ""
 
-#: oc-admin/themes/modern/items/settings.php:274
-#: oc-admin/themes/modern/settings/index.php:355
+#: oc-admin/themes/modern/items/settings.php
+#: oc-admin/themes/modern/settings/index.php
 msgid "Maps"
 msgstr ""
 
-#: oc-includes/osclass/helpers/hUtils.php:326
+#: oc-includes/osclass/helpers/hUtils.php
 msgid "Mar"
 msgstr ""
 
-#: oc-includes/osclass/helpers/hUtils.php:311
+#: oc-includes/osclass/helpers/hUtils.php
 msgid "March"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/submissions.php:169
+#: oc-admin/themes/modern/fields/submissions.php
 msgid "Mark %s"
 msgstr ""
 
-#: oc-admin/themes/modern/billing/order.php:164
+#: oc-admin/themes/modern/billing/order.php
 msgid "Mark as paid"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminItems.php:1014
-#: oc-includes/osclass/classes/controller/admin/CAdminItems.php:1016
-#: oc-includes/osclass/classes/controller/admin/CAdminItems.php:595
-#: oc-includes/osclass/classes/datatables/ItemsDataTable.php:273
+#: oc-includes/osclass/classes/controller/admin/CAdminItems.php
+#: oc-includes/osclass/classes/datatables/ItemsDataTable.php
 msgid "Mark as premium"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminItems.php:1030
-#: oc-includes/osclass/classes/controller/admin/CAdminItems.php:1032
-#: oc-includes/osclass/classes/controller/admin/CAdminItems.php:604
-#: oc-includes/osclass/classes/datatables/ItemsDataTable.php:284
+#: oc-includes/osclass/classes/controller/admin/CAdminItems.php
+#: oc-includes/osclass/classes/datatables/ItemsDataTable.php
 msgid "Mark as spam"
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:91
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Marketing"
 msgstr ""
 
-#: oc-admin/themes/modern/billing/order.php:154
+#: oc-admin/themes/modern/billing/order.php
 msgid "Marking this paid adds %s credits to the account straight away. "
 msgstr ""
 
-#: oc-admin/themes/modern/settings/keywordBlock_frm.php:91
+#: oc-admin/themes/modern/settings/keywordBlock_frm.php
 msgid "Match anywhere inside a word, not just whole words"
 msgstr ""
 
-#: oc-includes/osclass/classes/datatables/KeywordBlocksDataTable.php:49
+#: oc-includes/osclass/classes/datatables/KeywordBlocksDataTable.php
 msgid "Match type"
 msgstr ""
 
-#: oc-includes/osclass/classes/datatables/KeywordBlocksDataTable.php:48
+#: oc-includes/osclass/classes/datatables/KeywordBlocksDataTable.php
 msgid "Matches in"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/cleanup.php:52
+#: oc-admin/themes/modern/tools/cleanup.php
 msgid "Matching now"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:521
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "Max execution time"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/iframe.php:136
+#: oc-admin/themes/modern/fields/iframe.php
 msgid "Max length"
 msgstr ""
 
-#: oc-admin/themes/modern/main/index.php:280
+#: oc-admin/themes/modern/main/index.php
 msgid "Max upload size"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/iframe.php:134
+#: oc-admin/themes/modern/fields/iframe.php
 msgid "Maximum"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/cleanup.php:91
+#: oc-admin/themes/modern/tools/cleanup.php
 msgid "Maximum items removed per run"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/media.php:203
+#: oc-admin/themes/modern/settings/media.php
 msgid "Maximum size"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/media.php:209
+#: oc-admin/themes/modern/settings/media.php
 msgid "Maximum size PHP configuration allows: %d KB"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/media.php:49
+#: oc-admin/themes/modern/settings/media.php
 msgid "Maximum size: this field is required"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/media.php:50
+#: oc-admin/themes/modern/settings/media.php
 msgid "Maximum size: this field must only contain numeric characters"
 msgstr ""
 
-#: oc-includes/osclass/helpers/hUtils.php:313
-#: oc-includes/osclass/helpers/hUtils.php:328
+#: oc-includes/osclass/helpers/hUtils.php
 msgid "May"
 msgstr ""
 
-#: oc-admin/themes/modern/media/index.php:17
-#: oc-admin/themes/modern/media/index.php:18
-#: oc-admin/themes/modern/parts/media-picker.php:36
-#: oc-admin/themes/modern/settings/media.php:115
-#: oc-admin/themes/modern/tools/system-info.php:403
-#: oc-includes/osclass/classes/AdminMenu.php:145
+#: oc-admin/themes/modern/media/index.php
+#: oc-admin/themes/modern/parts/media-picker.php
+#: oc-admin/themes/modern/settings/media.php
+#: oc-admin/themes/modern/tools/system-info.php
+#: oc-includes/osclass/classes/AdminMenu.php
 msgid "Media"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/media.php:116
-#: oc-admin/themes/modern/settings/media.php:124
+#: oc-admin/themes/modern/settings/media.php
 msgid "Media Settings"
 msgstr ""
 
-#: oc-admin/themes/modern/media/index.php:245
-#: oc-admin/themes/modern/parts/media-picker.php:26
+#: oc-admin/themes/modern/media/index.php
+#: oc-admin/themes/modern/parts/media-picker.php
 msgid "Media library"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:405
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "Media settings"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/cache.php:130
+#: oc-admin/themes/modern/tools/cache.php
 msgid "Memory"
 msgstr ""
 
-#: oc-admin/themes/modern/main/index.php:281
-#: oc-admin/themes/modern/tools/system-info.php:503
+#: oc-admin/themes/modern/main/index.php
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "Memory limit"
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:74
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Men looking for Men"
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:73
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Men looking for Women"
 msgstr ""
 
-#: oc-admin/themes/modern/parts/header.php:59
+#: oc-admin/themes/modern/parts/header.php
 msgid "Menu"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebContact.php:81
+#: oc-includes/osclass/classes/controller/CWebContact.php
 msgid "Message: %s"
 msgstr ""
 
-#: oc-includes/osclass/classes/actions/ItemActions.php:1766
-#: oc-includes/osclass/classes/form/ContactForm.php:144
-#: oc-includes/osclass/classes/form/SendFriendForm.php:127
+#: oc-includes/osclass/classes/actions/ItemActions.php
+#: oc-includes/osclass/classes/form/ContactForm.php
+#: oc-includes/osclass/classes/form/SendFriendForm.php
 msgid "Message: this field is required"
 msgstr ""
 
-#: oc-includes/osclass/installer/gui/install.php:160
+#: oc-includes/osclass/installer/gui/install.php
 msgid "Met"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/storage.php:271
+#: oc-admin/themes/modern/settings/storage.php
 msgid "Migration"
 msgstr ""
 
-#: oc-includes/osclass/classes/upgrade/Osclass.php:159
+#: oc-includes/osclass/classes/upgrade/Osclass.php
 msgid "Migration failed: %s"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/iframe.php:133
+#: oc-admin/themes/modern/fields/iframe.php
 msgid "Minimum"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/index.php:390
+#: oc-admin/themes/modern/settings/index.php
 msgid "Minor - bug fixes"
 msgstr ""
 
-#: oc-includes/osclass/classes/datatables/ItemsDataTable.php:654
+#: oc-includes/osclass/classes/datatables/ItemsDataTable.php
 msgid "Misclassified"
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:77
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Missed Connections"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/cache.php:129
+#: oc-admin/themes/modern/tools/cache.php
 msgid "Misses"
 msgstr ""
 
-#: oc-includes/osclass/installer/gui/install.php:165
+#: oc-includes/osclass/installer/gui/install.php
 msgid "Missing"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/comments.php:29
+#: oc-admin/themes/modern/settings/comments.php
 msgid "Moderated comments: this field is required"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/comments.php:30
+#: oc-admin/themes/modern/settings/comments.php
 msgid "Moderated comments: this field must only contain numeric characters"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/keywordBlock.php:108
+#: oc-admin/themes/modern/settings/keywordBlock.php
 msgid "Moderation"
 msgstr ""
 
-#: oc-includes/osclass/classes/form/AdminForm.php:86
+#: oc-includes/osclass/classes/form/AdminForm.php
 msgid "Moderator"
 msgstr ""
 
-#: oc-admin/themes/modern/emails/index.php:19
+#: oc-admin/themes/modern/emails/index.php
 msgid "Modify the emails your site's users receive when they join your site,"
 msgstr ""
 
-#: oc-admin/themes/modern/items/settings.php:19
+#: oc-admin/themes/modern/items/settings.php
 msgid ""
 "Modify the general settings for your listings. Decide if users have to "
 "register in order to publish something, the number of pictures allowed for "
 "each listing, etc."
 msgstr ""
 
-#: oc-admin/themes/modern/settings/comments.php:72
+#: oc-admin/themes/modern/settings/comments.php
 msgid ""
 "Modify the options that allow your users to publish comments on your site's "
 "listings."
 msgstr ""
 
-#: oc-admin/themes/modern/settings/mailserver.php:80
+#: oc-admin/themes/modern/settings/mailserver.php
 msgid ""
 "Modify the settings of the mail server from which your site's emails are "
 "sent. <strong>Be careful</strong>"
 msgstr ""
 
-#: oc-admin/themes/modern/appearance/widgets.php:26
+#: oc-admin/themes/modern/appearance/widgets.php
 msgid "Modify your site's header or footer here."
 msgstr ""
 
-#: oc-includes/osclass/helpers/hUtils.php:347
+#: oc-includes/osclass/helpers/hUtils.php
 msgid "Mon"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/index.php:170
-#: oc-includes/osclass/helpers/hUtils.php:339
+#: oc-admin/themes/modern/settings/index.php
+#: oc-includes/osclass/helpers/hUtils.php
 msgid "Monday"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/sitemap.php:40
+#: oc-admin/themes/modern/settings/sitemap.php
 msgid "Monthly"
 msgstr ""
 
-#: oc-includes/osclass/classes/datatables/BanRulesDataTable.php:137
-#: oc-includes/osclass/classes/datatables/BanRulesDataTable.php:138
-#: oc-includes/osclass/classes/datatables/CommentsDataTable.php:166
-#: oc-includes/osclass/classes/datatables/CommentsDataTable.php:167
-#: oc-includes/osclass/classes/datatables/ItemsDataTable.php:308
-#: oc-includes/osclass/classes/datatables/ItemsDataTable.php:309
-#: oc-includes/osclass/classes/datatables/UsersDataTable.php:242
-#: oc-includes/osclass/classes/datatables/UsersDataTable.php:243
+#: oc-includes/osclass/classes/datatables/BanRulesDataTable.php
+#: oc-includes/osclass/classes/datatables/CommentsDataTable.php
+#: oc-includes/osclass/classes/datatables/ItemsDataTable.php
+#: oc-includes/osclass/classes/datatables/UsersDataTable.php
 msgid "More actions"
 msgstr ""
 
-#: oc-includes/osclass/installer/gui/install-database.php:71
+#: oc-includes/osclass/installer/gui/install-database.php
 msgid "More options"
 msgstr ""
 
-#: oc-admin/themes/modern/parts/market.php:365
+#: oc-admin/themes/modern/parts/market.php
 msgid "Most downloaded"
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:36
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Motorcycles"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/index.php:726
+#: oc-admin/themes/modern/fields/index.php
 msgid "Move into forms"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php:597
+#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php
 msgid "Moved %1$d fields into %2$d forms."
 msgstr ""
 
-#: oc-admin/themes/modern/appearance/widgets.php:247
+#: oc-admin/themes/modern/appearance/widgets.php
 msgid "Moved to position %1$d of %2$d in %3$s."
 msgstr ""
 
-#: oc-admin/themes/modern/fields/index.php:278
+#: oc-admin/themes/modern/fields/index.php
 msgid "Moved to position %1$d of %2$d."
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:62
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Moving - Storage"
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:43
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Music - Theatre - Dance Classes"
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:28
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Musical Instruments"
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:69
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Musicians - Artists - Bands"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/currency_form.php:130
+#: oc-admin/themes/modern/settings/currency_form.php
 msgid ""
 "Must be a three-character code according to the <a href=\"%s\" "
 "target=\"_blank\">ISO 4217</a>"
 msgstr ""
 
-#: oc-includes/osclass/classes/Breadcrumb.php:58
+#: oc-includes/osclass/classes/Breadcrumb.php
 msgid "My alerts"
 msgstr ""
 
-#: oc-includes/osclass/classes/Breadcrumb.php:57
+#: oc-includes/osclass/classes/Breadcrumb.php
 msgid "My listings"
 msgstr ""
 
-#: oc-includes/osclass/helpers/hUtils.php:397
+#: oc-includes/osclass/helpers/hUtils.php
 msgid "My profile"
 msgstr ""
 
-#: oc-includes/osclass/install-functions.php:127
+#: oc-includes/osclass/install-functions.php
 msgid "MySQLi extension for PHP"
 msgstr ""
 
-#: oc-includes/osclass/install-functions.php:129
+#: oc-includes/osclass/install-functions.php
 msgid "MySQLi extension is required. How to "
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php:457
+#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php
 msgid "NEW custom field"
 msgstr ""
 
-#: oc-admin/themes/modern/admins/index.php:45
-#: oc-admin/themes/modern/admins/index.php:59
-#: oc-admin/themes/modern/billing/package.php:46
-#: oc-admin/themes/modern/billing/packages.php:41
-#: oc-admin/themes/modern/emails/index.php:32
-#: oc-admin/themes/modern/emails/index.php:40
-#: oc-admin/themes/modern/items/frm.php:231
-#: oc-admin/themes/modern/languages/frm.php:49
-#: oc-admin/themes/modern/languages/index.php:59
-#: oc-admin/themes/modern/languages/index.php:74
-#: oc-admin/themes/modern/plugins/index.php:123
-#: oc-admin/themes/modern/plugins/index.php:95
-#: oc-admin/themes/modern/settings/currencies.php:76
-#: oc-admin/themes/modern/settings/currencies.php:89
-#: oc-admin/themes/modern/settings/currency_form.php:144
-#: oc-admin/themes/modern/settings/locations.php:158
-#: oc-admin/themes/modern/stats/users.php:211
-#: oc-admin/themes/modern/users/frm.php:217
-#: oc-admin/themes/modern/users/index.php:189
-#: oc-includes/osclass/classes/datatables/UsersDataTable.php:77
-#: oc-includes/osclass/classes/form/CategoryForm.php:209
-#: oc-includes/osclass/classes/form/FieldForm.php:861
+#: oc-admin/themes/modern/admins/index.php
+#: oc-admin/themes/modern/billing/package.php
+#: oc-admin/themes/modern/billing/packages.php
+#: oc-admin/themes/modern/emails/index.php
+#: oc-admin/themes/modern/items/frm.php
+#: oc-admin/themes/modern/languages/frm.php
+#: oc-admin/themes/modern/languages/index.php
+#: oc-admin/themes/modern/plugins/index.php
+#: oc-admin/themes/modern/settings/currencies.php
+#: oc-admin/themes/modern/settings/currency_form.php
+#: oc-admin/themes/modern/settings/locations.php
+#: oc-admin/themes/modern/stats/users.php
+#: oc-admin/themes/modern/users/frm.php
+#: oc-admin/themes/modern/users/index.php
+#: oc-includes/osclass/classes/datatables/UsersDataTable.php
+#: oc-includes/osclass/classes/form/CategoryForm.php
+#: oc-includes/osclass/classes/form/FieldForm.php
 msgid "Name"
 msgstr ""
 
-#: oc-admin/themes/modern/parts/market.php:366
+#: oc-admin/themes/modern/parts/market.php
 msgid "Name (A–Z)"
 msgstr ""
 
-#: oc-admin/themes/modern/parts/market.php:367
+#: oc-admin/themes/modern/parts/market.php
 msgid "Name (Z–A)"
 msgstr ""
 
-#: oc-admin/themes/modern/admins/frm.php:72
+#: oc-admin/themes/modern/admins/frm.php
 msgid "Name <em>(required)</em>"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/iframe.php:383
+#: oc-admin/themes/modern/fields/iframe.php
 msgid "Name for default locale is required."
 msgstr ""
 
-#: oc-admin/themes/modern/settings/mailserver.php:122
+#: oc-admin/themes/modern/settings/mailserver.php
 msgid "Name from"
 msgstr ""
 
-#: oc-includes/osclass/classes/EmailVariables.php:69
+#: oc-includes/osclass/classes/EmailVariables.php
 msgid "Name of the friend who wants send"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebContact.php:78
+#: oc-includes/osclass/classes/controller/CWebContact.php
 msgid "Name: %s"
 msgstr ""
 
-#: oc-includes/osclass/classes/form/AdminForm.php:121
-#: oc-includes/osclass/classes/form/ItemForm.php:1182
-#: oc-includes/osclass/classes/form/ItemForm.php:961
+#: oc-includes/osclass/classes/form/AdminForm.php
+#: oc-includes/osclass/classes/form/ItemForm.php
 msgid "Name: enter at least 3 characters"
 msgstr ""
 
-#: oc-includes/osclass/classes/form/ItemForm.php:1183
-#: oc-includes/osclass/classes/form/ItemForm.php:962
+#: oc-includes/osclass/classes/form/ItemForm.php
 msgid "Name: no more than 35 characters"
 msgstr ""
 
-#: oc-includes/osclass/classes/form/AdminForm.php:122
+#: oc-includes/osclass/classes/form/AdminForm.php
 msgid "Name: no more than 50 characters"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/currency_form.php:34
-#: oc-admin/themes/modern/settings/currency_form.php:35
-#: oc-includes/osclass/classes/form/AdminForm.php:120
-#: oc-includes/osclass/classes/form/LanguageForm.php:196
-#: oc-includes/osclass/classes/form/UserForm.php:417
-#: oc-includes/osclass/classes/form/UserForm.php:470
+#: oc-admin/themes/modern/settings/currency_form.php
+#: oc-includes/osclass/classes/form/AdminForm.php
+#: oc-includes/osclass/classes/form/LanguageForm.php
+#: oc-includes/osclass/classes/form/UserForm.php
 msgid "Name: this field is required"
 msgstr ""
 
-#: oc-includes/osclass/installer/gui/install.php:143
+#: oc-includes/osclass/installer/gui/install.php
 msgid "Need more help?"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/comments.php:102
-#: oc-admin/themes/modern/settings/keywordBlock.php:165
+#: oc-admin/themes/modern/settings/comments.php
+#: oc-admin/themes/modern/settings/keywordBlock.php
 msgid ""
 "Needs a CAPTCHA provider configured under Settings &raquo; "
 "reCAPTCHA/Turnstile; otherwise no challenge is shown."
 msgstr ""
 
-#: oc-admin/themes/modern/settings/billing.php:385
+#: oc-admin/themes/modern/settings/billing.php
 msgid "Needs setting up"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:418
+#: oc-admin/themes/modern/tools/system-info.php
 msgid ""
 "Neither Imagick nor GD is installed, so no uploaded photo can be resized "
 "and image uploads fail. Install the GD extension at minimum; Imagick is "
 "better still."
 msgstr ""
 
-#: oc-includes/osclass/classes/datatables/ItemsDataTable.php:380
-#: oc-includes/osclass/classes/datatables/ItemsDataTable.php:752
+#: oc-includes/osclass/classes/datatables/ItemsDataTable.php
 msgid "Never expires"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/submissions.php:35
+#: oc-admin/themes/modern/fields/submissions.php
 msgid "New"
 msgstr ""
 
-#: oc-admin/themes/modern/stats/items.php:221
+#: oc-admin/themes/modern/stats/items.php
 msgid "New alerts"
 msgstr ""
 
-#: oc-includes/osclass/functions.php:519
+#: oc-includes/osclass/functions.php
 msgid "New comments"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/index.php:792
+#: oc-admin/themes/modern/fields/index.php
 msgid "New field"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php:512
-#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php:514
+#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php
 msgid "New field group"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/index.php:739
+#: oc-admin/themes/modern/fields/index.php
 msgid "New form"
 msgstr ""
 
-#: oc-admin/themes/modern/stats/items.php:191
+#: oc-admin/themes/modern/stats/items.php
 msgid "New listing"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:239
-#: oc-admin/themes/modern/settings/permalinks.php:240
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid "New listing url: this field is required"
 msgstr ""
 
-#: oc-admin/themes/modern/main/index.php:78
+#: oc-admin/themes/modern/main/index.php
 msgid "New listings/users"
 msgstr ""
 
-#: oc-admin/gui/forgot_password.php:27
-#: oc-admin/gui/forgot_password.php:29
-#: oc-admin/themes/modern/admins/frm.php:103
-#: oc-admin/themes/modern/users/frm.php:329
+#: oc-admin/gui/forgot_password.php
+#: oc-admin/themes/modern/admins/frm.php
+#: oc-admin/themes/modern/users/frm.php
 msgid "New password"
 msgstr ""
 
-#: oc-admin/themes/modern/stats/items.php:236
+#: oc-admin/themes/modern/stats/items.php
 msgid "New subscribers"
 msgstr ""
 
-#: oc-admin/themes/modern/stats/users.php:159
-#: oc-admin/themes/modern/stats/users.php:78
+#: oc-admin/themes/modern/stats/users.php
 msgid "New users"
 msgstr ""
 
-#: oc-includes/osclass/helpers/hSearch.php:50
+#: oc-includes/osclass/helpers/hSearch.php
 msgid "Newly listed"
 msgstr ""
 
-#: oc-admin/themes/modern/parts/ui.php:468
-#: oc-admin/themes/modern/parts/ui.php:470
+#: oc-admin/themes/modern/parts/ui.php
 msgid "Next"
 msgstr ""
 
-#: oc-includes/osclass/classes/Pagination.php:122
+#: oc-includes/osclass/classes/Pagination.php
 msgid "Next page"
 msgstr ""
 
-#: oc-admin/themes/modern/parts/market.php:552
+#: oc-admin/themes/modern/parts/market.php
 msgid "Next screenshot"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/submissions.php:68
-#: oc-admin/themes/modern/tools/cache.php:182
-#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php:534
-#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php:535
-#: oc-includes/osclass/helpers/hItems.php:1612
+#: oc-admin/themes/modern/fields/submissions.php
+#: oc-admin/themes/modern/tools/cache.php
+#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php
+#: oc-includes/osclass/helpers/hItems.php
 msgid "No"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/upgrade.php:169
+#: oc-admin/themes/modern/tools/upgrade.php
 msgid "No Upgrade Available"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/logs.php:133
+#: oc-admin/themes/modern/tools/logs.php
 msgid "No activity has been logged yet."
 msgstr ""
 
-#: oc-admin/themes/modern/admins/index.php:73
+#: oc-admin/themes/modern/admins/index.php
 msgid "No admins yet"
 msgstr ""
 
-#: oc-admin/themes/modern/users/alerts.php:108
+#: oc-admin/themes/modern/users/alerts.php
 msgid "No alerts yet"
 msgstr ""
 
-#: oc-includes/osclass/classes/market/Installer.php:95
+#: oc-includes/osclass/classes/market/Installer.php
 msgid "No backup was found to roll back to."
 msgstr ""
 
-#: oc-admin/themes/modern/users/ban.php:134
+#: oc-admin/themes/modern/users/ban.php
 msgid "No ban rules yet"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/keywordBlock.php:237
+#: oc-admin/themes/modern/settings/keywordBlock.php
 msgid "No blocked keywords yet"
 msgstr ""
 
-#: oc-admin/themes/modern/categories/index.php:175
+#: oc-admin/themes/modern/categories/index.php
 msgid "No categories yet"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php:639
+#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php
 msgid "No category with id %d exists"
 msgstr ""
 
-#: oc-admin/themes/modern/functions.php:19
+#: oc-admin/themes/modern/functions.php
 msgid "No change expiration"
 msgstr ""
 
-#: oc-admin/themes/modern/comments/index.php:89
+#: oc-admin/themes/modern/comments/index.php
 msgid "No comments to moderate"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php:1396
+#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php
 msgid "No compatible version is available for this package."
 msgstr ""
 
-#: oc-admin/themes/modern/settings/locations.php:141
+#: oc-admin/themes/modern/settings/locations.php
 msgid "No countries available right now"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/locations.php:52
+#: oc-admin/themes/modern/settings/locations.php
 msgid "No countries installed yet. Use \"Add new\" above to add one."
 msgstr ""
 
-#: oc-admin/themes/modern/billing/order.php:115
+#: oc-admin/themes/modern/billing/order.php
 msgid "No credits moved yet"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:539
+#: oc-admin/themes/modern/tools/system-info.php
 msgid ""
 "No cron run has been recorded. Update checks, alert emails and cleanup "
 "depend on it. Schedule %s to run regularly."
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php:1445
+#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php
 msgid "No details are available for this package yet."
 msgstr ""
 
-#: oc-admin/themes/modern/emails/index.php:51
+#: oc-admin/themes/modern/emails/index.php
 msgid "No email templates"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/logs.php:123
+#: oc-admin/themes/modern/tools/logs.php
 msgid "No entries match your filter."
 msgstr ""
 
-#: oc-admin/themes/modern/fields/index.php:798
+#: oc-admin/themes/modern/fields/index.php
 msgid "No fields yet. Create one to get started."
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php:165
+#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php
 msgid "No file was received"
 msgstr ""
 
-#: oc-includes/AjaxUploader.php:61
+#: oc-includes/AjaxUploader.php
 msgid "No files were uploaded."
 msgstr ""
 
-#: oc-admin/themes/modern/fields/submissions.php:208
+#: oc-admin/themes/modern/fields/submissions.php
 msgid "No forms yet"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/index.php:746
+#: oc-admin/themes/modern/fields/index.php
 msgid "No forms yet. Create one, then drag fields into it from the palette."
 msgstr ""
 
-#: oc-includes/osclass/installer/gui/install-target.php:108
+#: oc-includes/osclass/installer/gui/install-target.php
 msgid ""
 "No internet connection. You can continue and add your location later from "
 "the admin panel."
 msgstr ""
 
-#: oc-admin/themes/modern/languages/index.php:91
+#: oc-admin/themes/modern/languages/index.php
 msgid "No languages yet"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:522
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "No limit — whatever runs long, runs."
 msgstr ""
 
-#: oc-admin/themes/modern/items/index.php:184
+#: oc-admin/themes/modern/items/index.php
 msgid "No listings found"
 msgstr ""
 
-#: oc-admin/themes/modern/items/index.php:175
+#: oc-admin/themes/modern/items/index.php
 msgid "No listings match these filters"
 msgstr ""
 
-#: oc-admin/themes/modern/parts/media-picker.php:34
+#: oc-admin/themes/modern/parts/media-picker.php
 msgid "No media here yet. Upload an image to get started."
 msgstr ""
 
-#: oc-admin/themes/modern/media/index.php:276
+#: oc-admin/themes/modern/media/index.php
 msgid "No media of this type"
 msgstr ""
 
-#: oc-admin/themes/modern/media/index.php:276
+#: oc-admin/themes/modern/media/index.php
 msgid "No media yet"
 msgstr ""
 
-#: oc-admin/themes/modern/billing/wallet.php:167
+#: oc-admin/themes/modern/billing/wallet.php
 msgid "No more than the %s credits currently held."
 msgstr ""
 
-#: oc-admin/themes/modern/languages/index.php:188
+#: oc-admin/themes/modern/languages/index.php
 msgid "No official languages available."
 msgstr ""
 
-#: oc-admin/themes/modern/billing/index.php:97
+#: oc-admin/themes/modern/billing/index.php
 msgid "No orders match this filter"
 msgstr ""
 
-#: oc-admin/themes/modern/billing/index.php:97
+#: oc-admin/themes/modern/billing/index.php
 msgid "No orders yet"
 msgstr ""
 
-#: oc-admin/themes/modern/appearance/index.php:190
+#: oc-admin/themes/modern/appearance/index.php
 msgid "No other themes are installed. Upload a theme to change your site's look."
 msgstr ""
 
-#: oc-admin/themes/modern/parts/market.php:425
-#: oc-admin/themes/modern/parts/market.php:610
+#: oc-admin/themes/modern/parts/market.php
 msgid "No packages match your search."
 msgstr ""
 
-#: oc-admin/themes/modern/billing/packages.php:32
+#: oc-admin/themes/modern/billing/packages.php
 msgid "No packages yet"
 msgstr ""
 
-#: oc-admin/themes/modern/pages/index.php:97
+#: oc-admin/themes/modern/pages/index.php
 msgid "No pages yet"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/billing.php:352
+#: oc-admin/themes/modern/settings/billing.php
 msgid "No payment methods installed"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:564
+#: oc-admin/themes/modern/tools/system-info.php
 msgid ""
 "No persistent cache configured, so per-request work is recomputed each "
 "time. Set %1$s in config.php to a driver such as %2$s or %3$s for a real "
 "speed-up on a busy site."
 msgstr ""
 
-#: oc-admin/themes/modern/parts/market.php:384
+#: oc-admin/themes/modern/parts/market.php
 msgid "No plugins are available right now."
 msgstr ""
 
-#: oc-admin/themes/modern/plugins/index.php:131
+#: oc-admin/themes/modern/plugins/index.php
 msgid "No plugins installed"
 msgstr ""
 
-#: oc-admin/themes/modern/items/reported.php:106
+#: oc-admin/themes/modern/items/reported.php
 msgid "No reported listings"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php:95
-#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php:96
+#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php
 msgid "No results"
 msgstr ""
 
-#: oc-admin/themes/modern/users/alerts.php:103
-#: oc-admin/themes/modern/users/index.php:143
+#: oc-admin/themes/modern/users/alerts.php
+#: oc-admin/themes/modern/users/index.php
 msgid "No results for this filter"
 msgstr ""
 
-#: oc-admin/themes/modern/functions.php:24
+#: oc-admin/themes/modern/functions.php
 msgid "No subcategory"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/advanced.php:62
+#: oc-admin/themes/modern/settings/advanced.php
 msgid "No subdomains"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/submissions.php:219
+#: oc-admin/themes/modern/fields/submissions.php
 msgid "No submissions in this view yet"
 msgstr ""
 
-#: oc-admin/themes/modern/parts/market.php:384
+#: oc-admin/themes/modern/parts/market.php
 msgid "No themes are available right now."
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php:907
+#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php
 msgid "No update available"
 msgstr ""
 
-#: oc-admin/themes/modern/users/index.php:148
+#: oc-admin/themes/modern/users/index.php
 msgid "No users yet"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php:1349
+#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php
 msgid "No version was specified."
 msgstr ""
 
-#: oc-admin/themes/modern/settings/media.php:198
+#: oc-admin/themes/modern/settings/media.php
 msgid "No white background will be added to keep the size."
 msgstr ""
 
-#: oc-admin/themes/modern/appearance/page-block-form.php:59
+#: oc-admin/themes/modern/appearance/page-block-form.php
 msgid ""
 "No widget types are available to you. Ask an administrator, or install a "
 "widget plugin."
 msgstr ""
 
-#: oc-admin/themes/modern/pages/frm.php:278
+#: oc-admin/themes/modern/pages/frm.php
 msgid "No widgets yet. Add your first widget to build this page."
 msgstr ""
 
-#: oc-admin/themes/modern/billing/credits.php:44
+#: oc-admin/themes/modern/billing/credits.php
 msgid "Nobody holds credits yet"
 msgstr ""
 
-#: oc-includes/osclass/classes/model/Category.php:956
+#: oc-includes/osclass/classes/model/Category.php
 msgid "Non-Existent Category"
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:92
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Non-profit - Volunteer"
 msgstr ""
 
-#: oc-admin/themes/modern/items/settings.php:281
-#: oc-admin/themes/modern/settings/media.php:242
-#: oc-admin/themes/modern/settings/spamNbots.php:109
-#: oc-includes/osclass/classes/datatables/ItemsDataTable.php:776
+#: oc-admin/themes/modern/items/settings.php
+#: oc-admin/themes/modern/settings/media.php
+#: oc-admin/themes/modern/settings/spamNbots.php
+#: oc-includes/osclass/classes/datatables/ItemsDataTable.php
 msgid "None"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/billing.php:380
+#: oc-admin/themes/modern/settings/billing.php
 msgid "None declared"
 msgstr ""
 
-#: oc-admin/themes/modern/billing/order.php:86
+#: oc-admin/themes/modern/billing/order.php
 msgid "None yet"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/media.php:149
+#: oc-admin/themes/modern/settings/media.php
 msgid "Normal size"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/media.php:46
+#: oc-admin/themes/modern/settings/media.php
 msgid "Normal size: is not in the correct format"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/media.php:45
+#: oc-admin/themes/modern/settings/media.php
 msgid "Normal size: this field is required"
 msgstr ""
 
-#: oc-admin/themes/modern/media/index.php:316
-#: oc-admin/themes/modern/media/index.php:347
+#: oc-admin/themes/modern/media/index.php
 msgid "Not attached"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/index.php:147
-#: oc-admin/themes/modern/fields/index.php:276
+#: oc-admin/themes/modern/fields/index.php
 msgid "Not attached to a category — it won't appear on listings yet"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/iframe.php:209
+#: oc-admin/themes/modern/fields/iframe.php
 msgid "Not cascading"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:427
+#: oc-admin/themes/modern/tools/system-info.php
 msgid ""
 "Not enabled. PHP recompiles every file on every request. It is the cheapest "
 "performance win available, and it is one ini line."
 msgstr ""
 
-#: oc-admin/themes/modern/settings/locations.php:159
-#: oc-admin/themes/modern/tools/cache.php:172
-#: oc-includes/osclass/classes/controller/admin/CAdminPlugins.php:424
+#: oc-admin/themes/modern/settings/locations.php
+#: oc-admin/themes/modern/tools/cache.php
+#: oc-includes/osclass/classes/controller/admin/CAdminPlugins.php
 msgid "Not installed"
 msgstr ""
 
-#: oc-includes/osclass/classes/utility/SystemInfo.php:273
-#: oc-includes/osclass/classes/utility/SystemInfo.php:283
-#: oc-includes/osclass/classes/utility/SystemInfo.php:293
-#: oc-includes/osclass/classes/utility/SystemInfo.php:303
-#: oc-includes/osclass/classes/utility/SystemInfo.php:313
+#: oc-includes/osclass/classes/utility/SystemInfo.php
 msgid "Not set"
 msgstr ""
 
-#: oc-includes/osclass/classes/market/Compatibility.php:160
+#: oc-includes/osclass/classes/market/Compatibility.php
 msgid "Not tested with %s yet"
 msgstr ""
 
-#: oc-includes/osclass/classes/market/Compatibility.php:85
+#: oc-includes/osclass/classes/market/Compatibility.php
 msgid "Not tested with Shopclass %s yet."
 msgstr ""
 
-#: oc-admin/themes/modern/parts/market.php:156
+#: oc-admin/themes/modern/parts/market.php
 msgid ""
 "Not tested with your Shopclass version yet. Installing and updating still "
 "work as normal."
 msgstr ""
 
-#: oc-admin/themes/modern/tools/cache.php:155
-#: oc-admin/themes/modern/tools/cache.php:184
+#: oc-admin/themes/modern/tools/cache.php
 msgid "Notes"
 msgstr ""
 
-#: oc-admin/themes/modern/media/index.php:280
+#: oc-admin/themes/modern/media/index.php
 msgid "Nothing has been uploaded under this filter yet."
 msgstr ""
 
-#: oc-admin/themes/modern/billing/wallet.php:57
+#: oc-admin/themes/modern/billing/wallet.php
 msgid "Nothing has moved yet"
 msgstr ""
 
-#: oc-admin/themes/modern/parts/ui.php:615
+#: oc-admin/themes/modern/parts/ui.php
 msgid "Nothing here yet"
 msgstr ""
 
-#: oc-admin/themes/modern/upgrade/index.php:44
+#: oc-admin/themes/modern/upgrade/index.php
 msgid "Nothing needed changing."
 msgstr ""
 
-#: oc-admin/themes/modern/items/settings.php:180
-#: oc-admin/themes/modern/settings/comments.php:132
+#: oc-admin/themes/modern/items/settings.php
+#: oc-admin/themes/modern/settings/comments.php
 msgid "Notifications"
 msgstr ""
 
-#: oc-admin/themes/modern/items/settings.php:184
+#: oc-admin/themes/modern/items/settings.php
 msgid "Notify admin when a new listing is added"
 msgstr ""
 
-#: oc-includes/osclass/helpers/hUtils.php:334
+#: oc-includes/osclass/helpers/hUtils.php
 msgid "Nov"
 msgstr ""
 
-#: oc-includes/osclass/helpers/hUtils.php:319
+#: oc-includes/osclass/helpers/hUtils.php
 msgid "November"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/sitemap.php:66
+#: oc-admin/themes/modern/settings/sitemap.php
 msgid ""
 "Number of URLs per XML item sitemap file. Extra listings roll into "
 "additional "
 msgstr ""
 
-#: oc-admin/themes/modern/languages/frm.php:79
+#: oc-admin/themes/modern/languages/frm.php
 msgid "Number of decimals"
 msgstr ""
 
-#: oc-includes/osclass/classes/form/LanguageForm.php:201
+#: oc-includes/osclass/classes/form/LanguageForm.php
 msgid "Number of decimals: this field is required"
 msgstr ""
 
-#: oc-includes/osclass/classes/form/LanguageForm.php:202
+#: oc-includes/osclass/classes/form/LanguageForm.php
 msgid "Number of decimals: this field must only contain numeric characters"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/keywordBlock.php:152
+#: oc-admin/themes/modern/settings/keywordBlock.php
 msgid ""
 "Number of distinct reporters (one vote per person) that auto-hides a "
 "listing."
 msgstr ""
 
-#: oc-admin/themes/modern/stats/items.php:224
+#: oc-admin/themes/modern/stats/items.php
 msgid "Number of new alerts"
 msgstr ""
 
-#: oc-admin/themes/modern/stats/items.php:194
+#: oc-admin/themes/modern/stats/items.php
 msgid "Number of new listings"
 msgstr ""
 
-#: oc-admin/themes/modern/stats/items.php:239
+#: oc-admin/themes/modern/stats/items.php
 msgid "Number of new subscribers"
 msgstr ""
 
-#: oc-admin/themes/modern/items/index.php:278
-#: oc-admin/themes/modern/items/index.php:293
-#: oc-admin/themes/modern/items/index.php:308
-#: oc-admin/themes/modern/items/index.php:323
-#: oc-admin/themes/modern/tools/maintenance.php:46
-#: oc-admin/themes/modern/users/index.php:216
-#: oc-admin/themes/modern/users/index.php:268
+#: oc-admin/themes/modern/items/index.php
+#: oc-admin/themes/modern/tools/maintenance.php
+#: oc-admin/themes/modern/users/index.php
 msgid "OFF"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:295
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "OK"
 msgstr ""
 
-#: oc-admin/themes/modern/items/index.php:276
-#: oc-admin/themes/modern/items/index.php:291
-#: oc-admin/themes/modern/items/index.php:306
-#: oc-admin/themes/modern/items/index.php:321
-#: oc-admin/themes/modern/tools/maintenance.php:46
-#: oc-admin/themes/modern/users/index.php:214
-#: oc-admin/themes/modern/users/index.php:266
+#: oc-admin/themes/modern/items/index.php
+#: oc-admin/themes/modern/tools/maintenance.php
+#: oc-admin/themes/modern/users/index.php
 msgid "ON"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:426
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "OPcache"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:563
-#: oc-admin/themes/modern/tools/system-info.php:570
-#: oc-admin/themes/modern/tools/system-info.php:577
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "Object cache"
 msgstr ""
 
-#: oc-includes/osclass/helpers/hUtils.php:333
+#: oc-includes/osclass/helpers/hUtils.php
 msgid "Oct"
 msgstr ""
 
-#: oc-includes/osclass/helpers/hUtils.php:318
+#: oc-includes/osclass/helpers/hUtils.php
 msgid "October"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:298
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "Off"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/cleanup.php:128
+#: oc-admin/themes/modern/tools/cleanup.php
 msgid ""
 "Off by default. Search-engine and AI crawlers are usually most of a busy "
 "site's traffic, so counting them both inflates the numbers and multiplies "
 "the writes."
 msgstr ""
 
-#: oc-admin/themes/modern/settings/keywordBlock.php:132
+#: oc-admin/themes/modern/settings/keywordBlock.php
 msgid ""
 "Off by default: a match is quarantined (flagged spam and hidden) so it can "
 "be reviewed and reversed. Turn this on to reject the post before it is ever "
 "saved."
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:588
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "Off, as it should be on a live site."
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:617
+#: oc-admin/themes/modern/tools/system-info.php
 msgid ""
 "Off. Some remote fetches fall back to cURL; update and market features rely "
 "on one of the two being available."
 msgstr ""
 
-#: oc-admin/themes/modern/stats/reports.php:68
-#: oc-includes/osclass/classes/datatables/ItemsDataTable.php:658
+#: oc-admin/themes/modern/stats/reports.php
+#: oc-includes/osclass/classes/datatables/ItemsDataTable.php
 msgid "Offensive"
 msgstr ""
 
-#: oc-admin/themes/modern/billing/package.php:78
+#: oc-admin/themes/modern/billing/package.php
 msgid "Offer this package at checkout"
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:53
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Office - Commercial Space"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/storage.php:281
+#: oc-admin/themes/modern/settings/storage.php
 msgid "Offload all local images to remote storage"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/cleanup.php:51
+#: oc-admin/themes/modern/tools/cleanup.php
 msgid "Older than"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/keywordBlock.php:124
+#: oc-admin/themes/modern/settings/keywordBlock.php
 msgid "On a match"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/upgrade.php:75
+#: oc-admin/themes/modern/tools/upgrade.php
 msgid ""
 "Once the upgrade is complete, you will be redirected to the Admin Control "
 "Panel."
 msgstr ""
 
-#: oc-admin/themes/modern/settings/searches.php:109
+#: oc-admin/themes/modern/settings/searches.php
 msgid "One day"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/searches.php:102
+#: oc-admin/themes/modern/settings/searches.php
 msgid "One hour"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/iframe.php:227
+#: oc-admin/themes/modern/fields/iframe.php
 msgid "One line per parent value: \"ParentValue: option1, option2\"."
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsLocations.php:157
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsLocations.php:323
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsLocations.php:491
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsLocations.php
 msgid "One location has been deleted"
 msgid_plural "%s locations have been deleted"
 msgstr[0] ""
 msgstr[1] ""
 
-#: oc-admin/themes/modern/settings/searches.php:116
+#: oc-admin/themes/modern/settings/searches.php
 msgid "One week"
 msgstr ""
 
-#: oc-admin/themes/modern/items/settings.php:149
+#: oc-admin/themes/modern/items/settings.php
 msgid "Only allow registered users to contact publisher"
 msgstr ""
 
-#: oc-admin/themes/modern/items/settings.php:174
+#: oc-admin/themes/modern/items/settings.php
 msgid "Only allow registered users to share listings"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/group_iframe.php:47
-#: oc-admin/themes/modern/fields/iframe.php:257
+#: oc-admin/themes/modern/fields/group_iframe.php
+#: oc-admin/themes/modern/fields/iframe.php
 msgid "Only alphanumeric characters are allowed [a-z0-9_-]"
 msgstr ""
 
-#: oc-includes/osclass/installer/gui/install-database.php:76
+#: oc-includes/osclass/installer/gui/install-database.php
 msgid ""
 "Only change this if you run more than one Shopclass install in the same "
 "database."
 msgstr ""
 
-#: oc-admin/themes/modern/items/settings.php:78
+#: oc-admin/themes/modern/items/settings.php
 msgid "Only logged in users can post listings"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/spamNbots.php:205
+#: oc-admin/themes/modern/settings/spamNbots.php
 msgid "Only logged-in users can subscribe to search alerts"
 msgstr ""
 
-#: oc-admin/themes/modern/billing/credits.php:78
+#: oc-admin/themes/modern/billing/credits.php
 msgid "Open"
 msgstr ""
 
-#: oc-includes/osclass/installer/gui/install-finish.php:92
+#: oc-includes/osclass/installer/gui/install-finish.php
 msgid "Open your admin panel"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:372
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "OpenSSL"
 msgstr ""
 
-#: oc-admin/themes/modern/items/settings.php:287
+#: oc-admin/themes/modern/items/settings.php
 msgid "OpenStreetMaps"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/index.php:367
+#: oc-admin/themes/modern/settings/index.php
 msgid "OpenStreetMaps key"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:635
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "Operating system"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/iframe.php:223
+#: oc-admin/themes/modern/fields/iframe.php
 msgid "Option map"
 msgstr ""
 
-#: oc-admin/themes/modern/items/settings.php:247
+#: oc-admin/themes/modern/items/settings.php
 msgid "Optional fields"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/sitemap.php:122
+#: oc-admin/themes/modern/settings/sitemap.php
 msgid "Optional. Leave blank to use today's date."
 msgstr ""
 
-#: oc-admin/themes/modern/settings/storage.php:186
+#: oc-admin/themes/modern/settings/storage.php
 msgid ""
 "Optional. Overrides the URL used to serve files, e.g. a CDN domain in front "
 "of the bucket."
 msgstr ""
 
-#: oc-admin/themes/modern/fields/iframe.php:94
+#: oc-admin/themes/modern/fields/iframe.php
 msgid "Options"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/iframe.php:388
+#: oc-admin/themes/modern/fields/iframe.php
 msgid "Options are required."
 msgstr ""
 
-#: oc-admin/themes/modern/settings/mailserver.php:154
+#: oc-admin/themes/modern/settings/mailserver.php
 msgid "Options: blank, ssl or tls"
 msgstr ""
 
-#: oc-admin/themes/modern/billing/index.php:113
-#: oc-admin/themes/modern/billing/order.php:107
-#: oc-includes/osclass/classes/datatables/PagesDataTable.php:59
+#: oc-admin/themes/modern/billing/index.php
+#: oc-admin/themes/modern/billing/order.php
+#: oc-includes/osclass/classes/datatables/PagesDataTable.php
 msgid "Order"
 msgstr ""
 
-#: oc-admin/themes/modern/billing/order.php:101
+#: oc-admin/themes/modern/billing/order.php
 msgid "Order #%d"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php:272
-#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php:504
+#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php
 msgid "Order saved"
 msgstr ""
 
-#: oc-admin/themes/modern/billing/index.php:47
-#: oc-includes/osclass/classes/AdminMenu.php:202
+#: oc-admin/themes/modern/billing/index.php
+#: oc-includes/osclass/classes/AdminMenu.php
 msgid "Orders"
 msgstr ""
 
-#: oc-admin/themes/modern/billing/index.php:100
+#: oc-admin/themes/modern/billing/index.php
 msgid "Orders appear here as soon as a payment plugin takes its first payment."
 msgstr ""
 
-#: oc-admin/themes/modern/settings/media.php:155
+#: oc-admin/themes/modern/settings/media.php
 msgid "Original size"
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:45
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Other Classes"
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:98
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Other Jobs"
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:65
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Other Services"
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:40
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Other Vehicles"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/comments.php:121
+#: oc-admin/themes/modern/settings/comments.php
 msgid "Other comment settings"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:158
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "Overview"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:457
+#: oc-admin/themes/modern/tools/system-info.php
 msgid ""
 "PHP rejects the whole request before it looks at the file, so the %1$s you "
 "advertise is unreachable — an upload over %2$s fails with an empty form. "
 "Raise %3$s above %4$s."
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:161
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "PHP settings &amp; help"
 msgstr ""
 
-#: oc-admin/themes/modern/main/index.php:278
-#: oc-admin/themes/modern/tools/system-info.php:358
-#: oc-admin/themes/modern/tools/system-info.php:360
-#: oc-admin/themes/modern/tools/system-info.php:362
-#: oc-admin/themes/modern/tools/system-info.php:632
+#: oc-admin/themes/modern/main/index.php
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "PHP version"
 msgstr ""
 
-#: oc-includes/osclass/install-functions.php:120
+#: oc-includes/osclass/install-functions.php
 msgid "PHP version >= 8.0.0"
 msgstr ""
 
-#: oc-includes/osclass/helpers/hUtils.php:348
+#: oc-includes/osclass/helpers/hUtils.php
 msgid "PM"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/mailserver.php:175
+#: oc-admin/themes/modern/settings/mailserver.php
 msgid "POP"
 msgstr ""
 
-#: oc-includes/osclass/classes/market/Installer.php:341
+#: oc-includes/osclass/classes/market/Installer.php
 msgid "Package installed."
 msgstr ""
 
-#: oc-includes/osclass/classes/market/Installer.php:122
+#: oc-includes/osclass/classes/market/Installer.php
 msgid "Package installs are disabled in demo mode."
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php:1362
-#: oc-includes/osclass/classes/market/Installer.php:128
+#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php
+#: oc-includes/osclass/classes/market/Installer.php
 msgid "Package installs are disabled on this deployment."
 msgstr ""
 
-#: oc-includes/osclass/classes/market/Installer.php:107
+#: oc-includes/osclass/classes/market/Installer.php
 msgid "Package rolled back to its previous version."
 msgstr ""
 
-#: oc-includes/osclass/classes/market/Installer.php:161
-#: oc-includes/osclass/classes/upgrade/Upgrade.php:86
+#: oc-includes/osclass/classes/market/Installer.php
+#: oc-includes/osclass/classes/upgrade/Upgrade.php
 msgid "Package source host is not on the allowed list for verified downloads."
 msgstr ""
 
-#: oc-admin/themes/modern/billing/packages.php:25
-#: oc-includes/osclass/classes/AdminMenu.php:209
+#: oc-admin/themes/modern/billing/packages.php
+#: oc-includes/osclass/classes/AdminMenu.php
 msgid "Packages"
 msgstr ""
 
-#: oc-admin/themes/modern/media/index.php:111
-#: oc-admin/themes/modern/media/index.php:240
-#: oc-includes/osclass/functions.php:136
-#: oc-includes/osclass/helpers/hPagination.php:173
+#: oc-admin/themes/modern/media/index.php
+#: oc-includes/osclass/functions.php
+#: oc-includes/osclass/helpers/hPagination.php
 msgid "Page"
 msgstr ""
 
-#: oc-includes/osclass/classes/Pagination.php:117
+#: oc-includes/osclass/classes/Pagination.php
 msgid "Page %s"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:403
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid "Page URL:"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/index.php:124
+#: oc-admin/themes/modern/settings/index.php
 msgid "Page description"
 msgstr ""
 
-#: oc-admin/themes/modern/pages/frm.php:321
+#: oc-admin/themes/modern/pages/frm.php
 msgid "Page settings"
 msgstr ""
 
-#: oc-admin/themes/modern/pages/frm.php:325
+#: oc-admin/themes/modern/pages/frm.php
 msgid "Page template"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/index.php:119
+#: oc-admin/themes/modern/settings/index.php
 msgid "Page title"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/index.php:40
-#: oc-admin/themes/modern/settings/index.php:41
+#: oc-admin/themes/modern/settings/index.php
 msgid "Page title: this field is required"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:175
-#: oc-admin/themes/modern/settings/permalinks.php:176
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid "Page url: this field is required"
 msgstr ""
 
-#: oc-admin/themes/modern/pages/frm.php:70
-#: oc-admin/themes/modern/pages/index.php:17
-#: oc-admin/themes/modern/pages/index.php:18
-#: oc-includes/osclass/classes/AdminMenu.php:162
-#: oc-includes/osclass/classes/controller/admin/CAdminMedia.php:119
+#: oc-admin/themes/modern/pages/frm.php
+#: oc-admin/themes/modern/pages/index.php
+#: oc-includes/osclass/classes/AdminMenu.php
+#: oc-includes/osclass/classes/controller/admin/CAdminMedia.php
 msgid "Pages"
 msgstr ""
 
-#: oc-admin/themes/modern/parts/ui.php:450
-#: oc-includes/osclass/classes/Pagination.php:81
+#: oc-admin/themes/modern/parts/ui.php
+#: oc-includes/osclass/classes/Pagination.php
 msgid "Pagination"
 msgstr ""
 
-#: oc-admin/themes/modern/billing/index.php:36
-#: oc-admin/themes/modern/billing/order.php:37
-#: oc-admin/themes/modern/billing/order.php:91
+#: oc-admin/themes/modern/billing/index.php
+#: oc-admin/themes/modern/billing/order.php
 msgid "Paid"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/index.php:314
+#: oc-admin/themes/modern/settings/index.php
 msgid "Parent categories"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php:677
+#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php
 msgid "Parent category is disabled, you can not enable that category"
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:51
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Parking Spots"
 msgstr ""
 
-#: oc-admin/themes/modern/upgrade/index.php:53
+#: oc-admin/themes/modern/upgrade/index.php
 msgid ""
 "Parts of your database did not match what Shopclass expected, and have been "
 "put right. This usually follows a plugin change or an upgrade that was "
 "interrupted."
 msgstr ""
 
-#: oc-admin/gui/login.php:32
-#: oc-admin/themes/modern/settings/mailserver.php:143
-#: oc-admin/themes/modern/users/frm.php:327
-#: oc-includes/osclass/installer/gui/install-database.php:59
-#: oc-includes/osclass/installer/gui/install-finish.php:73
-#: oc-includes/osclass/installer/gui/install-target.php:69
+#: oc-admin/gui/login.php
+#: oc-admin/themes/modern/settings/mailserver.php
+#: oc-admin/themes/modern/users/frm.php
+#: oc-includes/osclass/installer/gui/install-database.php
+#: oc-includes/osclass/installer/gui/install-finish.php
+#: oc-includes/osclass/installer/gui/install-target.php
 msgid "Password"
 msgstr ""
 
-#: oc-includes/osclass/classes/form/AdminForm.php:133
-#: oc-includes/osclass/classes/form/UserForm.php:423
-#: oc-includes/osclass/classes/form/UserForm.php:475
+#: oc-includes/osclass/classes/form/AdminForm.php
+#: oc-includes/osclass/classes/form/UserForm.php
 msgid "Password: enter at least 5 characters"
 msgstr ""
 
-#: oc-includes/osclass/classes/form/UserForm.php:422
+#: oc-includes/osclass/classes/form/UserForm.php
 msgid "Password: this field is required"
 msgstr ""
 
-#: oc-includes/osclass/classes/form/AdminForm.php:134
-#: oc-includes/osclass/classes/form/UserForm.php:426
-#: oc-includes/osclass/classes/form/UserForm.php:477
+#: oc-includes/osclass/classes/form/AdminForm.php
+#: oc-includes/osclass/classes/form/UserForm.php
 msgid "Passwords don't match"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/keywordBlock.php:176
+#: oc-admin/themes/modern/settings/keywordBlock.php
 msgid ""
 "Paste a comma-separated keyword list — useful for migrating an existing "
 "list from a theme or plugin. Wrap a keyword in asterisks (e.g. *viagra*) to "
 "import it as a substring match. Keywords already on file are skipped."
 msgstr ""
 
-#: oc-admin/themes/modern/settings/storage.php:170
+#: oc-admin/themes/modern/settings/storage.php
 msgid "Path-style URLs"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:649
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "Paths"
 msgstr ""
 
-#: oc-admin/themes/modern/items/index.php:113
-#: oc-admin/themes/modern/items/index.php:216
+#: oc-admin/themes/modern/items/index.php
 msgid "Pattern"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/iframe.php:138
+#: oc-admin/themes/modern/fields/iframe.php
 msgid "Pattern (regex)"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/billing.php:164
+#: oc-admin/themes/modern/settings/billing.php
 msgid "Payment instructions"
 msgstr ""
 
-#: oc-admin/themes/modern/billing/index.php:115
-#: oc-admin/themes/modern/billing/index.php:66
-#: oc-admin/themes/modern/billing/order.php:77
-#: oc-admin/themes/modern/settings/billing.php:366
+#: oc-admin/themes/modern/billing/index.php
+#: oc-admin/themes/modern/billing/order.php
+#: oc-admin/themes/modern/settings/billing.php
 msgid "Payment method"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/billing.php:347
+#: oc-admin/themes/modern/settings/billing.php
 msgid "Payment methods"
 msgstr ""
 
-#: oc-admin/themes/modern/billing/index.php:35
-#: oc-admin/themes/modern/billing/order.php:36
+#: oc-admin/themes/modern/billing/index.php
+#: oc-admin/themes/modern/billing/order.php
 msgid "Pending"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/storage.php:244
+#: oc-admin/themes/modern/settings/storage.php
 msgid "Pending jobs: %d &middot; Failed jobs: %d"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:350
-#: oc-admin/themes/modern/settings/permalinks.php:359
-#: oc-includes/osclass/classes/AdminMenu.php:332
+#: oc-admin/themes/modern/settings/permalinks.php
+#: oc-includes/osclass/classes/AdminMenu.php
 msgid "Permalinks"
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:10
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Personals"
 msgstr ""
 
-#: oc-admin/themes/modern/items/frm.php:239
-#: oc-admin/themes/modern/users/frm.php:242
+#: oc-admin/themes/modern/items/frm.php
+#: oc-admin/themes/modern/users/frm.php
 msgid "Phone"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/billing.php:290
+#: oc-admin/themes/modern/settings/billing.php
 msgid "Photo cap"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/billing.php:270
+#: oc-admin/themes/modern/settings/billing.php
 msgid "Photo count, the posting wait, and listing runtime are global limits by "
 msgstr ""
 
-#: oc-admin/themes/modern/items/frm.php:199
+#: oc-admin/themes/modern/items/frm.php
 msgid "Photos"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/billing.php:294
+#: oc-admin/themes/modern/settings/billing.php
 msgid "Photos allowed per listing while the entitlement is held."
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:493
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "Photos per listing"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/submissions.php:224
+#: oc-admin/themes/modern/fields/submissions.php
 msgid "Pick a form to see its submissions"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/iframe.php:130
+#: oc-admin/themes/modern/fields/iframe.php
 msgid "Placeholder"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/upgrade.php:76
+#: oc-admin/themes/modern/tools/upgrade.php
 msgid ""
 "Please be aware that this upgrade will overwrite any existing modification "
 "you have made to core files."
 msgstr ""
 
-#: oc-admin/gui/recover.php:18
+#: oc-admin/gui/recover.php
 msgid "Please enter your username or e-mail address"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/upgrade.php:74
+#: oc-admin/themes/modern/tools/upgrade.php
 msgid "Please note that this upgrade may take a few minutes to complete."
 msgstr ""
 
-#: oc-includes/osclass/classes/Plugins.php:173
+#: oc-includes/osclass/classes/Plugins.php
 msgid "Plugin %s is missing the index.php file %s"
 msgstr ""
 
-#: oc-admin/themes/modern/plugins/index.php:83
+#: oc-admin/themes/modern/plugins/index.php
 msgid ""
 "Plugin couldn't be installed because it triggered a <strong>fatal "
 "error</strong>"
 msgstr ""
 
-#: oc-admin/themes/modern/plugins/add.php:35
+#: oc-admin/themes/modern/plugins/add.php
 msgid "Plugin package (.zip)"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/index.php:395
-#: oc-includes/osclass/functions.php:641
+#: oc-admin/themes/modern/settings/index.php
+#: oc-includes/osclass/functions.php
 msgid "Plugin updates"
 msgstr ""
 
-#: oc-admin/themes/modern/plugins/add.php:17
-#: oc-admin/themes/modern/plugins/configuration.php:21
-#: oc-admin/themes/modern/plugins/configuration.php:22
-#: oc-admin/themes/modern/plugins/index.php:17
-#: oc-admin/themes/modern/plugins/index.php:18
-#: oc-admin/themes/modern/plugins/view.php:18
-#: oc-admin/themes/modern/plugins/view.php:19
-#: oc-includes/osclass/classes/AdminMenu.php:310
+#: oc-admin/themes/modern/plugins/add.php
+#: oc-admin/themes/modern/plugins/configuration.php
+#: oc-admin/themes/modern/plugins/index.php
+#: oc-admin/themes/modern/plugins/view.php
+#: oc-includes/osclass/classes/AdminMenu.php
 msgid "Plugins"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminPlugins.php:411
+#: oc-includes/osclass/classes/controller/admin/CAdminPlugins.php
 msgid "Plugins Site"
 msgstr ""
 
-#: oc-admin/themes/modern/plugins/index.php:132
+#: oc-admin/themes/modern/plugins/index.php
 msgid ""
 "Plugins extend what the panel and your site can do. Install one from "
 "Browse, or upload a package."
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:660
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "Plugins path"
 msgstr ""
 
-#: oc-admin/themes/modern/parts/market.php:608
+#: oc-admin/themes/modern/parts/market.php
 msgid "Plugins updated."
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:278
+#: oc-admin/themes/modern/tools/system-info.php
 msgid ""
 "Point %1$s at an installed driver (for example %2$s or %3$s) so category "
 "trees, user data and search stop being recomputed on every request; %4$s "
 "sets how long, in seconds, a value is kept."
 msgstr ""
 
-#: oc-admin/themes/modern/billing/package.php:68
-#: oc-admin/themes/modern/settings/media.php:383
-#: oc-admin/themes/modern/settings/media.php:419
+#: oc-admin/themes/modern/billing/package.php
+#: oc-admin/themes/modern/settings/media.php
 msgid "Position"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:662
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "Preferences"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/storage.php:124
+#: oc-admin/themes/modern/settings/storage.php
 msgid ""
 "Prefills the connection fields below with a starting point for the selected "
 "provider. "
 msgstr ""
 
-#: oc-admin/themes/modern/items/index.php:269
-#: oc-includes/osclass/classes/datatables/ItemsDataTable.php:464
+#: oc-admin/themes/modern/items/index.php
+#: oc-includes/osclass/classes/datatables/ItemsDataTable.php
 msgid "Premium"
 msgstr ""
 
-#: oc-admin/themes/modern/appearance/index.php:161
-#: oc-admin/themes/modern/media/index.php:289
-#: oc-admin/themes/modern/media/index.php:324
-#: oc-admin/themes/modern/media/index.php:329
-#: oc-admin/themes/modern/settings/index.php:73
-#: oc-admin/themes/modern/settings/index.php:82
+#: oc-admin/themes/modern/appearance/index.php
+#: oc-admin/themes/modern/media/index.php
+#: oc-admin/themes/modern/settings/index.php
 msgid "Preview"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/media.php:364
+#: oc-admin/themes/modern/settings/media.php
 msgid "Preview Watermark"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/media.php:143
+#: oc-admin/themes/modern/settings/media.php
 msgid "Preview size"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/media.php:42
+#: oc-admin/themes/modern/settings/media.php
 msgid "Preview size: is not in the correct format"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/media.php:41
+#: oc-admin/themes/modern/settings/media.php
 msgid "Preview size: this field is required"
 msgstr ""
 
-#: oc-admin/themes/modern/parts/ui.php:462
-#: oc-admin/themes/modern/parts/ui.php:464
+#: oc-admin/themes/modern/parts/ui.php
 msgid "Previous"
 msgstr ""
 
-#: oc-includes/osclass/classes/Pagination.php:110
+#: oc-includes/osclass/classes/Pagination.php
 msgid "Previous page"
 msgstr ""
 
-#: oc-admin/themes/modern/parts/market.php:547
+#: oc-admin/themes/modern/parts/market.php
 msgid "Previous screenshot"
 msgstr ""
 
-#: oc-admin/themes/modern/billing/package.php:51
-#: oc-admin/themes/modern/billing/packages.php:42
-#: oc-admin/themes/modern/items/settings.php:253
-#: oc-includes/osclass/classes/form/admin/Item.php:203
+#: oc-admin/themes/modern/billing/package.php
+#: oc-admin/themes/modern/billing/packages.php
+#: oc-admin/themes/modern/items/settings.php
+#: oc-includes/osclass/classes/form/admin/Item.php
 msgid "Price"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/billing.php:284
-#: oc-admin/themes/modern/settings/billing.php:306
-#: oc-admin/themes/modern/settings/billing.php:327
+#: oc-admin/themes/modern/settings/billing.php
 msgid "Price (credits)"
 msgstr ""
 
-#: oc-includes/osclass/classes/form/ItemForm.php:1177
-#: oc-includes/osclass/classes/form/ItemForm.php:956
+#: oc-includes/osclass/classes/form/ItemForm.php
 msgid "Price: no more than 50 characters"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/billing.php:61
+#: oc-admin/themes/modern/settings/billing.php
 msgid "Pricing"
 msgstr ""
 
-#: oc-includes/osclass/classes/form/ItemForm.php:1586
+#: oc-includes/osclass/classes/form/ItemForm.php
 msgid "Primary"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:297
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "Problem"
 msgstr ""
 
-#: oc-admin/themes/modern/plugins/index.php:177
-#: oc-includes/osclass/classes/controller/admin/CAdminPlugins.php:406
+#: oc-admin/themes/modern/plugins/index.php
+#: oc-includes/osclass/classes/controller/admin/CAdminPlugins.php
 msgid "Problems with this plugin? Ask for support."
 msgstr ""
 
-#: oc-admin/themes/modern/settings/storage.php:252
+#: oc-admin/themes/modern/settings/storage.php
 msgid "Process queue now"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/spamNbots.php:86
+#: oc-admin/themes/modern/settings/spamNbots.php
 msgid ""
 "Protect your site from automated abuse with Google reCAPTCHA or Cloudflare "
 "Turnstile. "
 msgstr ""
 
-#: oc-admin/themes/modern/settings/storage.php:113
+#: oc-admin/themes/modern/settings/storage.php
 msgid "Provider"
 msgstr ""
 
-#: oc-includes/osclass/helpers/hUtils.php:389
+#: oc-includes/osclass/helpers/hUtils.php
 msgid "Public Profile"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/storage.php:181
+#: oc-admin/themes/modern/settings/storage.php
 msgid "Public URL"
 msgstr ""
 
-#: oc-includes/osclass/classes/datatables/UsersDataTable.php:213
-#: oc-includes/osclass/functions.php:210
+#: oc-includes/osclass/classes/datatables/UsersDataTable.php
+#: oc-includes/osclass/functions.php
 msgid "Public profile"
 msgstr ""
 
-#: oc-admin/themes/modern/pages/frm.php:305
+#: oc-admin/themes/modern/pages/frm.php
 msgid "Publish"
 msgstr ""
 
-#: oc-includes/osclass/classes/Breadcrumb.php:48
-#: oc-includes/osclass/functions.php:105
+#: oc-includes/osclass/classes/Breadcrumb.php
+#: oc-includes/osclass/functions.php
 msgid "Publish a listing"
 msgstr ""
 
-#: oc-admin/themes/modern/billing/order.php:45
-#: oc-admin/themes/modern/billing/wallet.php:31
+#: oc-admin/themes/modern/billing/order.php
+#: oc-admin/themes/modern/billing/wallet.php
 msgid "Purchase"
 msgstr ""
 
-#: oc-includes/osclass/classes/EmailVariables.php:71
+#: oc-includes/osclass/classes/EmailVariables.php
 msgid "Question about your listing"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/storage.php:334
+#: oc-admin/themes/modern/settings/storage.php
 msgid "Queue downloads"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/storage.php:321
+#: oc-admin/themes/modern/settings/storage.php
 msgid "Queue every local image for upload?"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/storage.php:325
+#: oc-admin/themes/modern/settings/storage.php
 msgid "Queue uploads"
 msgstr ""
 
-#: oc-admin/themes/modern/stats/items.php:52
+#: oc-admin/themes/modern/stats/items.php
 msgid ""
 "Quickly find out how many new listings have been published on your site and "
 "how many visits each of the listings gets."
 msgstr ""
 
-#: oc-admin/themes/modern/settings/index.php:289
+#: oc-admin/themes/modern/settings/index.php
 msgid "RSS shows"
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:38
+#: oc-includes/osclass/installer/basic_data.php
 msgid "RVs - Campers - Caravans"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:237
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "Raise %1$s and %2$s together, keeping post at least as large as upload:"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:244
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "Raise %s to at least the number of photos per listing you allow in Settings."
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:271
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "Raise memory without touching php.ini"
 msgstr ""
 
-#: oc-includes/osclass/classes/datatables/UsersDataTable.php:235
+#: oc-includes/osclass/classes/datatables/UsersDataTable.php
 msgid "Re-send activation email"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/submissions.php:36
+#: oc-admin/themes/modern/fields/submissions.php
 msgid "Read"
 msgstr ""
 
-#: oc-admin/themes/modern/upgrade/index.php:315
+#: oc-admin/themes/modern/upgrade/index.php
 msgid "Read the full release notes on GitHub"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:600
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "Read-only, as it should be after install."
 msgstr ""
 
-#: oc-admin/themes/modern/settings/billing.php:385
+#: oc-admin/themes/modern/settings/billing.php
 msgid "Ready"
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:93
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Real Estate"
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:7
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Real estate"
 msgstr ""
 
-#: oc-includes/osclass/classes/AdminMenu.php:277
+#: oc-includes/osclass/classes/AdminMenu.php
 msgid "Recalculate category stats"
 msgstr ""
 
-#: oc-includes/osclass/classes/AdminMenu.php:270
+#: oc-includes/osclass/classes/AdminMenu.php
 msgid "Recalculate location stats"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/submissions.php:130
-#: oc-admin/themes/modern/fields/submissions.php:159
+#: oc-admin/themes/modern/fields/submissions.php
 msgid "Received"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/logs.php:73
+#: oc-admin/themes/modern/tools/logs.php
 msgid "Recent activity"
 msgstr ""
 
-#: oc-admin/themes/modern/parts/market.php:364
+#: oc-admin/themes/modern/parts/market.php
 msgid "Recently updated"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/media.php:456
+#: oc-admin/themes/modern/settings/media.php
 msgid "Recommendation"
 msgstr ""
 
-#: oc-admin/themes/modern/billing/order.php:188
+#: oc-admin/themes/modern/billing/order.php
 msgid "Record a refund"
 msgstr ""
 
-#: oc-admin/themes/modern/billing/order.php:203
+#: oc-admin/themes/modern/billing/order.php
 msgid "Record a refund for order #%d?"
 msgstr ""
 
-#: oc-admin/themes/modern/billing/order.php:183
+#: oc-admin/themes/modern/billing/order.php
 msgid "Record a refund you have already made through your payment provider. "
 msgstr ""
 
-#: oc-admin/themes/modern/tools/logs.php:43
+#: oc-admin/themes/modern/tools/logs.php
 msgid "Record activity"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/logs.php:48
+#: oc-admin/themes/modern/tools/logs.php
 msgid "Record admin and listing activity"
 msgstr ""
 
-#: oc-admin/themes/modern/billing/order.php:217
+#: oc-admin/themes/modern/billing/order.php
 msgid "Record the refund"
 msgstr ""
 
-#: oc-includes/osclass/functions.php:185
+#: oc-includes/osclass/functions.php
 msgid "Recover my password"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:295
-#: oc-admin/themes/modern/settings/permalinks.php:296
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid "Recover user url: this field is required"
 msgstr ""
 
-#: oc-includes/osclass/classes/Breadcrumb.php:64
-#: oc-includes/osclass/functions.php:182
+#: oc-includes/osclass/classes/Breadcrumb.php
+#: oc-includes/osclass/functions.php
 msgid "Recover your password"
 msgstr ""
 
-#: oc-admin/themes/modern/billing/order.php:85
-#: oc-admin/themes/modern/billing/wallet.php:69
+#: oc-admin/themes/modern/billing/order.php
+#: oc-admin/themes/modern/billing/wallet.php
 msgid "Reference"
 msgstr ""
 
-#: oc-admin/themes/modern/billing/order.php:181
-#: oc-admin/themes/modern/billing/order.php:47
-#: oc-admin/themes/modern/billing/wallet.php:33
+#: oc-admin/themes/modern/billing/order.php
+#: oc-admin/themes/modern/billing/wallet.php
 msgid "Refund"
 msgstr ""
 
-#: oc-admin/themes/modern/billing/index.php:38
-#: oc-admin/themes/modern/billing/order.php:39
+#: oc-admin/themes/modern/billing/index.php
+#: oc-admin/themes/modern/billing/order.php
 msgid "Refunded"
 msgstr ""
 
-#: oc-includes/osclass/classes/market/Installer.php:150
+#: oc-includes/osclass/classes/market/Installer.php
 msgid ""
 "Refusing to install: the catalog entry carries no checksum to verify the "
 "download against."
 msgstr ""
 
-#: oc-admin/themes/modern/settings/media.php:445
-#: oc-admin/themes/modern/settings/sitemap.php:202
+#: oc-admin/themes/modern/settings/media.php
+#: oc-admin/themes/modern/settings/sitemap.php
 msgid "Regenerate"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/sitemap.php:208
+#: oc-admin/themes/modern/settings/sitemap.php
 msgid "Regenerate / clear cache"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/media.php:436
+#: oc-admin/themes/modern/settings/media.php
 msgid "Regenerate images"
 msgstr ""
 
-#: oc-admin/themes/modern/items/frm.php:265
-#: oc-admin/themes/modern/items/index.php:240
-#: oc-admin/themes/modern/settings/locations.php:160
-#: oc-admin/themes/modern/settings/storage.php:137
-#: oc-admin/themes/modern/stats/users.php:112
-#: oc-admin/themes/modern/users/frm.php:298
-#: oc-admin/themes/modern/users/index.php:237
+#: oc-admin/themes/modern/items/frm.php
+#: oc-admin/themes/modern/items/index.php
+#: oc-admin/themes/modern/settings/locations.php
+#: oc-admin/themes/modern/settings/storage.php
+#: oc-admin/themes/modern/stats/users.php
+#: oc-admin/themes/modern/users/frm.php
+#: oc-admin/themes/modern/users/index.php
 msgid "Region"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/advanced.php:71
+#: oc-admin/themes/modern/settings/advanced.php
 msgid "Region based"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/locations.php:161
+#: oc-admin/themes/modern/settings/locations.php
 msgid "Region name"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/locations.php:85
+#: oc-admin/themes/modern/settings/locations.php
 msgid "Regions"
 msgstr ""
 
-#: oc-admin/themes/modern/comments/frm.php:67
+#: oc-admin/themes/modern/comments/frm.php
 msgid "Registered user"
 msgstr ""
 
-#: oc-admin/themes/modern/users/index.php:149
+#: oc-admin/themes/modern/users/index.php
 msgid "Registered users will appear here once they sign up or you add them."
 msgstr ""
 
-#: oc-admin/themes/modern/settings/keywordBlock.php:129
+#: oc-admin/themes/modern/settings/keywordBlock.php
 msgid "Reject the listing outright instead of quarantining it for review"
 msgstr ""
 
-#: oc-includes/osclass/helpers/hSearch.php:47
+#: oc-includes/osclass/helpers/hSearch.php
 msgid "Relevance"
 msgstr ""
 
-#: oc-admin/gui/login.php:54
+#: oc-admin/gui/login.php
 msgid "Remember me"
 msgstr ""
 
-#: oc-includes/osclass/install-functions.php:1100
+#: oc-includes/osclass/install-functions.php
 msgid ""
 "Remember that for any doubts you might have you can consult our <a "
 "href=\"%1$s\">documentation</a>"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/advanced.php:89
+#: oc-admin/themes/modern/settings/advanced.php
 msgid "Remember to enable cookies for the subdomains too."
 msgstr ""
 
-#: oc-admin/themes/modern/functions.php:351
-#: oc-admin/themes/modern/settings/sitemap.php:139
-#: oc-admin/themes/modern/settings/sitemap.php:159
-#: oc-includes/osclass/classes/form/ItemForm.php:1361
+#: oc-admin/themes/modern/functions.php
+#: oc-admin/themes/modern/settings/sitemap.php
+#: oc-includes/osclass/classes/form/ItemForm.php
 msgid "Remove"
 msgstr ""
 
-#: oc-admin/themes/modern/billing/wallet.php:151
-#: oc-admin/themes/modern/billing/wallet.php:173
+#: oc-admin/themes/modern/billing/wallet.php
 msgid "Remove credits"
 msgstr ""
 
-#: oc-admin/themes/modern/users/frm.php:271
+#: oc-admin/themes/modern/users/frm.php
 msgid "Remove current avatar"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/index.php:117
-#: oc-admin/themes/modern/fields/index.php:684
+#: oc-admin/themes/modern/fields/index.php
 msgid "Remove from form"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/locations.php:107
-#: oc-admin/themes/modern/settings/locations.php:45
-#: oc-admin/themes/modern/settings/locations.php:90
+#: oc-admin/themes/modern/settings/locations.php
 msgid "Remove selected"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/cleanup.php:16
+#: oc-admin/themes/modern/tools/cleanup.php
 msgid "Remove stale content in bulk — expired, unactivated, spam, blocked and "
 msgstr ""
 
-#: oc-admin/themes/modern/billing/order.php:49
-#: oc-admin/themes/modern/billing/wallet.php:35
+#: oc-admin/themes/modern/billing/order.php
+#: oc-admin/themes/modern/billing/wallet.php
 msgid "Removed by admin"
 msgstr ""
 
-#: oc-admin/themes/modern/appearance/widgets.php:119
+#: oc-admin/themes/modern/appearance/widgets.php
 msgid "Reorder %s"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/index.php:679
-#: oc-admin/themes/modern/fields/index.php:96
+#: oc-admin/themes/modern/fields/index.php
 msgid "Reorder field: use the arrow keys"
 msgstr ""
 
-#: oc-admin/themes/modern/pages/frm.php:244
+#: oc-admin/themes/modern/pages/frm.php
 msgid "Reorder widget %s. Drag, or focus and press the up"
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:63
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Repair"
 msgstr ""
 
-#: oc-admin/themes/modern/upgrade/index.php:52
+#: oc-admin/themes/modern/upgrade/index.php
 msgid "Repaired %s differences."
 msgstr ""
 
-#: oc-admin/themes/modern/upgrade/index.php:51
+#: oc-admin/themes/modern/upgrade/index.php
 msgid "Repaired one difference."
 msgstr ""
 
-#: oc-admin/gui/forgot_password.php:33
-#: oc-admin/gui/forgot_password.php:35
+#: oc-admin/gui/forgot_password.php
 msgid "Repeat new password"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/keywordBlock.php:157
+#: oc-admin/themes/modern/settings/keywordBlock.php
 msgid "Report CAPTCHA"
 msgstr ""
 
-#: oc-admin/themes/modern/functions.php:102
-#: oc-admin/themes/modern/functions.php:103
+#: oc-admin/themes/modern/functions.php
 msgid "Report Issue"
 msgstr ""
 
-#: oc-admin/themes/modern/stats/reports.php:104
-#: oc-admin/themes/modern/stats/reports.php:40
+#: oc-admin/themes/modern/stats/reports.php
 msgid "Report Statistics"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/keywordBlock.php:137
+#: oc-admin/themes/modern/settings/keywordBlock.php
 msgid "Report auto-block"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/cleanup.php:117
+#: oc-admin/themes/modern/tools/cleanup.php
 msgid "Report counts are always recorded — moderation depends on them."
 msgstr ""
 
-#: oc-admin/themes/modern/settings/keywordBlock.php:147
+#: oc-admin/themes/modern/settings/keywordBlock.php
 msgid "Report threshold"
 msgstr ""
 
-#: oc-admin/themes/modern/items/reported.php:18
-#: oc-admin/themes/modern/items/reported.php:29
-#: oc-admin/themes/modern/main/index.php:175
-#: oc-admin/themes/modern/tools/cleanup.php:23
-#: oc-includes/osclass/classes/AdminMenu.php:63
+#: oc-admin/themes/modern/items/reported.php
+#: oc-admin/themes/modern/main/index.php
+#: oc-admin/themes/modern/tools/cleanup.php
+#: oc-includes/osclass/classes/AdminMenu.php
 msgid "Reported listings"
 msgstr ""
 
-#: oc-includes/osclass/classes/AdminMenu.php:246
+#: oc-includes/osclass/classes/AdminMenu.php
 msgid "Reports"
 msgstr ""
 
-#: oc-admin/themes/modern/parts/market.php:613
+#: oc-admin/themes/modern/parts/market.php
 msgid "Repository"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/comments.php:100
+#: oc-admin/themes/modern/settings/comments.php
 msgid "Require a CAPTCHA to post a comment"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/keywordBlock.php:162
+#: oc-admin/themes/modern/settings/keywordBlock.php
 msgid "Require a CAPTCHA to report a listing"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/spamNbots.php:200
+#: oc-admin/themes/modern/settings/spamNbots.php
 msgid "Require login for alerts"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/storage.php:176
+#: oc-admin/themes/modern/settings/storage.php
 msgid "Required by MinIO and most self-hosted setups; leave off for AWS."
 msgstr ""
 
-#: oc-admin/themes/modern/fields/iframe.php:166
+#: oc-admin/themes/modern/fields/iframe.php
 msgid "Required only when…"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:354
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "Requirements"
 msgstr ""
 
-#: oc-admin/themes/modern/parts/market.php:571
+#: oc-admin/themes/modern/parts/market.php
 msgid "Requires"
 msgstr ""
 
-#: oc-includes/osclass/classes/market/Compatibility.php:153
+#: oc-includes/osclass/classes/market/Compatibility.php
 msgid "Requires %s+"
 msgstr ""
 
-#: oc-admin/themes/modern/parts/market.php:572
+#: oc-admin/themes/modern/parts/market.php
 msgid "Requires PHP"
 msgstr ""
 
-#: oc-includes/osclass/classes/market/Compatibility.php:75
+#: oc-includes/osclass/classes/market/Compatibility.php
 msgid "Requires PHP %1$s (you have %2$s)."
 msgstr ""
 
-#: oc-includes/osclass/classes/market/Compatibility.php:158
+#: oc-includes/osclass/classes/market/Compatibility.php
 msgid "Requires PHP %s"
 msgstr ""
 
-#: oc-includes/osclass/classes/market/Compatibility.php:64
+#: oc-includes/osclass/classes/market/Compatibility.php
 msgid "Requires Shopclass %1$s or newer (you have %2$s)."
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php:762
+#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php
 msgid "Resend activation"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php:760
+#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php
 msgid "Resend the activation to"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/logs.php:125
-#: oc-admin/themes/modern/tools/logs.php:82
+#: oc-admin/themes/modern/tools/logs.php
 msgid "Reset"
 msgstr ""
 
-#: oc-admin/themes/modern/items/index.php:177
-#: oc-admin/themes/modern/items/index.php:334
-#: oc-admin/themes/modern/items/index.php:92
-#: oc-admin/themes/modern/items/reported.php:54
-#: oc-admin/themes/modern/users/index.php:280
-#: oc-admin/themes/modern/users/index.php:93
+#: oc-admin/themes/modern/items/index.php
+#: oc-admin/themes/modern/items/reported.php
+#: oc-admin/themes/modern/users/index.php
 msgid "Reset filters"
 msgstr ""
 
-#: oc-includes/osclass/installer/gui/install.php:241
+#: oc-includes/osclass/installer/gui/install.php
 msgid "Restart the installer"
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:94
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Restaurant - Food Service"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/media.php:165
+#: oc-admin/themes/modern/settings/media.php
 msgid "Restrictions"
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:95
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Retail"
 msgstr ""
 
-#: oc-admin/themes/modern/items/settings.php:237
+#: oc-admin/themes/modern/items/settings.php
 msgid "Rich Edit"
 msgstr ""
 
-#: oc-includes/osclass/classes/market/Installer.php:100
+#: oc-includes/osclass/classes/market/Installer.php
 msgid "Rollback failed; the backup could not be restored."
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:48
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Rooms for Rent - Shared"
 msgstr ""
 
-#: oc-includes/osclass/install-functions.php:225
+#: oc-includes/osclass/install-functions.php
 msgid "Root directory is writable"
 msgstr ""
 
-#: oc-includes/osclass/install-functions.php:228
+#: oc-includes/osclass/install-functions.php
 msgid "Root folder has to be writable, i.e.: <code>chmod 0755 %s</code>"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/iframe.php:137
+#: oc-admin/themes/modern/fields/iframe.php
 msgid "Rows"
 msgstr ""
 
-#: oc-admin/themes/modern/parts/ui.php:723
+#: oc-admin/themes/modern/parts/ui.php
 msgid "Rows per page"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/cleanup.php:145
+#: oc-admin/themes/modern/tools/cleanup.php
 msgid "Run cleanup now"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/cleanup.php:158
+#: oc-admin/themes/modern/tools/cleanup.php
 msgid "Run cleanup now?"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/storage.php:230
+#: oc-admin/themes/modern/settings/storage.php
 msgid ""
 "Runs a small write/read/delete probe against the saved connection settings "
 "above."
 msgstr ""
 
-#: oc-admin/themes/modern/settings/mailserver.php:167
+#: oc-admin/themes/modern/settings/mailserver.php
 msgid "SMTP"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/mailserver.php:171
+#: oc-admin/themes/modern/settings/mailserver.php
 msgid "SMTP authentication enabled"
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:96
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Sales"
 msgstr ""
 
-#: oc-includes/osclass/helpers/hUtils.php:347
+#: oc-includes/osclass/helpers/hUtils.php
 msgid "Sat"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/index.php:185
-#: oc-includes/osclass/helpers/hUtils.php:344
+#: oc-admin/themes/modern/settings/index.php
+#: oc-includes/osclass/helpers/hUtils.php
 msgid "Saturday"
 msgstr ""
 
-#: oc-admin/themes/modern/admins/frm.php:28
-#: oc-admin/themes/modern/settings/locations.php:162
+#: oc-admin/themes/modern/admins/frm.php
+#: oc-admin/themes/modern/settings/locations.php
 msgid "Save"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/backup.php:28
+#: oc-admin/themes/modern/tools/backup.php
 msgid ""
 "Save a backup of all of your site's information: listings, users and "
 "configuration."
 msgstr ""
 
-#: oc-admin/themes/modern/settings/billing.php:172
+#: oc-admin/themes/modern/settings/billing.php
 msgid "Save bank transfer settings"
 msgstr ""
 
-#: oc-admin/themes/modern/appearance/add_widget.php:122
-#: oc-admin/themes/modern/appearance/add_widget.php:30
-#: oc-admin/themes/modern/categories/iframe.php:54
-#: oc-admin/themes/modern/emails/frm.php:147
-#: oc-admin/themes/modern/fields/group_iframe.php:74
-#: oc-admin/themes/modern/fields/iframe.php:278
-#: oc-admin/themes/modern/items/settings.php:294
-#: oc-admin/themes/modern/pages/frm.php:454
-#: oc-admin/themes/modern/pages/frm.php:58
-#: oc-admin/themes/modern/parts/ui.php:586
-#: oc-admin/themes/modern/settings/sitemap.php:85
-#: oc-admin/themes/modern/settings/spamNbots.php:186
-#: oc-admin/themes/modern/settings/spamNbots.php:210
-#: oc-admin/themes/modern/settings/spamNbots.php:277
-#: oc-admin/themes/modern/settings/spamNbots.php:77
-#: oc-admin/themes/modern/users/settings.php:80
+#: oc-admin/themes/modern/appearance/add_widget.php
+#: oc-admin/themes/modern/categories/iframe.php
+#: oc-admin/themes/modern/emails/frm.php
+#: oc-admin/themes/modern/fields/group_iframe.php
+#: oc-admin/themes/modern/fields/iframe.php
+#: oc-admin/themes/modern/items/settings.php
+#: oc-admin/themes/modern/pages/frm.php
+#: oc-admin/themes/modern/parts/ui.php
+#: oc-admin/themes/modern/settings/sitemap.php
+#: oc-admin/themes/modern/settings/spamNbots.php
+#: oc-admin/themes/modern/users/settings.php
 msgid "Save changes"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/billing.php:341
+#: oc-admin/themes/modern/settings/billing.php
 msgid "Save limits"
 msgstr ""
 
-#: oc-admin/themes/modern/billing/package.php:84
+#: oc-admin/themes/modern/billing/package.php
 msgid "Save package"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/billing.php:134
+#: oc-admin/themes/modern/settings/billing.php
 msgid "Save pricing"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/sitemap.php:192
+#: oc-admin/themes/modern/settings/sitemap.php
 msgid "Save robots.txt"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/billing.php:50
-#: oc-admin/themes/modern/tools/cleanup.php:144
+#: oc-admin/themes/modern/settings/billing.php
+#: oc-admin/themes/modern/tools/cleanup.php
 msgid "Save settings"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/searches.php:87
+#: oc-admin/themes/modern/settings/searches.php
 msgid "Save the latest user searches"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/searches.php:66
+#: oc-admin/themes/modern/settings/searches.php
 msgid ""
 "Save the searches users do on your site. In this way, you can get "
 "information on what they're most "
 msgstr ""
 
-#: oc-admin/themes/modern/pages/frm.php:292
+#: oc-admin/themes/modern/pages/frm.php
 msgid "Save this page with the Page builder template to compose it from"
 msgstr ""
 
-#: oc-includes/osclass/installer/gui/install-finish.php:53
+#: oc-includes/osclass/installer/gui/install-finish.php
 msgid "Save this password now — it won't be shown again. We also emailed it to %s."
 msgstr ""
 
-#: oc-admin/themes/modern/settings/billing.php:256
+#: oc-admin/themes/modern/settings/billing.php
 msgid "Save upgrade settings"
 msgstr ""
 
-#: oc-admin/themes/modern/appearance/widgets.php:244
-#: oc-admin/themes/modern/fields/index.php:272
-#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php:433
-#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php:554
-#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php:581
-#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php:607
+#: oc-admin/themes/modern/appearance/widgets.php
+#: oc-admin/themes/modern/fields/index.php
+#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php
 msgid "Saved"
 msgstr ""
 
-#: oc-admin/themes/modern/appearance/widgets.php:243
-#: oc-admin/themes/modern/fields/index.php:271
+#: oc-admin/themes/modern/appearance/widgets.php
+#: oc-admin/themes/modern/fields/index.php
 msgid "Saving…"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:538
-#: oc-admin/themes/modern/tools/system-info.php:545
-#: oc-admin/themes/modern/tools/system-info.php:552
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "Scheduled tasks (cron)"
 msgstr ""
 
-#: oc-admin/themes/modern/appearance/index.php:105
-#: oc-admin/themes/modern/appearance/index.php:146
+#: oc-admin/themes/modern/appearance/index.php
 msgid "Screenshot of the %s theme"
 msgstr ""
 
-#: oc-admin/themes/modern/parts/market.php:545
+#: oc-admin/themes/modern/parts/market.php
 msgid "Screenshots"
 msgstr ""
 
-#: oc-admin/themes/modern/parts/market.php:348
-#: oc-admin/themes/modern/settings/permalinks.php:428
+#: oc-admin/themes/modern/parts/market.php
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid "Search"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:440
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid "Search URL:"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/spamNbots.php:192
+#: oc-admin/themes/modern/settings/spamNbots.php
 msgid "Search alerts"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/spamNbots.php:193
+#: oc-admin/themes/modern/settings/spamNbots.php
 msgid ""
 "Search alerts email visitors when new listings match a saved search. "
 "Requiring login before "
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:203
-#: oc-admin/themes/modern/settings/permalinks.php:204
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid "Search category: this field is required"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:199
-#: oc-admin/themes/modern/settings/permalinks.php:200
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid "Search city area: this field is required"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:195
-#: oc-admin/themes/modern/settings/permalinks.php:196
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid "Search city: this field is required"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:187
-#: oc-admin/themes/modern/settings/permalinks.php:188
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid "Search country: this field is required"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:475
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid "Search keyword category"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:461
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid "Search keyword city"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:468
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid "Search keyword city area"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:447
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid "Search keyword country"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:489
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid "Search keyword pattern"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:454
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid "Search keyword region"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:482
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid "Search keyword user"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/index.php:305
+#: oc-admin/themes/modern/settings/index.php
 msgid "Search page shows"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:211
-#: oc-admin/themes/modern/settings/permalinks.php:212
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid "Search pattern: this field is required"
 msgstr ""
 
-#: oc-admin/themes/modern/parts/market.php:350
+#: oc-admin/themes/modern/parts/market.php
 msgid "Search plugins…"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:430
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid "Search prefix URL:"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:191
-#: oc-admin/themes/modern/settings/permalinks.php:192
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid "Search region: this field is required"
 msgstr ""
 
-#: oc-includes/osclass/classes/Breadcrumb.php:52
-#: oc-includes/osclass/functions.php:170
-#: oc-includes/osclass/functions.php:69
+#: oc-includes/osclass/classes/Breadcrumb.php
+#: oc-includes/osclass/functions.php
 msgid "Search results"
 msgstr ""
 
-#: oc-includes/osclass/classes/Breadcrumb.php:53
+#: oc-includes/osclass/classes/Breadcrumb.php
 msgid "Search results: %s"
 msgstr ""
 
-#: oc-admin/themes/modern/parts/market.php:350
+#: oc-admin/themes/modern/parts/market.php
 msgid "Search themes…"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:183
-#: oc-admin/themes/modern/settings/permalinks.php:184
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid "Search url: this field is required"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:207
-#: oc-admin/themes/modern/settings/permalinks.php:208
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid "Search user: this field is required"
 msgstr ""
 
-#: oc-includes/osclass/classes/form/UserForm.php:425
-#: oc-includes/osclass/classes/form/UserForm.php:476
+#: oc-includes/osclass/classes/form/UserForm.php
 msgid "Second password: enter at least 5 characters"
 msgstr ""
 
-#: oc-includes/osclass/classes/form/UserForm.php:424
+#: oc-includes/osclass/classes/form/UserForm.php
 msgid "Second password: this field is required"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/storage.php:206
+#: oc-admin/themes/modern/settings/storage.php
 msgid "Seconds a signed URL stays valid (60-604800)."
 msgstr ""
 
-#: oc-admin/themes/modern/settings/storage.php:162
+#: oc-admin/themes/modern/settings/storage.php
 msgid "Secret key"
 msgstr ""
 
-#: oc-includes/osclass/classes/datatables/LogsDataTable.php:67
+#: oc-includes/osclass/classes/datatables/LogsDataTable.php
 msgid "Section"
 msgstr ""
 
-#: oc-admin/themes/modern/appearance/widgets.php:78
+#: oc-admin/themes/modern/appearance/widgets.php
 msgid "Sections"
 msgstr ""
 
-#: oc-admin/themes/modern/stats/comments.php:44
+#: oc-admin/themes/modern/stats/comments.php
 msgid "See how many comments the listings published on your site have received."
 msgstr ""
 
-#: oc-admin/themes/modern/stats/reports.php:41
+#: oc-admin/themes/modern/stats/reports.php
 msgid ""
 "See how many listings from your site have been reported as spam, expired, "
 "duplicate, etc."
 msgstr ""
 
-#: oc-includes/osclass/classes/form/FieldForm.php:417
+#: oc-includes/osclass/classes/form/FieldForm.php
 msgid "Select"
 msgstr ""
 
-#: oc-includes/osclass/classes/form/admin/Item.php:221
+#: oc-includes/osclass/classes/form/admin/Item.php
 msgid "Select Currency"
 msgstr ""
 
-#: oc-includes/osclass/classes/form/ItemForm.php:74
-#: oc-includes/osclass/classes/form/ManageItemsForm.php:50
-#: oc-includes/osclass/helpers/hCategories.php:310
+#: oc-includes/osclass/classes/form/ItemForm.php
+#: oc-includes/osclass/classes/form/ManageItemsForm.php
+#: oc-includes/osclass/helpers/hCategories.php
 msgid "Select a category"
 msgstr ""
 
-#: oc-includes/osclass/classes/form/ItemForm.php:1191
+#: oc-includes/osclass/classes/form/ItemForm.php
 msgid "Select a city"
 msgstr ""
 
-#: oc-includes/osclass/classes/form/ItemForm.php:1083
-#: oc-includes/osclass/classes/form/ItemForm.php:634
-#: oc-includes/osclass/classes/form/UserForm.php:316
-#: oc-includes/osclass/classes/form/UserForm.php:514
+#: oc-includes/osclass/classes/form/ItemForm.php
+#: oc-includes/osclass/classes/form/UserForm.php
 msgid "Select a city..."
 msgstr ""
 
-#: oc-includes/osclass/classes/form/ItemForm.php:503
-#: oc-includes/osclass/classes/form/UserForm.php:250
+#: oc-includes/osclass/classes/form/ItemForm.php
+#: oc-includes/osclass/classes/form/UserForm.php
 msgid "Select a country..."
 msgstr ""
 
-#: oc-admin/themes/modern/fields/iframe.php:174
+#: oc-admin/themes/modern/fields/iframe.php
 msgid "Select a field"
 msgstr ""
 
-#: oc-includes/osclass/classes/form/ItemForm.php:1190
+#: oc-includes/osclass/classes/form/ItemForm.php
 msgid "Select a region"
 msgstr ""
 
-#: oc-includes/osclass/classes/form/ItemForm.php:1082
-#: oc-includes/osclass/classes/form/ItemForm.php:587
-#: oc-includes/osclass/classes/form/UserForm.php:285
-#: oc-includes/osclass/classes/form/UserForm.php:513
+#: oc-includes/osclass/classes/form/ItemForm.php
+#: oc-includes/osclass/classes/form/UserForm.php
 msgid "Select a region..."
 msgstr ""
 
-#: oc-admin/themes/modern/settings/index.php:194
+#: oc-admin/themes/modern/settings/index.php
 msgid "Select a timezone..."
 msgstr ""
 
-#: oc-admin/themes/modern/languages/index.php:118
+#: oc-admin/themes/modern/languages/index.php
 msgid "Select an option"
 msgstr ""
 
-#: oc-admin/themes/modern/functions.php:23
-#: oc-includes/osclass/classes/form/ItemForm.php:190
+#: oc-admin/themes/modern/functions.php
+#: oc-includes/osclass/classes/form/ItemForm.php
 msgid "Select category"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/locations.php:163
+#: oc-admin/themes/modern/settings/locations.php
 msgid "Select option"
 msgstr ""
 
-#: oc-admin/themes/modern/functions.php:25
-#: oc-includes/osclass/classes/form/ItemForm.php:193
+#: oc-admin/themes/modern/functions.php
+#: oc-includes/osclass/classes/form/ItemForm.php
 msgid "Select subcategory"
 msgstr ""
 
-#: oc-admin/themes/modern/plugins/configuration.php:70
+#: oc-admin/themes/modern/plugins/configuration.php
 msgid "Select the categories where you want to apply these attribute:"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/iframe.php:233
+#: oc-admin/themes/modern/fields/iframe.php
 msgid "Select the categories where you want to apply this attribute:"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/group_iframe.php:58
+#: oc-admin/themes/modern/fields/group_iframe.php
 msgid "Select the categories where you want to apply this group:"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/billing.php:279
+#: oc-admin/themes/modern/settings/billing.php
 msgid "Sell a raised photo cap"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/billing.php:195
+#: oc-admin/themes/modern/settings/billing.php
 msgid "Sell bump to top"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/billing.php:85
+#: oc-admin/themes/modern/settings/billing.php
 msgid "Sell extra listing slots"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/billing.php:322
+#: oc-admin/themes/modern/settings/billing.php
 msgid "Sell extra runtime beyond the category limit"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/billing.php:108
+#: oc-admin/themes/modern/settings/billing.php
 msgid "Sell featured listings"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/billing.php:217
+#: oc-admin/themes/modern/settings/billing.php
 msgid "Sell highlighting"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/billing.php:238
+#: oc-admin/themes/modern/settings/billing.php
 msgid "Sell marking a listing urgent"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/billing.php:301
+#: oc-admin/themes/modern/settings/billing.php
 msgid "Sell waiving the flood wait"
 msgstr ""
 
-#: oc-includes/osclass/classes/EmailVariables.php:81
+#: oc-includes/osclass/classes/EmailVariables.php
 msgid "Seller email"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/billing.php:267
+#: oc-admin/themes/modern/settings/billing.php
 msgid "Seller limits"
 msgstr ""
 
-#: oc-includes/osclass/classes/EmailVariables.php:80
+#: oc-includes/osclass/classes/EmailVariables.php
 msgid "Seller name"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/billing.php:38
+#: oc-admin/themes/modern/settings/billing.php
 msgid "Selling on this site"
 msgstr ""
 
-#: oc-admin/themes/modern/items/settings.php:191
+#: oc-admin/themes/modern/items/settings.php
 msgid "Send admin a copy of the \"contact publisher\" email"
 msgstr ""
 
-#: oc-admin/themes/modern/items/settings.php:198
+#: oc-admin/themes/modern/items/settings.php
 msgid "Send admin a copy to \"share listing\" email"
 msgstr ""
 
-#: oc-admin/themes/modern/emails/frm.php:172
-#: oc-admin/themes/modern/emails/frm.php:178
+#: oc-admin/themes/modern/emails/frm.php
 msgid "Send email"
 msgstr ""
 
-#: oc-includes/osclass/classes/Breadcrumb.php:50
-#: oc-includes/osclass/functions.php:111
+#: oc-includes/osclass/classes/Breadcrumb.php
+#: oc-includes/osclass/functions.php
 msgid "Send to a friend"
 msgstr ""
 
-#: oc-includes/osclass/helpers/hUtils.php:332
+#: oc-includes/osclass/helpers/hUtils.php
 msgid "Sep"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/iframe.php:97
+#: oc-admin/themes/modern/fields/iframe.php
 msgid "Separate options with commas"
 msgstr ""
 
-#: oc-includes/osclass/helpers/hUtils.php:317
+#: oc-includes/osclass/helpers/hUtils.php
 msgid "September"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/storage.php:196
+#: oc-admin/themes/modern/settings/storage.php
 msgid "Serve files through time-limited signed URLs."
 msgstr ""
 
-#: oc-admin/themes/modern/tools/cache.php:133
+#: oc-admin/themes/modern/tools/cache.php
 msgid "Server"
 msgstr ""
 
-#: oc-includes/osclass/installer/gui/install.php:152
+#: oc-includes/osclass/installer/gui/install.php
 msgid "Server checklist"
 msgstr ""
 
-#: oc-includes/AjaxUploader.php:58
+#: oc-includes/AjaxUploader.php
 msgid "Server error. Upload directory isn't writable."
 msgstr ""
 
-#: oc-admin/themes/modern/settings/mailserver.php:129
+#: oc-admin/themes/modern/settings/mailserver.php
 msgid "Server port"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:718
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid "Server rules (.htaccess)"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:694
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid "Server rules (nginx)"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/mailserver.php:97
+#: oc-admin/themes/modern/settings/mailserver.php
 msgid "Server type"
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:8
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Services"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/base/AdminSecBaseModel.php:114
-#: oc-includes/osclass/classes/controller/base/WebSecBaseModel.php:55
+#: oc-includes/osclass/classes/controller/base/AdminSecBaseModel.php
+#: oc-includes/osclass/classes/controller/base/WebSecBaseModel.php
 msgid "Session timed out"
 msgstr ""
 
-#: oc-admin/themes/modern/items/settings.php:289
+#: oc-admin/themes/modern/items/settings.php
 msgid "Set the API key in Settings -> General."
 msgstr ""
 
-#: oc-includes/osclass/installer/gui/install-target.php:114
+#: oc-includes/osclass/installer/gui/install-target.php
 msgid "Set up my site"
 msgstr ""
 
-#: oc-admin/themes/modern/billing/index.php:104
+#: oc-admin/themes/modern/billing/index.php
 msgid "Set up payments"
 msgstr ""
 
-#: oc-includes/osclass/installer/gui/install-target.php:48
+#: oc-includes/osclass/installer/gui/install-target.php
 msgid "Set up your site"
 msgstr ""
 
-#: oc-includes/osclass/installer/gui/install-target.php:120
+#: oc-includes/osclass/installer/gui/install-target.php
 msgid ""
 "Setting up your site… this can take a minute on shared hosting — don't "
 "close this tab."
 msgstr ""
 
-#: oc-admin/themes/modern/comments/index.php:25
-#: oc-admin/themes/modern/emails/frm.php:19
-#: oc-admin/themes/modern/emails/index.php:17
-#: oc-admin/themes/modern/items/index.php:29
-#: oc-admin/themes/modern/items/settings.php:74
-#: oc-admin/themes/modern/languages/add.php:17
-#: oc-admin/themes/modern/languages/frm.php:18
-#: oc-admin/themes/modern/languages/index.php:17
-#: oc-admin/themes/modern/media/index.php:33
-#: oc-admin/themes/modern/parts/header.php:93
-#: oc-admin/themes/modern/settings/advanced.php:38
-#: oc-admin/themes/modern/settings/billing.php:14
-#: oc-admin/themes/modern/settings/comments.php:70
-#: oc-admin/themes/modern/settings/currency_form.php:52
-#: oc-admin/themes/modern/settings/index.php:100
-#: oc-admin/themes/modern/settings/keywordBlock.php:14
-#: oc-admin/themes/modern/settings/keywordBlock_frm.php:39
-#: oc-admin/themes/modern/settings/mailserver.php:78
-#: oc-admin/themes/modern/settings/permalinks.php:349
-#: oc-admin/themes/modern/settings/searches.php:64
-#: oc-admin/themes/modern/settings/sitemap.php:14
-#: oc-admin/themes/modern/settings/spamNbots.php:25
-#: oc-admin/themes/modern/settings/storage.php:79
-#: oc-admin/themes/modern/tools/system-info.php:403
-#: oc-admin/themes/modern/tools/system-info.php:488
-#: oc-admin/themes/modern/users/ban.php:29
-#: oc-admin/themes/modern/users/index.php:30
-#: oc-admin/themes/modern/users/settings.php:32
-#: oc-includes/osclass/classes/AdminMenu.php:139
-#: oc-includes/osclass/classes/AdminMenu.php:155
-#: oc-includes/osclass/classes/AdminMenu.php:223
-#: oc-includes/osclass/classes/AdminMenu.php:321
-#: oc-includes/osclass/classes/AdminMenu.php:98
+#: oc-admin/themes/modern/comments/index.php
+#: oc-admin/themes/modern/emails/frm.php
+#: oc-admin/themes/modern/emails/index.php
+#: oc-admin/themes/modern/items/index.php
+#: oc-admin/themes/modern/items/settings.php
+#: oc-admin/themes/modern/languages/add.php
+#: oc-admin/themes/modern/languages/frm.php
+#: oc-admin/themes/modern/languages/index.php
+#: oc-admin/themes/modern/media/index.php
+#: oc-admin/themes/modern/parts/header.php
+#: oc-admin/themes/modern/settings/advanced.php
+#: oc-admin/themes/modern/settings/billing.php
+#: oc-admin/themes/modern/settings/comments.php
+#: oc-admin/themes/modern/settings/currency_form.php
+#: oc-admin/themes/modern/settings/index.php
+#: oc-admin/themes/modern/settings/keywordBlock.php
+#: oc-admin/themes/modern/settings/keywordBlock_frm.php
+#: oc-admin/themes/modern/settings/mailserver.php
+#: oc-admin/themes/modern/settings/permalinks.php
+#: oc-admin/themes/modern/settings/searches.php
+#: oc-admin/themes/modern/settings/sitemap.php
+#: oc-admin/themes/modern/settings/spamNbots.php
+#: oc-admin/themes/modern/settings/storage.php
+#: oc-admin/themes/modern/tools/system-info.php
+#: oc-admin/themes/modern/users/ban.php
+#: oc-admin/themes/modern/users/index.php
+#: oc-admin/themes/modern/users/settings.php
+#: oc-includes/osclass/classes/AdminMenu.php
 msgid "Settings"
 msgstr ""
 
-#: oc-admin/themes/modern/billing/order.php:151
+#: oc-admin/themes/modern/billing/order.php
 msgid "Settle this order"
 msgstr ""
 
-#: oc-includes/osclass/install-functions.php:722
+#: oc-includes/osclass/install-functions.php
 msgid ""
 "Setup could not finish writing its initial settings. Nothing partial was "
 "saved "
 msgstr ""
 
-#: oc-includes/osclass/install-functions.php:656
+#: oc-includes/osclass/install-functions.php
 msgid "Setup couldn't save the site language. The database user may not be able to "
 msgstr ""
 
-#: oc-admin/themes/modern/items/settings.php:162
+#: oc-admin/themes/modern/items/settings.php
 msgid "Share listing"
 msgstr ""
 
-#: oc-includes/osclass/functions.php:560
+#: oc-includes/osclass/functions.php
 msgid "Shopclass "
 msgstr ""
 
-#: oc-admin/themes/modern/tools/version.php:18
+#: oc-admin/themes/modern/tools/version.php
 msgid "Shopclass %s"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/version.php:22
+#: oc-admin/themes/modern/tools/version.php
 msgid "Shopclass %s &raquo; %s"
 msgstr ""
 
-#: oc-includes/osclass/classes/upgrade/Osclass.php:123
+#: oc-includes/osclass/classes/upgrade/Osclass.php
 msgid "Shopclass &raquo; Has some errors"
 msgstr ""
 
-#: oc-includes/osclass/classes/upgrade/Osclass.php:169
+#: oc-includes/osclass/classes/upgrade/Osclass.php
 msgid "Shopclass DB Upgraded Successfully"
 msgstr ""
 
-#: oc-includes/osclass/installer/gui/install.php:55
+#: oc-includes/osclass/installer/gui/install.php
 msgid "Shopclass Installation"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/cache.php:84
+#: oc-admin/themes/modern/tools/cache.php
 msgid ""
 "Shopclass caches with %s. A cache only ever holds copies — clearing it is "
 "safe, and the site rebuilds what it needs on the next request."
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:444
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "Shopclass can write to %s."
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:445
+#: oc-admin/themes/modern/tools/system-info.php
 msgid ""
 "Shopclass cannot write to %s, so no photo or file upload can be saved. Fix "
 "the folder permissions so the web server user can write to it."
 msgstr ""
 
-#: oc-admin/themes/modern/settings/media.php:415
+#: oc-admin/themes/modern/settings/media.php
 msgid "Shopclass doesn't check the watermark image size"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:530
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "Shopclass health"
 msgstr ""
 
-#: oc-includes/osclass/installer/gui/install.php:71
+#: oc-includes/osclass/installer/gui/install.php
 msgid "Shopclass is already installed here."
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:481
+#: oc-admin/themes/modern/tools/system-info.php
 msgid ""
 "Shopclass lets a seller attach %1$s photos to a listing, but PHP accepts "
 "only %2$s files per request and drops the rest. Raise %3$s to at least %4$s."
 msgstr ""
 
-#: oc-admin/themes/modern/settings/billing.php:353
+#: oc-admin/themes/modern/settings/billing.php
 msgid "Shopclass never handles card details itself. To take payments, install a "
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:494
+#: oc-admin/themes/modern/tools/system-info.php
 msgid ""
 "Shopclass offers %1$s photos per listing; PHP accepts %2$s files per "
 "request."
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:360
+#: oc-admin/themes/modern/tools/system-info.php
 msgid ""
 "Shopclass runs, but PHP 7.x is past end of life and no longer gets security "
 "fixes. Shopclass targets PHP 8.0 and up — move to PHP 8."
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php:1030
+#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php
 msgid "Shopclass upgraded successfully."
 msgstr ""
 
-#: oc-admin/themes/modern/main/index.php:277
-#: oc-admin/themes/modern/tools/system-info.php:631
+#: oc-admin/themes/modern/main/index.php
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "Shopclass version"
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:54
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Shops for Rent - Sale"
 msgstr ""
 
-#: oc-admin/themes/modern/languages/frm.php:55
-#: oc-admin/themes/modern/languages/index.php:60
-#: oc-admin/themes/modern/languages/index.php:76
+#: oc-admin/themes/modern/languages/frm.php
+#: oc-admin/themes/modern/languages/index.php
 msgid "Short name"
 msgstr ""
 
-#: oc-includes/osclass/classes/form/LanguageForm.php:197
+#: oc-includes/osclass/classes/form/LanguageForm.php
 msgid "Short name: this field is required"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/maintenance.php:30
+#: oc-admin/themes/modern/tools/maintenance.php
 msgid ""
 "Show a \"Site in maintenance mode\" message to your users while you're "
 "updating your site or modifying its configuration."
 msgstr ""
 
-#: oc-admin/themes/modern/pages/frm.php:368
+#: oc-admin/themes/modern/pages/frm.php
 msgid "Show a link in the footer"
 msgstr ""
 
-#: oc-includes/osclass/functions.php:147
+#: oc-includes/osclass/functions.php
 msgid "Show all listings"
 msgstr ""
 
-#: oc-admin/themes/modern/items/frm.php:252
+#: oc-admin/themes/modern/items/frm.php
 msgid "Show e-mail"
 msgstr ""
 
-#: oc-admin/themes/modern/items/index.php:126
-#: oc-admin/themes/modern/users/index.php:99
+#: oc-admin/themes/modern/items/index.php
+#: oc-admin/themes/modern/users/index.php
 msgid "Show filters"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/iframe.php:165
+#: oc-admin/themes/modern/fields/iframe.php
 msgid "Show only when…"
 msgstr ""
 
-#: oc-includes/osclass/installer/gui/install-database.php:62
-#: oc-includes/osclass/installer/gui/install-finish.php:77
-#: oc-includes/osclass/installer/gui/install-target.php:72
-#: oc-includes/osclass/installer/gui/install.php:44
+#: oc-includes/osclass/installer/gui/install-database.php
+#: oc-includes/osclass/installer/gui/install-finish.php
+#: oc-includes/osclass/installer/gui/install-target.php
+#: oc-includes/osclass/installer/gui/install.php
 msgid "Show password"
 msgstr ""
 
-#: oc-admin/themes/modern/items/settings.php:138
+#: oc-admin/themes/modern/items/settings.php
 msgid "Show reCAPTCHA in add/edit listing form"
 msgstr ""
 
-#: oc-admin/themes/modern/categories/index.php:77
+#: oc-admin/themes/modern/categories/index.php
 msgid "Show subcategories"
 msgstr ""
 
-#: oc-admin/themes/modern/upgrade/index.php:55
+#: oc-admin/themes/modern/upgrade/index.php
 msgid "Show technical detail"
 msgstr ""
 
-#: oc-admin/themes/modern/categories/iframe.php:41
+#: oc-admin/themes/modern/categories/iframe.php
 msgid "Show the price field on listings in this category"
 msgstr ""
 
-#: oc-includes/osclass/helpers/hPagination.php:215
+#: oc-includes/osclass/helpers/hPagination.php
 msgid "Showing %s to %s of %s results"
 msgstr ""
 
-#: oc-includes/osclass/helpers/hPagination.php:207
+#: oc-includes/osclass/helpers/hPagination.php
 msgid "Showing %s to %s of %s results (filtered from %s total results)"
 msgstr ""
 
-#: oc-admin/themes/modern/parts/header.php:96
+#: oc-admin/themes/modern/parts/header.php
 msgid "Sign out"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/spamNbots.php:216
+#: oc-admin/themes/modern/settings/spamNbots.php
 msgid "Sign-in protection"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/storage.php:202
+#: oc-admin/themes/modern/settings/storage.php
 msgid "Signed URL TTL"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/storage.php:191
+#: oc-admin/themes/modern/settings/storage.php
 msgid "Signed URLs"
 msgstr ""
 
-#: oc-includes/osclass/classes/AdminMenu.php:322
+#: oc-includes/osclass/classes/AdminMenu.php
 msgid "Site"
 msgstr ""
 
-#: oc-includes/osclass/installer/gui/install-target.php:80
+#: oc-includes/osclass/installer/gui/install-target.php
 msgid "Site details"
 msgstr ""
 
-#: oc-includes/osclass/classes/EmailVariables.php:47
+#: oc-includes/osclass/classes/EmailVariables.php
 msgid "Site home page link."
 msgstr ""
 
-#: oc-includes/osclass/classes/EmailVariables.php:46
+#: oc-includes/osclass/classes/EmailVariables.php
 msgid "Site home page url."
 msgstr ""
 
-#: oc-admin/themes/modern/settings/sitemap.php:15
-#: oc-admin/themes/modern/settings/sitemap.php:46
-#: oc-includes/osclass/classes/AdminMenu.php:346
+#: oc-admin/themes/modern/settings/sitemap.php
+#: oc-includes/osclass/classes/AdminMenu.php
 msgid "Sitemap"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/sitemap.php:55
+#: oc-admin/themes/modern/settings/sitemap.php
 msgid "Sitemap settings"
 msgstr ""
 
-#: oc-admin/themes/modern/media/index.php:292
-#: oc-admin/themes/modern/media/index.php:351
-#: oc-admin/themes/modern/parts/market.php:574
+#: oc-admin/themes/modern/media/index.php
+#: oc-admin/themes/modern/parts/market.php
 msgid "Size"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/media.php:207
+#: oc-admin/themes/modern/settings/media.php
 msgid "Size in KB"
 msgstr ""
 
-#: oc-includes/osclass/installer/gui/install-target.php:98
+#: oc-includes/osclass/installer/gui/install-target.php
 msgid "Skip for now"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/billing.php:297
+#: oc-admin/themes/modern/settings/billing.php
 msgid "Skip the posting wait"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/billing.php:92
+#: oc-admin/themes/modern/settings/billing.php
 msgid "Slot price in credits"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/billing.php:98
+#: oc-admin/themes/modern/settings/billing.php
 msgid "Slots per purchase"
 msgstr ""
 
-#: oc-admin/themes/modern/pages/frm.php:348
-#: oc-admin/themes/modern/settings/locations.php:164
-#: oc-includes/osclass/classes/form/CategoryForm.php:213
+#: oc-admin/themes/modern/pages/frm.php
+#: oc-admin/themes/modern/settings/locations.php
+#: oc-includes/osclass/classes/form/CategoryForm.php
 msgid "Slug"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/index.php:376
+#: oc-admin/themes/modern/settings/index.php
 msgid "Software updates"
 msgstr ""
 
-#: oc-includes/osclass/installer/gui/install-finish.php:42
+#: oc-includes/osclass/installer/gui/install-finish.php
 msgid "Some sample content couldn't be added. Your site will still work fine."
 msgstr ""
 
-#: oc-includes/osclass/installer/gui/install.php:46
+#: oc-includes/osclass/installer/gui/install.php
 msgid "Something went wrong. Check your connection and try again."
 msgstr ""
 
-#: oc-admin/themes/modern/categories/index.php:159
-#: oc-admin/themes/modern/parts/market.php:606
+#: oc-admin/themes/modern/categories/index.php
+#: oc-admin/themes/modern/parts/market.php
 msgid "Something went wrong. Please try again."
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php:779
+#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php
 msgid "Sorry, including at least a title is mandatory"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php:425
+#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php
 msgid "Sorry, you already have a field with that name"
 msgstr ""
 
-#: oc-includes/osclass/classes/form/ItemForm.php:1373
+#: oc-includes/osclass/classes/form/ItemForm.php
 msgid "Sorry, you have reached the maximum number of images per listing"
 msgstr ""
 
-#: oc-admin/themes/modern/parts/market.php:362
+#: oc-admin/themes/modern/parts/market.php
 msgid "Sort"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/submissions.php:132
-#: oc-admin/themes/modern/fields/submissions.php:192
+#: oc-admin/themes/modern/fields/submissions.php
 msgid "Source"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:515
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "Space left on the uploads volume."
 msgstr ""
 
-#: oc-admin/themes/modern/fields/submissions.php:37
-#: oc-admin/themes/modern/items/index.php:314
-#: oc-admin/themes/modern/stats/reports.php:65
-#: oc-includes/osclass/classes/datatables/ItemsDataTable.php:443
-#: oc-includes/osclass/classes/datatables/ItemsDataTable.php:651
-#: oc-includes/osclass/functions.php:536
+#: oc-admin/themes/modern/fields/submissions.php
+#: oc-admin/themes/modern/items/index.php
+#: oc-admin/themes/modern/stats/reports.php
+#: oc-includes/osclass/classes/datatables/ItemsDataTable.php
+#: oc-includes/osclass/functions.php
 msgid "Spam"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/spamNbots.php:26
-#: oc-admin/themes/modern/settings/spamNbots.php:33
-#: oc-includes/osclass/classes/AdminMenu.php:361
+#: oc-admin/themes/modern/settings/spamNbots.php
+#: oc-includes/osclass/classes/AdminMenu.php
 msgid "Spam and bots"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/cleanup.php:26
+#: oc-admin/themes/modern/tools/cleanup.php
 msgid "Spam listings"
 msgstr ""
 
-#: oc-admin/themes/modern/billing/order.php:46
-#: oc-admin/themes/modern/billing/wallet.php:32
+#: oc-admin/themes/modern/billing/order.php
+#: oc-admin/themes/modern/billing/wallet.php
 msgid "Spent"
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:29
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Sporting Goods - Bicycles"
 msgstr ""
 
-#: oc-admin/themes/modern/pages/index.php:98
+#: oc-admin/themes/modern/pages/index.php
 msgid "Static pages like \"About Us\" or \"Info\" live here."
 msgstr ""
 
-#: oc-admin/themes/modern/main/index.php:241
-#: oc-admin/themes/modern/stats/comments.php:42
-#: oc-admin/themes/modern/stats/items.php:50
-#: oc-admin/themes/modern/stats/reports.php:39
-#: oc-admin/themes/modern/stats/users.php:45
-#: oc-admin/themes/modern/tools/category.php:26
-#: oc-admin/themes/modern/tools/locations.php:76
-#: oc-includes/osclass/classes/AdminMenu.php:231
+#: oc-admin/themes/modern/main/index.php
+#: oc-admin/themes/modern/stats/comments.php
+#: oc-admin/themes/modern/stats/items.php
+#: oc-admin/themes/modern/stats/reports.php
+#: oc-admin/themes/modern/stats/users.php
+#: oc-admin/themes/modern/tools/category.php
+#: oc-admin/themes/modern/tools/locations.php
+#: oc-includes/osclass/classes/AdminMenu.php
 msgid "Statistics"
 msgstr ""
 
-#: oc-admin/themes/modern/billing/index.php:118
-#: oc-admin/themes/modern/billing/index.php:54
-#: oc-admin/themes/modern/billing/order.php:54
-#: oc-admin/themes/modern/billing/packages.php:44
-#: oc-admin/themes/modern/comments/frm.php:80
-#: oc-admin/themes/modern/comments/frm.php:92
-#: oc-admin/themes/modern/fields/submissions.php:102
-#: oc-admin/themes/modern/fields/submissions.php:129
-#: oc-admin/themes/modern/fields/submissions.php:156
-#: oc-admin/themes/modern/plugins/index.php:124
-#: oc-admin/themes/modern/plugins/index.php:96
-#: oc-admin/themes/modern/settings/billing.php:368
-#: oc-admin/themes/modern/tools/cache.php:152
-#: oc-admin/themes/modern/tools/cache.php:175
-#: oc-includes/osclass/classes/datatables/CommentsDataTable.php:81
-#: oc-includes/osclass/classes/datatables/ItemsDataTable.php:84
-#: oc-includes/osclass/classes/datatables/UsersDataTable.php:73
+#: oc-admin/themes/modern/billing/index.php
+#: oc-admin/themes/modern/billing/order.php
+#: oc-admin/themes/modern/billing/packages.php
+#: oc-admin/themes/modern/comments/frm.php
+#: oc-admin/themes/modern/fields/submissions.php
+#: oc-admin/themes/modern/plugins/index.php
+#: oc-admin/themes/modern/settings/billing.php
+#: oc-admin/themes/modern/tools/cache.php
+#: oc-includes/osclass/classes/datatables/CommentsDataTable.php
+#: oc-includes/osclass/classes/datatables/ItemsDataTable.php
+#: oc-includes/osclass/classes/datatables/UsersDataTable.php
 msgid "Status"
 msgstr ""
 
-#: oc-admin/themes/modern/stats/users.php:47
+#: oc-admin/themes/modern/stats/users.php
 msgid ""
 "Stay up-to-date on the number of users registered on your site. You can "
 "also see a breakdown of the "
 msgstr ""
 
-#: oc-admin/themes/modern/settings/billing.php:159
+#: oc-admin/themes/modern/settings/billing.php
 msgid "Stays hidden at checkout until instructions are written below — "
 msgstr ""
 
-#: oc-admin/themes/modern/fields/iframe.php:135
+#: oc-admin/themes/modern/fields/iframe.php
 msgid "Step"
 msgstr ""
 
-#: oc-admin/themes/modern/languages/frm.php:103
+#: oc-admin/themes/modern/languages/frm.php
 msgid "Stopwords"
 msgstr ""
 
-#: oc-includes/osclass/classes/AdminMenu.php:398
+#: oc-includes/osclass/classes/AdminMenu.php
 msgid "Storage"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/storage.php:80
-#: oc-admin/themes/modern/settings/storage.php:87
+#: oc-admin/themes/modern/settings/storage.php
 msgid "Storage Settings"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/storage.php:239
+#: oc-admin/themes/modern/settings/storage.php
 msgid "Storage queue"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/searches.php:141
+#: oc-admin/themes/modern/settings/searches.php
 msgid "Store %s queries"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/searches.php:130
+#: oc-admin/themes/modern/settings/searches.php
 msgid "Store 1000 queries"
 msgstr ""
 
-#: oc-admin/themes/modern/categories/index.php:87
+#: oc-admin/themes/modern/categories/index.php
 msgid "Subcategories"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/advanced.php:57
+#: oc-admin/themes/modern/settings/advanced.php
 msgid "Subdomain type"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebContact.php:80
+#: oc-includes/osclass/classes/controller/CWebContact.php
 msgid "Subject: %s"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/submissions.php:131
-#: oc-admin/themes/modern/fields/submissions.php:176
+#: oc-admin/themes/modern/fields/submissions.php
 msgid "Submission"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/submissions.php:80
-#: oc-admin/themes/modern/fields/submissions.php:87
-#: oc-includes/osclass/classes/AdminMenu.php:182
+#: oc-admin/themes/modern/fields/submissions.php
+#: oc-includes/osclass/classes/AdminMenu.php
 msgid "Submissions"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/backup.php:67
-#: oc-includes/osclass/helpers/hForms.php:71
+#: oc-admin/themes/modern/tools/backup.php
+#: oc-includes/osclass/helpers/hForms.php
 msgid "Submit"
 msgstr ""
 
-#: oc-admin/themes/modern/stats/items.php:99
+#: oc-admin/themes/modern/stats/items.php
 msgid "Subscribers"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/keywordBlock_frm.php:87
-#: oc-includes/osclass/classes/datatables/KeywordBlocksDataTable.php:136
+#: oc-admin/themes/modern/settings/keywordBlock_frm.php
+#: oc-includes/osclass/classes/datatables/KeywordBlocksDataTable.php
 msgid "Substring"
 msgstr ""
 
-#: oc-includes/osclass/helpers/hUtils.php:347
+#: oc-includes/osclass/helpers/hUtils.php
 msgid "Sun"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/index.php:167
-#: oc-includes/osclass/helpers/hUtils.php:345
+#: oc-admin/themes/modern/settings/index.php
+#: oc-includes/osclass/helpers/hUtils.php
 msgid "Sunday"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:358
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "Supported."
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:284
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "Switch debugging on"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/billing.php:16
+#: oc-admin/themes/modern/settings/billing.php
 msgid "Switch on the billing section, and see which payment plugins are installed. "
 msgstr ""
 
-#: oc-admin/themes/modern/parts/footer.php:79
+#: oc-admin/themes/modern/parts/footer.php
 msgid "Switch to dark mode"
 msgstr ""
 
-#: oc-admin/themes/modern/parts/footer.php:79
+#: oc-admin/themes/modern/parts/footer.php
 msgid "Switch to light mode"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/billing.php:44
+#: oc-admin/themes/modern/settings/billing.php
 msgid "Switching this off later hides the Billing menu but keeps every order "
 msgstr ""
 
-#: oc-includes/osclass/classes/AdminMenu.php:395
+#: oc-includes/osclass/classes/AdminMenu.php
 msgid "System"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:142
-#: oc-admin/themes/modern/tools/system-info.php:154
-#: oc-includes/osclass/classes/AdminMenu.php:475
+#: oc-admin/themes/modern/tools/system-info.php
+#: oc-includes/osclass/classes/AdminMenu.php
 msgid "System info"
 msgstr ""
 
-#: oc-admin/themes/modern/main/index.php:263
+#: oc-admin/themes/modern/main/index.php
 msgid "System status"
 msgstr ""
 
-#: oc-includes/osclass/installer/gui/install-database.php:74
+#: oc-includes/osclass/installer/gui/install-database.php
 msgid "Table prefix"
 msgstr ""
 
-#: oc-admin/themes/modern/billing/wallet.php:153
+#: oc-admin/themes/modern/billing/wallet.php
 msgid "Take credits back off this account. You can add them again afterwards, and "
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:97
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Technology"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/storage.php:234
-#: oc-includes/osclass/installer/gui/install-database.php:106
+#: oc-admin/themes/modern/settings/storage.php
+#: oc-includes/osclass/installer/gui/install-database.php
 msgid "Test connection"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php:824
+#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php
 msgid "Test email"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php:823
+#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php
 msgid "Test email, %s"
 msgstr ""
 
-#: oc-admin/themes/modern/emails/frm.php:148
+#: oc-admin/themes/modern/emails/frm.php
 msgid "Test it"
 msgstr ""
 
-#: oc-admin/themes/modern/parts/market.php:573
+#: oc-admin/themes/modern/parts/market.php
 msgid "Tested up to"
 msgstr ""
 
-#: oc-includes/osclass/installer/gui/install.php:41
+#: oc-includes/osclass/installer/gui/install.php
 msgid "Testing…"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/index.php:681
-#: oc-admin/themes/modern/settings/media.php:248
+#: oc-admin/themes/modern/fields/index.php
+#: oc-admin/themes/modern/settings/media.php
 msgid "Text"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/media.php:342
+#: oc-admin/themes/modern/settings/media.php
 msgid "Text Color"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/media.php:328
+#: oc-admin/themes/modern/settings/media.php
 msgid "Text offset_x"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/media.php:335
+#: oc-admin/themes/modern/settings/media.php
 msgid "Text offset_y"
 msgstr ""
 
-#: oc-admin/themes/modern/functions.php:97
+#: oc-admin/themes/modern/functions.php
 msgid "Thank you for using <a href=\"%s\" target=\"_blank\">Shopclass</a>"
 msgstr ""
 
-#: oc-includes/osclass/install-functions.php:308
+#: oc-includes/osclass/install-functions.php
 msgid ""
 "That user connected, but isn't allowed to use the database %s. In your "
 "hosting "
 msgstr ""
 
-#: oc-admin/themes/modern/parts/market.php:299
+#: oc-admin/themes/modern/parts/market.php
 msgid ""
 "The %s directory isn't writable, so packages can't be installed from here. "
 "Make it writable and reload this page."
 msgstr ""
 
-#: oc-includes/osclass/install-functions.php:1104
+#: oc-includes/osclass/install-functions.php
 msgid "The <a href=\"https://github.com/mindstellar/shopclass\">Shopclass</a> team"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/storage.php:91
+#: oc-admin/themes/modern/settings/storage.php
 msgid ""
 "The <strong>Better S3</strong> plugin is currently active. Disable it "
 "before turning on "
 msgstr ""
 
-#: oc-admin/themes/modern/settings/spamNbots.php:220
+#: oc-admin/themes/modern/settings/spamNbots.php
 msgid ""
 "The account limit is skipped while a captcha provider is configured above, "
 "because every "
 msgstr ""
 
-#: oc-includes/osclass/install-location.php:89
+#: oc-includes/osclass/install-location.php
 msgid ""
 "The admin account could not be created. Nothing was saved — please try "
 "again."
 msgstr ""
 
-#: oc-includes/osclass/install-location.php:68
+#: oc-includes/osclass/install-location.php
 msgid "The admin username may only contain letters and numbers."
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php:1406
+#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php
 msgid ""
 "The available version has changed since you loaded this page; refresh and "
 "try again."
 msgstr ""
 
-#: oc-includes/osclass/classes/market/Installer.php:144
+#: oc-includes/osclass/classes/market/Installer.php
 msgid "The catalog entry is missing a version or a download url."
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php:705
+#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php
 msgid "The categories have been deleted"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php:666
+#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php
 msgid "The category as well as its subcategories have been disabled"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php:662
+#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php
 msgid "The category as well as its subcategories have been enabled"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:256
+#: oc-admin/themes/modern/tools/system-info.php
 msgid ""
 "The cheapest speed-up there is — PHP stops recompiling every file on every "
 "request."
 msgstr ""
 
-#: oc-admin/themes/modern/tools/cache.php:77
+#: oc-admin/themes/modern/tools/cache.php
 msgid ""
 "The current cache holds nothing between requests, so there is nothing to "
 "clear."
 msgstr ""
 
-#: oc-admin/themes/modern/appearance/widgets.php:70
+#: oc-admin/themes/modern/appearance/widgets.php
 msgid "The current theme does not declare any widget sections."
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php:448
+#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php
 msgid "The custom field has been deleted"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/logs.php:64
+#: oc-admin/themes/modern/tools/logs.php
 msgid ""
 "The daily task deletes entries older than this. Set to 0 to keep them "
 "forever."
 msgstr ""
 
-#: oc-includes/osclass/installer/gui/install-database.php:49
+#: oc-includes/osclass/installer/gui/install-database.php
 msgid "The database Shopclass should use."
 msgstr ""
 
-#: oc-includes/osclass/install-functions.php:345
+#: oc-includes/osclass/install-functions.php
 msgid ""
 "The database returned an unexpected error (code %s). Your hosting support "
 "will "
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php:1250
+#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php
 msgid ""
 "The database schema had drifted and %d difference(s) were repaired during "
 "the upgrade."
 msgstr ""
 
-#: oc-includes/osclass/install-functions.php:301
+#: oc-includes/osclass/install-functions.php
 msgid "The database server rejected that username and password. Re-copy them from "
 msgstr ""
 
-#: oc-includes/osclass/classes/market/Installer.php:244
+#: oc-includes/osclass/classes/market/Installer.php
 msgid "The downloads directory could not be created."
 msgstr ""
 
-#: oc-includes/osclass/classes/market/Installer.php:247
+#: oc-includes/osclass/classes/market/Installer.php
 msgid "The downloads directory is not writable."
 msgstr ""
 
-#: oc-includes/osclass/classes/market/Installer.php:240
+#: oc-includes/osclass/classes/market/Installer.php
 msgid "The existing package directory is not writable."
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php:564
+#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php
 msgid "The field group has been deleted"
 msgstr ""
 
-#: oc-includes/osclass/install-functions.php:670
-#: oc-includes/osclass/install-functions.php:693
+#: oc-includes/osclass/install-functions.php
 msgid "The file %s doesn't exist"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php:177
+#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php
 msgid "The file is not a valid image"
 msgstr ""
 
-#: oc-includes/osclass/classes/market/Installer.php:236
+#: oc-includes/osclass/classes/market/Installer.php
 msgid "The installation directory is not writable."
 msgstr ""
 
-#: oc-admin/themes/modern/settings/spamNbots.php:59
+#: oc-admin/themes/modern/settings/spamNbots.php
 msgid "The key you entered is invalid. Please double-check it"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:546
+#: oc-admin/themes/modern/tools/system-info.php
 msgid ""
 "The last cron run was %s ago — longer than a day, so it is probably no "
 "longer scheduled. Update checks, alerts and cleanup have stopped until it "
 "runs again."
 msgstr ""
 
-#: oc-admin/themes/modern/tools/cache.php:36
+#: oc-admin/themes/modern/tools/cache.php
 msgid "The older memcache extension."
 msgstr ""
 
-#: oc-includes/osclass/classes/market/Installer.php:209
+#: oc-includes/osclass/classes/market/Installer.php
 msgid "The package archive is invalid or unsafe."
 msgstr ""
 
-#: oc-includes/osclass/classes/market/Installer.php:266
+#: oc-includes/osclass/classes/market/Installer.php
 msgid "The package archive must contain exactly one top-level directory."
 msgstr ""
 
-#: oc-includes/osclass/classes/market/Installer.php:293
+#: oc-includes/osclass/classes/market/Installer.php
 msgid "The package header declares version %1$s, but the catalog entry is for %2$s."
 msgstr ""
 
-#: oc-includes/osclass/classes/market/Installer.php:281
+#: oc-includes/osclass/classes/market/Installer.php
 msgid "The package is missing its index.php."
 msgstr ""
 
-#: oc-includes/osclass/classes/market/Installer.php:338
+#: oc-includes/osclass/classes/market/Installer.php
 msgid "The package swap did not produce a valid package directory."
 msgstr ""
 
-#: oc-includes/osclass/classes/market/Installer.php:286
+#: oc-includes/osclass/classes/market/Installer.php
 msgid "The package's index.php has no parseable Version header."
 msgstr ""
 
-#: oc-includes/osclass/classes/market/Installer.php:274
+#: oc-includes/osclass/classes/market/Installer.php
 msgid "The package's top-level directory must be named \"%s\"."
 msgstr ""
 
-#: oc-admin/themes/modern/plugins/add.php:50
+#: oc-admin/themes/modern/plugins/add.php
 msgid "The plugin folder is not writable on your server so you cannot upload "
 msgstr ""
 
-#: oc-admin/themes/modern/settings/index.php:56
+#: oc-admin/themes/modern/settings/index.php
 msgid "The search page shows: this field is required"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/index.php:57
+#: oc-admin/themes/modern/settings/index.php
 msgid "The search page shows: this field must only contain numeric characters"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:181
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "The server clock zone used for listing and stat dates."
 msgstr ""
 
-#: oc-admin/themes/modern/languages/index.php:134
+#: oc-admin/themes/modern/languages/index.php
 msgid ""
 "The site falls back to the default language for any content that relied on "
 "this one."
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:608
+#: oc-admin/themes/modern/tools/system-info.php
 msgid ""
 "The site is in maintenance mode — visitors see the maintenance page. Remove "
 "the %s file to bring it back."
 msgstr ""
 
-#: oc-admin/themes/modern/settings/sitemap.php:49
+#: oc-admin/themes/modern/settings/sitemap.php
 msgid ""
 "The sitemap index is served at %s and always reflects the current site "
 "content."
 msgstr ""
 
-#: oc-admin/themes/modern/settings/sitemap.php:203
+#: oc-admin/themes/modern/settings/sitemap.php
 msgid ""
 "The sitemap is cached for a few hours after it is first requested. Use this "
 "if you need "
 msgstr ""
 
-#: oc-admin/themes/modern/settings/media.php:133
+#: oc-admin/themes/modern/settings/media.php
 msgid ""
 "The sizes listed below determine the maximum dimensions in pixels to use "
 "when uploading a image."
 msgstr ""
 
-#: oc-admin/themes/modern/settings/locations.php:166
+#: oc-admin/themes/modern/settings/locations.php
 msgid "The slug has to be a unique string, could be left blank"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/locations.php:165
+#: oc-admin/themes/modern/settings/locations.php
 msgid "The slug is not unique."
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php:689
+#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php
 msgid "The subcategory has been disabled"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php:685
+#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php
 msgid "The subcategory has been enabled"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php:612
+#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php
 msgid "The submission has been deleted"
 msgstr ""
 
-#: oc-includes/osclass/install-functions.php:528
+#: oc-includes/osclass/install-functions.php
 msgid "The table prefix can only contain letters, numbers and underscores."
 msgstr ""
 
-#: oc-admin/themes/modern/appearance/add.php:50
+#: oc-admin/themes/modern/appearance/add.php
 msgid ""
 "The theme folder is not writable on your server so you can't upload themes "
 "from "
 msgstr ""
 
-#: oc-admin/themes/modern/languages/add.php:48
+#: oc-admin/themes/modern/languages/add.php
 msgid "The translations folder is not writable on your server "
 msgstr ""
 
-#: oc-admin/themes/modern/upgrade/index.php:43
+#: oc-admin/themes/modern/upgrade/index.php
 msgid "The upgrade did not finish"
 msgstr ""
 
-#: oc-includes/osclass/install-functions.php:338
+#: oc-includes/osclass/install-functions.php
 msgid "The user connected, but isn't allowed to write to this database. Grant it "
 msgstr ""
 
-#: oc-admin/themes/modern/users/frm.php:159
+#: oc-admin/themes/modern/users/frm.php
 msgid "The username is NOT available"
 msgstr ""
 
-#: oc-admin/themes/modern/users/frm.php:158
+#: oc-admin/themes/modern/users/frm.php
 msgid "The username is available"
 msgstr ""
 
-#: oc-admin/themes/modern/pages/frm.php:208
+#: oc-admin/themes/modern/pages/frm.php
 msgid "The widgets below make up this page. Widgets can also appear in your"
 msgstr ""
 
-#: oc-admin/themes/modern/appearance/add.php:35
+#: oc-admin/themes/modern/appearance/add.php
 msgid "Theme package (.zip)"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/index.php:407
-#: oc-includes/osclass/functions.php:716
+#: oc-admin/themes/modern/settings/index.php
+#: oc-includes/osclass/functions.php
 msgid "Theme updates"
 msgstr ""
 
-#: oc-admin/themes/modern/appearance/index.php:83
+#: oc-admin/themes/modern/appearance/index.php
 msgid "Themes"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:661
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "Themes path"
 msgstr ""
 
-#: oc-admin/themes/modern/parts/market.php:608
+#: oc-admin/themes/modern/parts/market.php
 msgid "Themes updated."
 msgstr ""
 
-#: oc-admin/themes/modern/stats/comments.php:124
-#: oc-admin/themes/modern/stats/comments.php:166
-#: oc-admin/themes/modern/stats/items.php:197
-#: oc-admin/themes/modern/stats/items.php:212
-#: oc-admin/themes/modern/stats/items.php:227
-#: oc-admin/themes/modern/stats/items.php:242
-#: oc-admin/themes/modern/stats/reports.php:127
-#: oc-admin/themes/modern/stats/users.php:165
-#: oc-admin/themes/modern/stats/users.php:180
-#: oc-admin/themes/modern/stats/users.php:195
-#: oc-admin/themes/modern/stats/users.php:234
+#: oc-admin/themes/modern/stats/comments.php
+#: oc-admin/themes/modern/stats/items.php
+#: oc-admin/themes/modern/stats/reports.php
+#: oc-admin/themes/modern/stats/users.php
 msgid "There are no statistics yet"
 msgstr ""
 
-#: oc-admin/themes/modern/main/index.php:233
+#: oc-admin/themes/modern/main/index.php
 msgid "There aren't any uploaded listing yet"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php:594
+#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php
 msgid "There were no fields to move."
 msgstr ""
 
-#: oc-admin/themes/modern/settings/comments.php:149
+#: oc-admin/themes/modern/settings/comments.php
 msgid "There's a new comment on his listing"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminPlugins.php:362
+#: oc-includes/osclass/classes/controller/admin/CAdminPlugins.php
 msgid "There's a new update available"
 msgstr ""
 
-#: oc-includes/osclass/install-functions.php:317
+#: oc-includes/osclass/install-functions.php
 msgid ""
 "There's no database called %s yet. Open More options below and let "
 "Shopclass create "
 msgstr ""
 
-#: oc-admin/themes/modern/upgrade/index.php:50
+#: oc-admin/themes/modern/upgrade/index.php
 msgid "These bring your existing data in line with the new version."
 msgstr ""
 
-#: oc-includes/osclass/classes/upgrade/Osclass.php:129
+#: oc-includes/osclass/classes/upgrade/Osclass.php
 msgid "These errors could be false-positive errors."
 msgstr ""
 
-#: oc-admin/themes/modern/fields/index.php:723
+#: oc-admin/themes/modern/fields/index.php
 msgid ""
 "They still show on those listings, but you can only manage them once they "
 "are in a form. Move them in — grouped by the categories they share — "
 "without changing where any of them appears."
 msgstr ""
 
-#: oc-admin/themes/modern/billing/order.php:73
+#: oc-admin/themes/modern/billing/order.php
 msgid "This account has been deleted"
 msgstr ""
 
-#: oc-admin/themes/modern/plugins/index.php:191
+#: oc-admin/themes/modern/plugins/index.php
 msgid "This action can not be undone."
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php:1281
-#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php:1356
+#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php
 msgid "This action can't be done because it's a demo site"
 msgstr ""
 
-#: oc-includes/osclass/classes/form/ItemForm.php:1041
-#: oc-includes/osclass/classes/form/ItemForm.php:1262
-#: oc-includes/osclass/classes/form/ItemForm.php:1581
+#: oc-includes/osclass/classes/form/ItemForm.php
 msgid "This action can't be undone. Are you sure you want to continue?"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/locations.php:149
+#: oc-admin/themes/modern/settings/locations.php
 msgid ""
 "This action can't be undone. Items associated to this location will be "
 "deleted. "
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php:1019
-#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php:986
+#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php
 msgid "This action cannot be done because it is a demo site"
 msgstr ""
 
-#: oc-admin/themes/modern/billing/wallet.php:123
+#: oc-admin/themes/modern/billing/wallet.php
 msgid "This balance is below zero, usually after a refund of credits that had "
 msgstr ""
 
-#: oc-admin/themes/modern/upgrade/index.php:259
-#: oc-admin/themes/modern/upgrade/index.php:57
+#: oc-admin/themes/modern/upgrade/index.php
 msgid ""
 "This can take a minute on a large site. Please leave this page open until "
 "it finishes."
 msgstr ""
 
-#: oc-admin/themes/modern/categories/index.php:158
+#: oc-admin/themes/modern/categories/index.php
 msgid "This can take a moment on a large category."
 msgstr ""
 
-#: oc-includes/osclass/install-functions.php:331
+#: oc-includes/osclass/install-functions.php
 msgid "This database already has Shopclass tables in it. Choose a different table "
 msgstr ""
 
-#: oc-admin/themes/modern/fields/index.php:816
+#: oc-admin/themes/modern/fields/index.php
 msgid "This deletes the field definition and removes it from every form. Continue?"
 msgstr ""
 
-#: oc-admin/themes/modern/parts/market.php:235
+#: oc-admin/themes/modern/parts/market.php
 msgid "This directory isn't writable, so packages can't be installed from here."
 msgstr ""
 
-#: oc-admin/themes/modern/settings/searches.php:152
+#: oc-admin/themes/modern/settings/searches.php
 msgid ""
 "This feature can generate a lot of data. It's recommended to purge this "
 "data periodically."
 msgstr ""
 
-#: oc-admin/themes/modern/fields/iframe.php:123
+#: oc-admin/themes/modern/fields/iframe.php
 msgid "This field is required"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/iframe.php:80
+#: oc-admin/themes/modern/fields/iframe.php
 msgid "This field is used in %d form. Changes here apply to that form."
 msgid_plural "This field is used in %d forms. Changes here apply to all of them."
 msgstr[0] ""
 msgstr[1] ""
 
-#: oc-admin/themes/modern/media/index.php:386
+#: oc-admin/themes/modern/media/index.php
 msgid "This file will be removed from the server. The listing, user or page it "
 msgstr ""
 
-#: oc-admin/themes/modern/items/settings.php:168
+#: oc-admin/themes/modern/items/settings.php
 msgid ""
 "This form emails a listing to a recipient the visitor types in. Off by "
 "default because it can be abused to relay mail; enable it only if you need "
 "it."
 msgstr ""
 
-#: oc-admin/themes/modern/tools/upgrade.php:23
+#: oc-admin/themes/modern/tools/upgrade.php
 msgid ""
 "This installation runs from a container image. Update by deploying a newer "
 "image tag; the database is migrated automatically when the container starts."
 msgstr ""
 
-#: oc-includes/osclass/installer/gui/install.php:73
+#: oc-includes/osclass/installer/gui/install.php
 msgid ""
 "This installer only runs once, and it looks like this site is already set "
 "up. If you genuinely need to start over, remove the tables from your "
 "database first, then reload this page."
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:114
+#: oc-includes/osclass/installer/basic_data.php
 msgid ""
 "This is an example page description. This is a good place to put your Terms "
 "of Service or any other help information."
 msgstr ""
 
-#: oc-admin/themes/modern/tools/backup.php:51
+#: oc-admin/themes/modern/tools/backup.php
 msgid ""
 "This is the folder in which your backups will be created. We recommend that "
 "you choose a non-public path."
 msgstr ""
 
-#: oc-admin/themes/modern/settings/spamNbots.php:55
+#: oc-admin/themes/modern/settings/spamNbots.php
 msgid "This key is valid"
 msgstr ""
 
-#: oc-includes/osclass/classes/actions/ItemActions.php:1648
+#: oc-includes/osclass/classes/actions/ItemActions.php
 msgid "This listing doesn't exist"
 msgstr ""
 
-#: oc-admin/themes/modern/billing/packages.php:97
+#: oc-admin/themes/modern/billing/packages.php
 msgid "This only removes it from checkout. Orders already placed against it "
 msgstr ""
 
-#: oc-admin/themes/modern/items/settings.php:209
+#: oc-admin/themes/modern/items/settings.php
 msgid ""
 "This option will send an email X days before an ad expires to the author. 0 "
 "for no email."
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php:1374
+#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php
 msgid "This package is already installed; use Update instead."
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php:1385
+#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php
 msgid "This package is not installed; use Install instead."
 msgstr ""
 
-#: oc-admin/themes/modern/tools/logs.php:153
+#: oc-admin/themes/modern/tools/logs.php
 msgid "This permanently deletes every log entry. This can't be undone."
 msgstr ""
 
-#: oc-admin/themes/modern/fields/submissions.php:261
+#: oc-admin/themes/modern/fields/submissions.php
 msgid "This permanently deletes every submission for this form. Continue?"
 msgstr ""
 
-#: oc-admin/themes/modern/users/index.php:291
+#: oc-admin/themes/modern/users/index.php
 msgid "This permanently deletes the account and every listing the user published."
 msgstr ""
 
-#: oc-admin/themes/modern/comments/index.php:107
+#: oc-admin/themes/modern/comments/index.php
 msgid ""
 "This permanently deletes the comment from the listing. This cannot be "
 "undone."
 msgstr ""
 
-#: oc-admin/themes/modern/items/index.php:344
-#: oc-admin/themes/modern/items/reported.php:124
+#: oc-admin/themes/modern/items/index.php
+#: oc-admin/themes/modern/items/reported.php
 msgid "This permanently deletes the listing and its photos. This cannot be undone."
 msgstr ""
 
-#: oc-admin/themes/modern/tools/cleanup.php:159
+#: oc-admin/themes/modern/tools/cleanup.php
 msgid ""
 "This permanently deletes the matching listings and users for every enabled "
 "rule (up to the per-run limit). This can't be undone."
 msgstr ""
 
-#: oc-admin/themes/modern/fields/submissions.php:251
+#: oc-admin/themes/modern/fields/submissions.php
 msgid "This permanently deletes the submission. Continue?"
 msgstr ""
 
-#: oc-admin/themes/modern/appearance/index.php:216
+#: oc-admin/themes/modern/appearance/index.php
 msgid ""
 "This permanently deletes the theme's files from the server, along with any "
 "customizations made to it."
 msgstr ""
 
-#: oc-admin/themes/modern/pages/index.php:120
+#: oc-admin/themes/modern/pages/index.php
 msgid "This permanently removes the page and any link to it in the footer."
 msgstr ""
 
-#: oc-admin/themes/modern/admins/index.php:96
+#: oc-admin/themes/modern/admins/index.php
 msgid ""
 "This removes the account from the admin panel. Their listings and the site "
 "itself are untouched."
 msgstr ""
 
-#: oc-admin/themes/modern/users/alerts.php:126
+#: oc-admin/themes/modern/users/alerts.php
 msgid ""
 "This removes the saved alert; the user will no longer be notified when a "
 "new listing matches it."
 msgstr ""
 
-#: oc-admin/themes/modern/appearance/widgets.php:190
+#: oc-admin/themes/modern/appearance/widgets.php
 msgid "This removes the widget from its section immediately and cannot be undone."
 msgstr ""
 
-#: oc-admin/themes/modern/billing/order.php:207
+#: oc-admin/themes/modern/billing/order.php
 msgid "This takes %1$s credits back from %2$s. If they have already spent "
 msgstr ""
 
-#: oc-includes/osclass/install-functions.php:325
+#: oc-includes/osclass/install-functions.php
 msgid "This user isn't allowed to create databases. Create the database in your "
 msgstr ""
 
-#: oc-admin/themes/modern/languages/frm.php:91
+#: oc-admin/themes/modern/languages/frm.php
 msgid "Thousands separator"
 msgstr ""
 
-#: oc-includes/osclass/classes/form/LanguageForm.php:205
+#: oc-includes/osclass/classes/form/LanguageForm.php
 msgid "Thousands separator: this field is required"
 msgstr ""
 
-#: oc-includes/osclass/helpers/hUtils.php:347
+#: oc-includes/osclass/helpers/hUtils.php
 msgid "Thu"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/media.php:137
+#: oc-admin/themes/modern/settings/media.php
 msgid "Thumbnail size"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/media.php:38
+#: oc-admin/themes/modern/settings/media.php
 msgid "Thumbnail size: is not in the correct format"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/media.php:37
+#: oc-admin/themes/modern/settings/media.php
 msgid "Thumbnail size: this field is required"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/index.php:179
-#: oc-includes/osclass/helpers/hUtils.php:342
+#: oc-admin/themes/modern/settings/index.php
+#: oc-includes/osclass/helpers/hUtils.php
 msgid "Thursday"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/iframe.php:264
+#: oc-admin/themes/modern/fields/iframe.php
 msgid "Tick to allow searches by this field"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/iframe.php:271
+#: oc-admin/themes/modern/fields/iframe.php
 msgid "Tick to open links in new tab"
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:30
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Tickets"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/index.php:246
+#: oc-admin/themes/modern/settings/index.php
 msgid "Time"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/index.php:190
+#: oc-admin/themes/modern/settings/index.php
 msgid "Timezone"
 msgstr ""
 
-#: oc-admin/themes/modern/comments/frm.php:57
-#: oc-admin/themes/modern/emails/index.php:33
-#: oc-admin/themes/modern/emails/index.php:43
-#: oc-admin/themes/modern/stats/comments.php:139
-#: oc-includes/osclass/classes/datatables/ItemsDataTable.php:644
-#: oc-includes/osclass/classes/datatables/ItemsDataTable.php:87
-#: oc-includes/osclass/classes/datatables/PagesDataTable.php:58
-#: oc-includes/osclass/classes/form/ItemForm.php:362
-#: oc-includes/osclass/classes/form/PageForm.php:205
-#: oc-includes/osclass/classes/form/PageForm.php:90
-#: oc-includes/osclass/classes/form/admin/Item.php:152
-#: oc-includes/osclass/emails.php:1135
-#: oc-includes/osclass/emails.php:1140
-#: oc-includes/osclass/emails.php:1242
-#: oc-includes/osclass/emails.php:1247
-#: oc-includes/osclass/emails.php:1363
-#: oc-includes/osclass/emails.php:1368
+#: oc-admin/themes/modern/comments/frm.php
+#: oc-admin/themes/modern/emails/index.php
+#: oc-admin/themes/modern/stats/comments.php
+#: oc-includes/osclass/classes/datatables/ItemsDataTable.php
+#: oc-includes/osclass/classes/datatables/PagesDataTable.php
+#: oc-includes/osclass/classes/form/ItemForm.php
+#: oc-includes/osclass/classes/form/PageForm.php
+#: oc-includes/osclass/classes/form/admin/Item.php
+#: oc-includes/osclass/emails.php
 msgid "Title"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/keywordBlock.php:97
-#: oc-includes/osclass/classes/datatables/KeywordBlocksDataTable.php:100
-#: oc-includes/osclass/classes/form/KeywordBlockForm.php:41
+#: oc-admin/themes/modern/settings/keywordBlock.php
+#: oc-includes/osclass/classes/datatables/KeywordBlocksDataTable.php
+#: oc-includes/osclass/classes/form/KeywordBlockForm.php
 msgid "Title and description"
 msgstr ""
 
-#: oc-admin/themes/modern/items/settings.php:213
+#: oc-admin/themes/modern/items/settings.php
 msgid "Title length"
 msgstr ""
 
-#: oc-includes/osclass/classes/EmailVariables.php:48
+#: oc-includes/osclass/classes/EmailVariables.php
 msgid "Title of your site"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/keywordBlock.php:98
-#: oc-includes/osclass/classes/datatables/KeywordBlocksDataTable.php:93
-#: oc-includes/osclass/classes/form/KeywordBlockForm.php:39
+#: oc-admin/themes/modern/settings/keywordBlock.php
+#: oc-includes/osclass/classes/datatables/KeywordBlocksDataTable.php
+#: oc-includes/osclass/classes/form/KeywordBlockForm.php
 msgid "Title only"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/cache.php:199
+#: oc-admin/themes/modern/tools/cache.php
 msgid ""
 "To cache between requests, install one of the extensions above and set %s "
 "in your config file."
 msgstr ""
 
-#: oc-admin/themes/modern/appearance/add.php:54
-#: oc-admin/themes/modern/languages/add.php:53
-#: oc-admin/themes/modern/plugins/add.php:55
+#: oc-admin/themes/modern/appearance/add.php
+#: oc-admin/themes/modern/languages/add.php
+#: oc-admin/themes/modern/plugins/add.php
 msgid ""
 "To make the directory writable under UNIX execute this command from the "
 "shell:"
 msgstr ""
 
-#: oc-admin/themes/modern/parts/header.php:67
-#: oc-admin/themes/modern/parts/header.php:68
+#: oc-admin/themes/modern/parts/header.php
 msgid "Toggle dark mode"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/group_iframe.php:87
-#: oc-admin/themes/modern/fields/iframe.php:291
-#: oc-admin/themes/modern/plugins/configuration.php:49
+#: oc-admin/themes/modern/fields/group_iframe.php
+#: oc-admin/themes/modern/fields/iframe.php
+#: oc-admin/themes/modern/plugins/configuration.php
 msgid "Toggle subcategories"
 msgstr ""
 
-#: oc-includes/osclass/classes/AdminMenu.php:759
+#: oc-includes/osclass/classes/AdminMenu.php
 msgid "Toggle the %s submenu"
 msgstr ""
 
-#: oc-includes/osclass/classes/form/ItemForm.php:1584
+#: oc-includes/osclass/classes/form/ItemForm.php
 msgid "Too many images. The limit is {limit}."
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:362
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "Too old. Shopclass is built and tested against PHP 8.0 and up."
 msgstr ""
 
-#: oc-admin/themes/modern/tools/backup.php:26
-#: oc-admin/themes/modern/tools/cache.php:61
-#: oc-admin/themes/modern/tools/cleanup.php:14
-#: oc-admin/themes/modern/tools/import.php:26
-#: oc-admin/themes/modern/tools/logs.php:14
-#: oc-admin/themes/modern/tools/maintenance.php:28
-#: oc-admin/themes/modern/tools/system-info.php:141
-#: oc-admin/themes/modern/tools/upgrade.php:193
-#: oc-admin/themes/modern/upgrade/index.php:17
-#: oc-includes/osclass/classes/AdminMenu.php:423
+#: oc-admin/themes/modern/tools/backup.php
+#: oc-admin/themes/modern/tools/cache.php
+#: oc-admin/themes/modern/tools/cleanup.php
+#: oc-admin/themes/modern/tools/import.php
+#: oc-admin/themes/modern/tools/logs.php
+#: oc-admin/themes/modern/tools/maintenance.php
+#: oc-admin/themes/modern/tools/system-info.php
+#: oc-admin/themes/modern/tools/upgrade.php
+#: oc-admin/themes/modern/upgrade/index.php
+#: oc-includes/osclass/classes/AdminMenu.php
 msgid "Tools"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/media.php:389
-#: oc-admin/themes/modern/settings/media.php:425
+#: oc-admin/themes/modern/settings/media.php
 msgid "Top Left"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/media.php:391
-#: oc-admin/themes/modern/settings/media.php:427
+#: oc-admin/themes/modern/settings/media.php
 msgid "Top Right"
 msgstr ""
 
-#: oc-admin/themes/modern/stats/items.php:209
+#: oc-admin/themes/modern/stats/items.php
 msgid "Total number of listings' views"
 msgstr ""
 
-#: oc-admin/themes/modern/main/index.php:246
+#: oc-admin/themes/modern/main/index.php
 msgid "Total number of listings: %s"
 msgstr ""
 
-#: oc-admin/themes/modern/stats/reports.php:121
+#: oc-admin/themes/modern/stats/reports.php
 msgid "Total number of reports"
 msgstr ""
 
-#: oc-admin/themes/modern/main/index.php:250
+#: oc-admin/themes/modern/main/index.php
 msgid "Total number of users: %s"
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:31
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Toys - Games - Hobbies"
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:39
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Trucks - Commercial Vehicles"
 msgstr ""
 
-#: oc-admin/themes/modern/billing/index.php:99
+#: oc-admin/themes/modern/billing/index.php
 msgid "Try a different status or payment method."
 msgstr ""
 
-#: oc-includes/osclass/helpers/hUtils.php:347
+#: oc-includes/osclass/helpers/hUtils.php
 msgid "Tue"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/index.php:173
-#: oc-includes/osclass/helpers/hUtils.php:340
+#: oc-admin/themes/modern/settings/index.php
+#: oc-includes/osclass/helpers/hUtils.php
 msgid "Tuesday"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/logs.php:51
+#: oc-admin/themes/modern/tools/logs.php
 msgid ""
 "Turn logging off to stop recording new entries. Existing entries are kept "
 "until pruned."
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:255
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "Turn on OPcache"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:277
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "Turn on a persistent object cache"
 msgstr ""
 
-#: oc-includes/osclass/installer/gui/install-database.php:83
+#: oc-includes/osclass/installer/gui/install-database.php
 msgid ""
 "Turn this on if the database doesn't exist yet and you want Shopclass to "
 "create it."
 msgstr ""
 
-#: oc-admin/themes/modern/settings/billing.php:33
+#: oc-admin/themes/modern/settings/billing.php
 msgid ""
 "Turn this on to sell things on your site — featured listings, posting "
 "credits, "
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:377
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid "Turns links like index.php?page=item&id=42 into readable ones like "
 msgstr ""
 
-#: oc-admin/themes/modern/settings/spamNbots.php:165
+#: oc-admin/themes/modern/settings/spamNbots.php
 msgid "Turnstile secret key"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/spamNbots.php:154
+#: oc-admin/themes/modern/settings/spamNbots.php
 msgid "Turnstile site key"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/spamNbots.php:124
+#: oc-admin/themes/modern/settings/spamNbots.php
 msgid "Turnstile site key and Turnstile secret key"
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:44
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Tutoring - Private Lessons"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:224
+#: oc-admin/themes/modern/tools/system-info.php
 msgid ""
 "Two files hold these settings. PHP's own limits live in %1$s%2$s; "
 "Shopclass's own behaviour lives in %3$s in the site root%4$s. Edit the "
@@ -9395,1002 +8886,955 @@ msgid ""
 "takes effect on the next request."
 msgstr ""
 
-#: oc-admin/themes/modern/fields/iframe.php:101
-#: oc-admin/themes/modern/media/index.php:291
-#: oc-admin/themes/modern/media/index.php:350
+#: oc-admin/themes/modern/fields/iframe.php
+#: oc-admin/themes/modern/media/index.php
 msgid "Type"
 msgstr ""
 
-#: oc-admin/gui/forgot_password.php:18
+#: oc-admin/gui/forgot_password.php
 msgid "Type your new password"
 msgstr ""
 
-#: oc-admin/themes/modern/admins/frm.php:113
-#: oc-admin/themes/modern/users/frm.php:340
+#: oc-admin/themes/modern/admins/frm.php
+#: oc-admin/themes/modern/users/frm.php
 msgid "Type your new password again"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/sitemap.php:136
-#: oc-admin/themes/modern/settings/sitemap.php:145
-#: oc-admin/themes/modern/settings/sitemap.php:99
+#: oc-admin/themes/modern/settings/sitemap.php
 msgid "URL"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/sitemap.php:61
+#: oc-admin/themes/modern/settings/sitemap.php
 msgid "URLs per sitemap file"
 msgstr ""
 
-#: oc-includes/osclass/classes/market/Installer.php:326
+#: oc-includes/osclass/classes/market/Installer.php
 msgid "Unable to back up the existing package before replacing it."
 msgstr ""
 
-#: oc-includes/osclass/classes/upgrade/Plugin.php:112
-#: oc-includes/osclass/classes/upgrade/Plugin.php:129
-#: oc-includes/osclass/classes/upgrade/Plugin.php:95
-#: oc-includes/osclass/classes/upgrade/Theme.php:110
-#: oc-includes/osclass/classes/upgrade/Theme.php:127
-#: oc-includes/osclass/classes/upgrade/Theme.php:93
+#: oc-includes/osclass/classes/upgrade/Plugin.php
+#: oc-includes/osclass/classes/upgrade/Theme.php
 msgid "Unable to fetch a usable package info from the update URI."
 msgstr ""
 
-#: oc-includes/osclass/classes/upgrade/Upgrade.php:99
+#: oc-includes/osclass/classes/upgrade/Upgrade.php
 msgid "Unable to follow upgrade, invalid package info"
 msgstr ""
 
-#: oc-includes/osclass/classes/upgrade/Upgrade.php:190
+#: oc-includes/osclass/classes/upgrade/Upgrade.php
 msgid "Unable to unzip package file."
 msgstr ""
 
-#: oc-includes/osclass/classes/upgrade/Osclass.php:179
+#: oc-includes/osclass/classes/upgrade/Osclass.php
 msgid "Unable to upgrade Database"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/cleanup.php:25
+#: oc-admin/themes/modern/tools/cleanup.php
 msgid "Unactivated listings"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/cleanup.php:28
+#: oc-admin/themes/modern/tools/cleanup.php
 msgid "Unactivated users"
 msgstr ""
 
-#: oc-admin/themes/modern/comments/frm.php:99
-#: oc-includes/osclass/classes/controller/admin/CAdminItemComments.php:309
-#: oc-includes/osclass/classes/controller/admin/CAdminItemComments.php:311
-#: oc-includes/osclass/classes/controller/admin/CAdminItems.php:1006
-#: oc-includes/osclass/classes/controller/admin/CAdminItems.php:1008
-#: oc-includes/osclass/classes/controller/admin/CAdminItems.php:586
-#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php:120
-#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php:734
-#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php:736
-#: oc-includes/osclass/classes/datatables/CommentsDataTable.php:144
-#: oc-includes/osclass/classes/datatables/ItemsDataTable.php:263
-#: oc-includes/osclass/classes/datatables/UsersDataTable.php:230
+#: oc-admin/themes/modern/comments/frm.php
+#: oc-includes/osclass/classes/controller/admin/CAdminItemComments.php
+#: oc-includes/osclass/classes/controller/admin/CAdminItems.php
+#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php
+#: oc-includes/osclass/classes/datatables/CommentsDataTable.php
+#: oc-includes/osclass/classes/datatables/ItemsDataTable.php
+#: oc-includes/osclass/classes/datatables/UsersDataTable.php
 msgid "Unblock"
 msgstr ""
 
-#: oc-admin/themes/modern/comments/frm.php:95
+#: oc-admin/themes/modern/comments/frm.php
 msgid "Unblocked"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/group_iframe.php:63
-#: oc-admin/themes/modern/fields/iframe.php:238
-#: oc-admin/themes/modern/plugins/configuration.php:77
+#: oc-admin/themes/modern/fields/group_iframe.php
+#: oc-admin/themes/modern/fields/iframe.php
+#: oc-admin/themes/modern/plugins/configuration.php
 msgid "Uncheck all"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:504
+#: oc-admin/themes/modern/tools/system-info.php
 msgid ""
 "Under 128M. Resizing a large photo is the most memory-hungry thing "
 "Shopclass does, and this is where it fails first."
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:514
+#: oc-admin/themes/modern/tools/system-info.php
 msgid ""
 "Under 512MB left on the uploads volume. When it fills, uploads and backups "
 "start failing."
 msgstr ""
 
-#: oc-admin/themes/modern/fields/iframe.php:109
+#: oc-admin/themes/modern/fields/iframe.php
 msgid "Ungrouped"
 msgstr ""
 
-#: oc-admin/themes/modern/appearance/index.php:217
-#: oc-admin/themes/modern/plugins/index.php:195
-#: oc-includes/osclass/classes/controller/admin/CAdminPlugins.php:389
+#: oc-admin/themes/modern/appearance/index.php
+#: oc-admin/themes/modern/plugins/index.php
+#: oc-includes/osclass/classes/controller/admin/CAdminPlugins.php
 msgid "Uninstall"
 msgstr ""
 
-#: oc-includes/osclass/classes/datatables/ItemsDataTable.php:649
+#: oc-includes/osclass/classes/datatables/ItemsDataTable.php
 msgid "Unique reporters"
 msgstr ""
 
-#: oc-admin/themes/modern/stats/users.php:100
-#: oc-admin/themes/modern/stats/users.php:116
+#: oc-admin/themes/modern/stats/users.php
 msgid "Unknown"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminItems.php:1022
-#: oc-includes/osclass/classes/controller/admin/CAdminItems.php:1024
-#: oc-includes/osclass/classes/controller/admin/CAdminItems.php:591
-#: oc-includes/osclass/classes/datatables/ItemsDataTable.php:268
+#: oc-includes/osclass/classes/controller/admin/CAdminItems.php
+#: oc-includes/osclass/classes/datatables/ItemsDataTable.php
 msgid "Unmark as premium"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminItems.php:1038
-#: oc-includes/osclass/classes/controller/admin/CAdminItems.php:1040
-#: oc-includes/osclass/classes/controller/admin/CAdminItems.php:600
-#: oc-includes/osclass/classes/datatables/ItemsDataTable.php:279
+#: oc-includes/osclass/classes/controller/admin/CAdminItems.php
+#: oc-includes/osclass/classes/datatables/ItemsDataTable.php
 msgid "Unmark as spam"
 msgstr ""
 
-#: oc-includes/osclass/classes/EmailVariables.php:45
+#: oc-includes/osclass/classes/EmailVariables.php
 msgid "Unsubscribe link."
 msgstr ""
 
-#: oc-includes/osclass/classes/datatables/PagesDataTable.php:108
+#: oc-includes/osclass/classes/datatables/PagesDataTable.php
 msgid "Up"
 msgstr ""
 
-#: oc-includes/osclass/classes/market/Compatibility.php:187
+#: oc-includes/osclass/classes/market/Compatibility.php
 msgid "Up to %s"
 msgstr ""
 
-#: oc-admin/themes/modern/appearance/index.php:170
-#: oc-admin/themes/modern/plugins/configuration.php:87
+#: oc-admin/themes/modern/appearance/index.php
+#: oc-admin/themes/modern/plugins/configuration.php
 msgid "Update"
 msgstr ""
 
-#: oc-admin/themes/modern/parts/market.php:449
+#: oc-admin/themes/modern/parts/market.php
 msgid "Update all (%d)"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/locations.php:167
-#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php:907
+#: oc-admin/themes/modern/settings/locations.php
+#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php
 msgid "Update available"
 msgstr ""
 
-#: oc-admin/themes/modern/comments/frm.php:23
+#: oc-admin/themes/modern/comments/frm.php
 msgid "Update comment"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/currency_form.php:79
+#: oc-admin/themes/modern/settings/currency_form.php
 msgid "Update currency"
 msgstr ""
 
-#: oc-includes/osclass/classes/datatables/UsersDataTable.php:80
+#: oc-includes/osclass/classes/datatables/UsersDataTable.php
 msgid "Update date"
 msgstr ""
 
-#: oc-admin/themes/modern/items/frm.php:299
+#: oc-admin/themes/modern/items/frm.php
 msgid "Update expiration?"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php:526
+#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php
 msgid "Update here"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/keywordBlock_frm.php:27
+#: oc-admin/themes/modern/settings/keywordBlock_frm.php
 msgid "Update keyword"
 msgstr ""
 
-#: oc-admin/themes/modern/items/frm.php:40
+#: oc-admin/themes/modern/items/frm.php
 msgid "Update listing"
 msgstr ""
 
-#: oc-includes/osclass/classes/Breadcrumb.php:59
-#: oc-includes/osclass/functions.php:207
+#: oc-includes/osclass/classes/Breadcrumb.php
+#: oc-includes/osclass/functions.php
 msgid "Update my profile"
 msgstr ""
 
-#: oc-admin/themes/modern/users/ban_frm.php:30
+#: oc-admin/themes/modern/users/ban_frm.php
 msgid "Update rule"
 msgstr ""
 
-#: oc-admin/themes/modern/parts/market.php:492
+#: oc-admin/themes/modern/parts/market.php
 msgid "Update to %s"
 msgstr ""
 
-#: oc-admin/themes/modern/users/frm.php:34
+#: oc-admin/themes/modern/users/frm.php
 msgid "Update user"
 msgstr ""
 
-#: oc-admin/themes/modern/languages/index.php:181
+#: oc-admin/themes/modern/languages/index.php
 msgid "Updated"
 msgstr ""
 
-#: oc-admin/themes/modern/appearance/index.php:85
-#: oc-admin/themes/modern/plugins/index.php:73
+#: oc-admin/themes/modern/appearance/index.php
+#: oc-admin/themes/modern/plugins/index.php
 msgid "Updates"
 msgstr ""
 
-#: oc-admin/themes/modern/upgrade/index.php:257
-#: oc-admin/themes/modern/upgrade/index.php:56
+#: oc-admin/themes/modern/upgrade/index.php
 msgid "Updating your database"
 msgstr ""
 
-#: oc-admin/themes/modern/parts/market.php:604
-#: oc-admin/themes/modern/parts/market.php:607
+#: oc-admin/themes/modern/parts/market.php
 msgid "Updating…"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/upgrade.php:194
-#: oc-admin/themes/modern/tools/upgrade.php:203
-#: oc-admin/themes/modern/upgrade/index.php:252
-#: oc-admin/themes/modern/upgrade/index.php:27
+#: oc-admin/themes/modern/tools/upgrade.php
+#: oc-admin/themes/modern/upgrade/index.php
 msgid "Upgrade"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/upgrade.php:143
+#: oc-admin/themes/modern/tools/upgrade.php
 msgid "Upgrade Failed"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/upgrade.php:73
+#: oc-admin/themes/modern/tools/upgrade.php
 msgid "Upgrade Notes:"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/upgrade.php:78
+#: oc-admin/themes/modern/tools/upgrade.php
 msgid "Upgrade Now to "
 msgstr ""
 
-#: oc-includes/osclass/classes/AdminMenu.php:426
+#: oc-includes/osclass/classes/AdminMenu.php
 msgid "Upgrade Shopclass"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/upgrade.php:123
+#: oc-admin/themes/modern/tools/upgrade.php
 msgid "Upgrade Successful"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/upgrade.php:132
+#: oc-admin/themes/modern/tools/upgrade.php
 msgid "Upgrade completed with few errors"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/upgrade.php:66
+#: oc-admin/themes/modern/tools/upgrade.php
 msgid "Upgrade is available for (Current version %s)"
 msgstr ""
 
-#: oc-admin/themes/modern/upgrade/index.php:268
+#: oc-admin/themes/modern/upgrade/index.php
 msgid "Upgrade now"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/billing.php:183
+#: oc-admin/themes/modern/settings/billing.php
 msgid "Upgrades"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/upgrade.php:107
+#: oc-admin/themes/modern/tools/upgrade.php
 msgid "Upgrading your Shopclass installation (this could take a while):"
 msgstr ""
 
-#: oc-admin/themes/modern/appearance/add.php:41
-#: oc-admin/themes/modern/languages/add.php:39
-#: oc-admin/themes/modern/media/index.php:25
-#: oc-admin/themes/modern/parts/media-picker.php:28
-#: oc-admin/themes/modern/plugins/add.php:41
+#: oc-admin/themes/modern/appearance/add.php
+#: oc-admin/themes/modern/languages/add.php
+#: oc-admin/themes/modern/media/index.php
+#: oc-admin/themes/modern/parts/media-picker.php
+#: oc-admin/themes/modern/plugins/add.php
 msgid "Upload"
 msgstr ""
 
-#: oc-admin/themes/modern/languages/index.php:25
-#: oc-admin/themes/modern/languages/index.php:94
+#: oc-admin/themes/modern/languages/index.php
 msgid "Upload language"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/import.php:29
+#: oc-admin/themes/modern/tools/import.php
 msgid ""
 "Upload registers from other Shopclass installations or upload new "
 "geographic information to your site. "
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php:159
+#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php
 msgid "Upload target not allowed"
 msgstr ""
 
-#: oc-admin/themes/modern/media/index.php:293
-#: oc-admin/themes/modern/media/index.php:352
+#: oc-admin/themes/modern/media/index.php
 msgid "Uploaded"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/media.php:173
+#: oc-admin/themes/modern/settings/media.php
 msgid "Uploaded images will be saved in JPG/JPEG format, "
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:435
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "Uploads &amp; storage"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:442
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "Uploads folder is writable"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:659
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "Uploads path"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/cache.php:132
+#: oc-admin/themes/modern/tools/cache.php
 msgid "Uptime"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/billing.php:234
+#: oc-admin/themes/modern/settings/billing.php
 msgid "Urgent"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/billing.php:249
+#: oc-admin/themes/modern/settings/billing.php
 msgid "Urgent duration (days)"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/billing.php:243
+#: oc-admin/themes/modern/settings/billing.php
 msgid "Urgent price (credits)"
 msgstr ""
 
-#: oc-includes/osclass/classes/EmailVariables.php:43
+#: oc-includes/osclass/classes/EmailVariables.php
 msgid "Url for account validation."
 msgstr ""
 
-#: oc-includes/osclass/classes/EmailVariables.php:63
+#: oc-includes/osclass/classes/EmailVariables.php
 msgid "Url for edit listing"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/media.php:222
+#: oc-admin/themes/modern/settings/media.php
 msgid "Use ImageMagick instead of GD library"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/mailserver.php:179
+#: oc-admin/themes/modern/settings/mailserver.php
 msgid "Use POP before SMTP"
 msgstr ""
 
-#: oc-includes/osclass/timezones.php:16
+#: oc-includes/osclass/timezones.php
 msgid "Use native php function for timezones list."
 msgstr ""
 
-#: oc-admin/themes/modern/settings/storage.php:175
+#: oc-admin/themes/modern/settings/storage.php
 msgid "Use path-style bucket URLs."
 msgstr ""
 
-#: oc-admin/themes/modern/settings/storage.php:197
+#: oc-admin/themes/modern/settings/storage.php
 msgid "Use this for a private bucket. Leave off for a public bucket or CDN."
 msgstr ""
 
-#: oc-admin/themes/modern/media/index.php:290
-#: oc-admin/themes/modern/media/index.php:334
+#: oc-admin/themes/modern/media/index.php
 msgid "Used in"
 msgstr ""
 
-#: oc-admin/themes/modern/emails/frm.php:139
+#: oc-admin/themes/modern/emails/frm.php
 msgid "Used to identify the email template"
 msgstr ""
 
-#: oc-admin/themes/modern/pages/frm.php:351
+#: oc-admin/themes/modern/pages/frm.php
 msgid "Used to quickly identify this page"
 msgstr ""
 
-#: oc-admin/themes/modern/billing/credits.php:53
-#: oc-admin/themes/modern/billing/index.php:114
-#: oc-admin/themes/modern/billing/order.php:65
-#: oc-admin/themes/modern/billing/order.php:73
-#: oc-admin/themes/modern/items/frm.php:229
-#: oc-admin/themes/modern/media/index.php:111
-#: oc-admin/themes/modern/media/index.php:240
-#: oc-includes/osclass/classes/datatables/ItemsDataTable.php:645
-#: oc-includes/osclass/classes/datatables/ItemsDataTable.php:88
-#: oc-includes/osclass/classes/form/UserForm.php:373
+#: oc-admin/themes/modern/billing/credits.php
+#: oc-admin/themes/modern/billing/index.php
+#: oc-admin/themes/modern/billing/order.php
+#: oc-admin/themes/modern/items/frm.php
+#: oc-admin/themes/modern/media/index.php
+#: oc-includes/osclass/classes/datatables/ItemsDataTable.php
+#: oc-includes/osclass/classes/form/UserForm.php
 msgid "User"
 msgstr ""
 
-#: oc-admin/themes/modern/items/index.php:122
+#: oc-admin/themes/modern/items/index.php
 msgid "User Email"
 msgstr ""
 
-#: oc-admin/themes/modern/items/index.php:123
+#: oc-admin/themes/modern/items/index.php
 msgid "User ID"
 msgstr ""
 
-#: oc-admin/themes/modern/parts/header.php:75
+#: oc-admin/themes/modern/parts/header.php
 msgid "User Menu"
 msgstr ""
 
-#: oc-admin/themes/modern/users/settings.php:18
-#: oc-admin/themes/modern/users/settings.php:25
+#: oc-admin/themes/modern/users/settings.php
 msgid "User Settings"
 msgstr ""
 
-#: oc-admin/themes/modern/stats/users.php:142
-#: oc-admin/themes/modern/stats/users.php:46
+#: oc-admin/themes/modern/stats/users.php
 msgid "User Statistics"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:574
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid "User account"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:604
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid "User activate"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:611
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid "User activate alert"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:632
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid "User alerts"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:291
-#: oc-admin/themes/modern/settings/permalinks.php:292
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid "User alerts url: this field is required"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/advanced.php:77
+#: oc-admin/themes/modern/settings/advanced.php
 msgid "User based"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:660
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid "User change email"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:667
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid "User change email confirm"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:653
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid "User change password"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:674
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid "User change username"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:583
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid "User dashboard"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:263
-#: oc-admin/themes/modern/settings/permalinks.php:264
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid "User dashboard url: this field is required"
 msgstr ""
 
-#: oc-includes/osclass/classes/EmailVariables.php:41
+#: oc-includes/osclass/classes/EmailVariables.php
 msgid "User email"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:646
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid "User forgot"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:299
-#: oc-admin/themes/modern/settings/permalinks.php:300
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid "User forgot url: this field is required"
 msgstr ""
 
-#: oc-includes/osclass/classes/EmailVariables.php:51
+#: oc-includes/osclass/classes/EmailVariables.php
 msgid "User ip address"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:625
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid "User listings"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:287
-#: oc-admin/themes/modern/settings/permalinks.php:288
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid "User listings url: this field is required"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:576
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid "User login"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:590
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid "User logout"
 msgstr ""
 
-#: oc-includes/osclass/classes/EmailVariables.php:40
+#: oc-includes/osclass/classes/EmailVariables.php
 msgid "User name"
 msgstr ""
 
-#: oc-includes/osclass/classes/EmailVariables.php:73
+#: oc-includes/osclass/classes/EmailVariables.php
 msgid "User phone number"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:618
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid "User profile"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:283
-#: oc-admin/themes/modern/settings/permalinks.php:284
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid "User profile url: this field is required"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:639
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid "User recover"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:597
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid "User register"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:271
-#: oc-admin/themes/modern/settings/permalinks.php:272
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid "User register url: this field is required"
 msgstr ""
 
-#: oc-admin/themes/modern/main/index.php:255
+#: oc-admin/themes/modern/main/index.php
 msgid "User statistics"
 msgstr ""
 
-#: oc-admin/themes/modern/users/frm.php:279
+#: oc-admin/themes/modern/users/frm.php
 msgid "User type"
 msgstr ""
 
-#: oc-admin/gui/login.php:25
-#: oc-admin/themes/modern/admins/index.php:44
-#: oc-admin/themes/modern/admins/index.php:57
-#: oc-admin/themes/modern/settings/mailserver.php:136
-#: oc-admin/themes/modern/users/frm.php:223
-#: oc-admin/themes/modern/users/index.php:198
-#: oc-includes/osclass/classes/datatables/UsersDataTable.php:76
-#: oc-includes/osclass/installer/gui/install-database.php:53
-#: oc-includes/osclass/installer/gui/install-finish.php:60
-#: oc-includes/osclass/installer/gui/install-target.php:64
+#: oc-admin/gui/login.php
+#: oc-admin/themes/modern/admins/index.php
+#: oc-admin/themes/modern/settings/mailserver.php
+#: oc-admin/themes/modern/users/frm.php
+#: oc-admin/themes/modern/users/index.php
+#: oc-includes/osclass/classes/datatables/UsersDataTable.php
+#: oc-includes/osclass/installer/gui/install-database.php
+#: oc-includes/osclass/installer/gui/install-finish.php
+#: oc-includes/osclass/installer/gui/install-target.php
 msgid "Username"
 msgstr ""
 
-#: oc-admin/themes/modern/admins/frm.php:78
+#: oc-admin/themes/modern/admins/frm.php
 msgid "Username <em>(required)</em>"
 msgstr ""
 
-#: oc-admin/themes/modern/users/settings.php:70
+#: oc-admin/themes/modern/users/settings.php
 msgid "Username blacklist"
 msgstr ""
 
-#: oc-includes/osclass/classes/form/AdminForm.php:126
+#: oc-includes/osclass/classes/form/AdminForm.php
 msgid "Username: enter at least 3 characters"
 msgstr ""
 
-#: oc-includes/osclass/classes/form/AdminForm.php:127
+#: oc-includes/osclass/classes/form/AdminForm.php
 msgid "Username: no more than 50 characters"
 msgstr ""
 
-#: oc-admin/themes/modern/users/frm.php:130
-#: oc-includes/osclass/classes/form/AdminForm.php:125
+#: oc-admin/themes/modern/users/frm.php
+#: oc-includes/osclass/classes/form/AdminForm.php
 msgid "Username: this field is required"
 msgstr ""
 
-#: oc-includes/osclass/installer/gui/install-target.php:66
+#: oc-includes/osclass/installer/gui/install-target.php
 msgid "Usernames can only contain letters and numbers."
 msgstr ""
 
-#: oc-admin/themes/modern/admins/frm.php:40
-#: oc-admin/themes/modern/admins/index.php:17
-#: oc-admin/themes/modern/main/index.php:110
-#: oc-admin/themes/modern/main/index.php:161
-#: oc-admin/themes/modern/users/alerts.php:15
-#: oc-admin/themes/modern/users/ban.php:17
-#: oc-admin/themes/modern/users/ban_frm.php:42
-#: oc-admin/themes/modern/users/frm.php:48
-#: oc-admin/themes/modern/users/index.php:17
-#: oc-admin/themes/modern/users/settings.php:17
-#: oc-includes/osclass/classes/AdminMenu.php:108
-#: oc-includes/osclass/classes/AdminMenu.php:253
-#: oc-includes/osclass/classes/controller/admin/CAdminMedia.php:119
+#: oc-admin/themes/modern/admins/frm.php
+#: oc-admin/themes/modern/admins/index.php
+#: oc-admin/themes/modern/main/index.php
+#: oc-admin/themes/modern/users/alerts.php
+#: oc-admin/themes/modern/users/ban.php
+#: oc-admin/themes/modern/users/ban_frm.php
+#: oc-admin/themes/modern/users/frm.php
+#: oc-admin/themes/modern/users/index.php
+#: oc-admin/themes/modern/users/settings.php
+#: oc-includes/osclass/classes/AdminMenu.php
+#: oc-includes/osclass/classes/controller/admin/CAdminMedia.php
 msgid "Users"
 msgstr ""
 
-#: oc-admin/themes/modern/users/settings.php:37
+#: oc-admin/themes/modern/users/settings.php
 msgid "Users enabled"
 msgstr ""
 
-#: oc-admin/themes/modern/items/settings.php:111
+#: oc-admin/themes/modern/items/settings.php
 msgid "Users have to validate their listings"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/comments.php:95
+#: oc-admin/themes/modern/settings/comments.php
 msgid "Users must be registered and logged in to comment"
 msgstr ""
 
-#: oc-admin/themes/modern/users/settings.php:53
+#: oc-admin/themes/modern/users/settings.php
 msgid "Users need to validate their account"
 msgstr ""
 
-#: oc-admin/themes/modern/stats/users.php:174
-#: oc-admin/themes/modern/stats/users.php:97
+#: oc-admin/themes/modern/stats/users.php
 msgid "Users per country"
 msgstr ""
 
-#: oc-admin/themes/modern/stats/users.php:113
-#: oc-admin/themes/modern/stats/users.php:189
+#: oc-admin/themes/modern/stats/users.php
 msgid "Users per region"
 msgstr ""
 
-#: oc-admin/themes/modern/users/ban.php:157
+#: oc-admin/themes/modern/users/ban.php
 msgid "Users, listings and comments matching this rule will no longer be blocked."
 msgstr ""
 
-#: oc-includes/osclass/installer/gui/install-database.php:43
+#: oc-includes/osclass/installer/gui/install-database.php
 msgid ""
 "Usually 'localhost'. If your host gave you a different one, add a port as "
 "host:port."
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:50
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Vacation Rentals"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/iframe.php:194
+#: oc-admin/themes/modern/fields/iframe.php
 msgid "Value"
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:5
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Vehicles"
 msgstr ""
 
-#: oc-admin/themes/modern/appearance/index.php:116
-#: oc-admin/themes/modern/appearance/index.php:177
-#: oc-admin/themes/modern/parts/market.php:531
-#: oc-admin/themes/modern/parts/market.php:570
+#: oc-admin/themes/modern/appearance/index.php
+#: oc-admin/themes/modern/parts/market.php
 msgid "Version"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminPlugins.php:441
+#: oc-includes/osclass/classes/controller/admin/CAdminPlugins.php
 msgid "Version:"
 msgstr ""
 
-#: oc-admin/themes/modern/parts/market.php:565
+#: oc-admin/themes/modern/parts/market.php
 msgid "Versions"
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:32
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Video Games - Consoles"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/submissions.php:163
+#: oc-admin/themes/modern/fields/submissions.php
 msgid "View"
 msgstr ""
 
-#: oc-includes/osclass/classes/datatables/ItemsDataTable.php:297
+#: oc-includes/osclass/classes/datatables/ItemsDataTable.php
 msgid "View comments"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/cleanup.php:105
+#: oc-admin/themes/modern/tools/cleanup.php
 msgid "View counts are written on every page render, so they are the busiest "
 msgstr ""
 
-#: oc-admin/themes/modern/parts/market.php:394
-#: oc-admin/themes/modern/parts/market.php:468
+#: oc-admin/themes/modern/parts/market.php
 msgid "View details for %s"
 msgstr ""
 
-#: oc-admin/themes/modern/media/index.php:355
-#: oc-admin/themes/modern/media/index.php:356
+#: oc-admin/themes/modern/media/index.php
 msgid "View full image"
 msgstr ""
 
-#: oc-admin/themes/modern/items/frm.php:158
+#: oc-admin/themes/modern/items/frm.php
 msgid "View listing on front"
 msgstr ""
 
-#: oc-includes/osclass/classes/datatables/ItemsDataTable.php:301
+#: oc-includes/osclass/classes/datatables/ItemsDataTable.php
 msgid "View media"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/locations.php:168
-#: oc-admin/themes/modern/settings/locations.php:72
+#: oc-admin/themes/modern/settings/locations.php
 msgid "View more"
 msgstr ""
 
-#: oc-admin/themes/modern/media/index.php:399
+#: oc-admin/themes/modern/media/index.php
 msgid "View original"
 msgstr ""
 
-#: oc-includes/osclass/classes/datatables/PagesDataTable.php:86
+#: oc-includes/osclass/classes/datatables/PagesDataTable.php
 msgid "View page"
 msgstr ""
 
-#: oc-admin/themes/modern/pages/frm.php:358
+#: oc-admin/themes/modern/pages/frm.php
 msgid "View page on site"
 msgstr ""
 
-#: oc-admin/themes/modern/parts/header.php:37
+#: oc-admin/themes/modern/parts/header.php
 msgid "View your site"
 msgstr ""
 
-#: oc-admin/themes/modern/stats/items.php:91
+#: oc-admin/themes/modern/stats/items.php
 msgid "Views"
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:70
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Volunteers"
 msgstr ""
 
-#: oc-admin/themes/modern/items/settings.php:204
+#: oc-admin/themes/modern/items/settings.php
 msgid "Warn about expiration"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/media.php:234
+#: oc-admin/themes/modern/settings/media.php
 msgid "Watermark"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/media.php:321
+#: oc-admin/themes/modern/settings/media.php
 msgid "Watermark Height"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/media.php:401
+#: oc-admin/themes/modern/settings/media.php
 msgid "Watermark Image Settings"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/media.php:269
+#: oc-admin/themes/modern/settings/media.php
 msgid "Watermark Text"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/media.php:267
+#: oc-admin/themes/modern/settings/media.php
 msgid "Watermark Text Settings"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/media.php:314
+#: oc-admin/themes/modern/settings/media.php
 msgid "Watermark Width"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/media.php:236
+#: oc-admin/themes/modern/settings/media.php
 msgid "Watermark type"
 msgstr ""
 
-#: oc-includes/osclass/installer/gui/install-finish.php:48
+#: oc-includes/osclass/installer/gui/install-finish.php
 msgid "We couldn't email your password. Copy it now and store it somewhere safe."
 msgstr ""
 
-#: oc-includes/osclass/install-functions.php:293
+#: oc-includes/osclass/install-functions.php
 msgid ""
 "We couldn't reach a database server at %s. If your site and database are on "
 "the "
 msgstr ""
 
-#: oc-includes/osclass/installer/gui/install-finish.php:33
+#: oc-includes/osclass/installer/gui/install-finish.php
 msgid ""
 "We couldn't save your selected location. You can set it later from the "
 "admin panel."
 msgstr ""
 
-#: oc-admin/themes/modern/settings/media.php:457
+#: oc-admin/themes/modern/settings/media.php
 msgid ""
 "We highly recommend you have the 'Keep original image' option active when "
 "you use watermarks."
 msgstr ""
 
-#: oc-includes/osclass/classes/upgrade/Osclass.php:124
+#: oc-includes/osclass/classes/upgrade/Osclass.php
 msgid ""
 "We've encountered some problems while updating the database structure. The "
 "following queries failed:"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:634
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "Web server"
 msgstr ""
 
-#: oc-includes/osclass/installer/gui/install-target.php:82
+#: oc-includes/osclass/installer/gui/install-target.php
 msgid "Web title"
 msgstr ""
 
-#: oc-admin/themes/modern/users/frm.php:248
+#: oc-admin/themes/modern/users/frm.php
 msgid "Website"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:657
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "Website URL"
 msgstr ""
 
-#: oc-includes/osclass/helpers/hUtils.php:347
+#: oc-includes/osclass/helpers/hUtils.php
 msgid "Wed"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/index.php:176
-#: oc-includes/osclass/helpers/hUtils.php:341
+#: oc-admin/themes/modern/settings/index.php
+#: oc-includes/osclass/helpers/hUtils.php
 msgid "Wednesday"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/index.php:162
+#: oc-admin/themes/modern/settings/index.php
 msgid "Week starts on"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/sitemap.php:39
+#: oc-admin/themes/modern/settings/sitemap.php
 msgid "Weekly"
 msgstr ""
 
-#: oc-includes/osclass/installer/gui/install.php:115
+#: oc-includes/osclass/installer/gui/install.php
 msgid "Welcome to Shopclass"
 msgstr ""
 
-#: oc-admin/themes/modern/parts/market.php:374
+#: oc-admin/themes/modern/parts/market.php
 msgid "What \"downloads\" means"
 msgstr ""
 
-#: oc-admin/themes/modern/billing/packages.php:16
+#: oc-admin/themes/modern/billing/packages.php
 msgid "What a buyer can choose at checkout — a price, a currency and how many "
 msgstr ""
 
-#: oc-admin/themes/modern/billing/order.php:123
-#: oc-admin/themes/modern/billing/wallet.php:66
+#: oc-admin/themes/modern/billing/order.php
+#: oc-admin/themes/modern/billing/wallet.php
 msgid "What happened"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:732
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid "What it should look like"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/billing.php:64
+#: oc-admin/themes/modern/settings/billing.php
 msgid "What posting costs once the free quota runs out, and what a featured "
 msgstr ""
 
-#: oc-admin/themes/modern/tools/cleanup.php:50
+#: oc-admin/themes/modern/tools/cleanup.php
 msgid "What to remove"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:733
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid "What your .htaccess file should look like"
 msgstr ""
 
-#: oc-admin/themes/modern/upgrade/index.php:289
+#: oc-admin/themes/modern/upgrade/index.php
 msgid "What's new"
 msgstr ""
 
-#: oc-admin/themes/modern/users/settings.php:64
+#: oc-admin/themes/modern/users/settings.php
 msgid "When a new user is registered"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:272
+#: oc-admin/themes/modern/tools/system-info.php
 msgid ""
 "When you cannot edit php.ini, Shopclass will lift PHP's memory limit up to "
 "%s on its own at start-up."
 msgstr ""
 
-#: oc-admin/themes/modern/settings/keywordBlock.php:190
-#: oc-admin/themes/modern/settings/keywordBlock_frm.php:81
-#: oc-includes/osclass/classes/form/KeywordBlockForm.php:45
+#: oc-admin/themes/modern/settings/keywordBlock.php
+#: oc-admin/themes/modern/settings/keywordBlock_frm.php
+#: oc-includes/osclass/classes/form/KeywordBlockForm.php
 msgid "Where to match"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/maintenance.php:42
+#: oc-admin/themes/modern/tools/maintenance.php
 msgid ""
 "While in maintenance mode, users can't access your website. Useful if you "
 "need to "
 msgstr ""
 
-#: oc-includes/osclass/classes/datatables/LogsDataTable.php:66
+#: oc-includes/osclass/classes/datatables/LogsDataTable.php
 msgid "Who"
 msgstr ""
 
-#: oc-includes/osclass/classes/datatables/KeywordBlocksDataTable.php:137
+#: oc-includes/osclass/classes/datatables/KeywordBlocksDataTable.php
 msgid "Whole word"
 msgstr ""
 
-#: oc-includes/osclass/classes/datatables/ItemsDataTable.php:650
+#: oc-includes/osclass/classes/datatables/ItemsDataTable.php
 msgid "Why hidden"
 msgstr ""
 
-#: oc-admin/themes/modern/appearance/widgets.php:114
+#: oc-admin/themes/modern/appearance/widgets.php
 msgid "Widget %d"
 msgstr ""
 
-#: oc-admin/themes/modern/appearance/add_widget.php:162
-#: oc-admin/themes/modern/appearance/page-block-form.php:67
+#: oc-admin/themes/modern/appearance/add_widget.php
+#: oc-admin/themes/modern/appearance/page-block-form.php
 msgid "Widget type"
 msgstr ""
 
-#: oc-admin/themes/modern/pages/frm.php:202
-#: oc-admin/themes/modern/pages/frm.php:289
+#: oc-admin/themes/modern/pages/frm.php
 msgid "Widgets"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/spamNbots.php:238
+#: oc-admin/themes/modern/settings/spamNbots.php
 msgid "Window"
 msgstr ""
 
-#: oc-admin/themes/modern/pages/index.php:19
+#: oc-admin/themes/modern/pages/index.php
 msgid ""
 "With Shopclass you can create static pages on which information can be "
 "stored, "
 msgstr ""
 
-#: oc-admin/themes/modern/functions.php:20
+#: oc-admin/themes/modern/functions.php
 msgid "Without expiration"
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:72
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Women looking for Men"
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:75
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Women looking for Women"
 msgstr ""
 
-#: oc-includes/osclass/classes/market/Compatibility.php:198
+#: oc-includes/osclass/classes/market/Compatibility.php
 msgid "Works with %1$s – %2$s"
 msgstr ""
 
-#: oc-includes/osclass/classes/market/Compatibility.php:195
+#: oc-includes/osclass/classes/market/Compatibility.php
 msgid "Works with %s"
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:64
+#: oc-includes/osclass/installer/basic_data.php
 msgid "Writing - Editing - Translating"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/sitemap.php:41
+#: oc-admin/themes/modern/settings/sitemap.php
 msgid "Yearly"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/submissions.php:68
-#: oc-admin/themes/modern/tools/cache.php:182
-#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php:534
-#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php:535
-#: oc-includes/osclass/helpers/hItems.php:1612
+#: oc-admin/themes/modern/fields/submissions.php
+#: oc-admin/themes/modern/tools/cache.php
+#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php
+#: oc-includes/osclass/helpers/hItems.php
 msgid "Yes"
 msgstr ""
 
-#: oc-admin/themes/modern/plugins/index.php:209
+#: oc-admin/themes/modern/plugins/index.php
 msgid "You are about to delete the files of the plugin. Do you want to continue?"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/category.php:36
+#: oc-admin/themes/modern/tools/category.php
 msgid "You can recalculate your category stats if they are incorrect."
 msgstr ""
 
-#: oc-admin/themes/modern/tools/locations.php:91
+#: oc-admin/themes/modern/tools/locations.php
 msgid "You can recalculate your location stats if they are incorrect."
 msgstr ""
 
-#: oc-admin/themes/modern/settings/media.php:440
+#: oc-admin/themes/modern/settings/media.php
 msgid ""
 "You can regenerate different image dimensions. If you have changed the "
 "dimension of thumbnails, "
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php:1094
+#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php
 msgid "You don't have the necessary permissions"
 msgstr ""
 
-#: oc-includes/osclass/install-functions.php:168
+#: oc-includes/osclass/install-functions.php
 msgid "You have to create <code>downloads</code> folder, i.e.: "
 msgstr ""
 
-#: oc-includes/osclass/install-functions.php:149
+#: oc-includes/osclass/install-functions.php
 msgid ""
 "You have to create <code>uploads</code> folder, i.e.: <code>mkdir "
 "%soc-content/uploads/</code>"
 msgstr ""
 
-#: oc-includes/osclass/install-functions.php:188
+#: oc-includes/osclass/install-functions.php
 msgid "You have to create the <code>languages</code> folder, i.e.: "
 msgstr ""
 
-#: oc-admin/themes/modern/upgrade/index.php:265
+#: oc-admin/themes/modern/upgrade/index.php
 msgid ""
 "You have uploaded a new version of Shopclass, you need to upgrade Shopclass "
 "for it to work correctly."
 msgstr ""
 
-#: oc-admin/themes/modern/parts/market.php:319
+#: oc-admin/themes/modern/parts/market.php
 msgid "You haven't checked for %s yet. Check now to browse what's available."
 msgstr ""
 
-#: oc-admin/gui/recover.php:19
+#: oc-admin/gui/recover.php
 msgid "You will receive a new password via e-mail"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/storage.php:341
+#: oc-admin/themes/modern/settings/storage.php
 msgid ""
 "Your Better S3 configuration is copied into these settings and images "
 "already in that "
 msgstr ""
 
-#: oc-includes/osclass/installer/gui/install-database.php:67
+#: oc-includes/osclass/installer/gui/install-database.php
 msgid "Your MySQL password."
 msgstr ""
 
-#: oc-includes/osclass/installer/gui/install-database.php:55
+#: oc-includes/osclass/installer/gui/install-database.php
 msgid "Your MySQL username."
 msgstr ""
 
-#: oc-includes/osclass/install-functions.php:1092
+#: oc-includes/osclass/install-functions.php
 msgid "Your Shopclass installation at %s is up and running."
 msgstr ""
 
-#: oc-admin/themes/modern/tools/upgrade.php:212
+#: oc-admin/themes/modern/tools/upgrade.php
 msgid ""
 "Your Shopclass installation can be auto-upgraded. \n"
 "                                        Please, back up your database and "
@@ -10401,455 +9845,437 @@ msgid ""
 "manually, more information in the %s"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/upgrade.php:124
+#: oc-admin/themes/modern/tools/upgrade.php
 msgid "Your Shopclass installation has been upgraded to version "
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:722
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid "Your current .htaccess file"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/advanced.php:87
+#: oc-admin/themes/modern/settings/advanced.php
 msgid "Your current host is \"%s\". Add it without \"www\"."
 msgstr ""
 
-#: oc-admin/themes/modern/admins/frm.php:120
+#: oc-admin/themes/modern/admins/frm.php
 msgid "Your current password"
 msgstr ""
 
-#: oc-admin/themes/modern/upgrade/index.php:45
+#: oc-admin/themes/modern/upgrade/index.php
 msgid "Your database already matched this version of Shopclass."
 msgstr ""
 
-#: oc-admin/themes/modern/upgrade/index.php:42
+#: oc-admin/themes/modern/upgrade/index.php
 msgid "Your database is up to date"
 msgstr ""
 
-#: oc-includes/osclass/classes/actions/ItemActions.php:1659
+#: oc-includes/osclass/classes/actions/ItemActions.php
 msgid "Your email: invalid email address"
 msgstr ""
 
-#: oc-includes/osclass/classes/actions/ItemActions.php:1665
+#: oc-includes/osclass/classes/actions/ItemActions.php
 msgid "Your friend's email: invalid email address"
 msgstr ""
 
-#: oc-includes/osclass/classes/actions/ItemActions.php:1662
+#: oc-includes/osclass/classes/actions/ItemActions.php
 msgid "Your friend's name: this field is required"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/advanced.php:85
+#: oc-admin/themes/modern/settings/advanced.php
 msgid "Your host is required to know the subdomain."
 msgstr ""
 
-#: oc-includes/osclass/helpers/hSpam.php:124
+#: oc-includes/osclass/helpers/hSpam.php
 msgid "Your listing could not be posted. Please review its content and try again."
 msgstr ""
 
-#: oc-includes/osclass/classes/actions/ItemActions.php:1656
-#: oc-includes/osclass/classes/actions/ItemActions.php:1760
-#: oc-includes/osclass/classes/form/SendFriendForm.php:115
+#: oc-includes/osclass/classes/actions/ItemActions.php
+#: oc-includes/osclass/classes/form/SendFriendForm.php
 msgid "Your name: this field is required"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/index.php:795
+#: oc-admin/themes/modern/fields/index.php
 msgid ""
 "Your reusable fields. Drag one into a form on the left, or use a form’s "
 "“Add field”. The same field can be placed in several forms."
 msgstr ""
 
-#: oc-includes/osclass/installer/gui/install.php:135
+#: oc-includes/osclass/installer/gui/install.php
 msgid "Your server is missing something Shopclass needs."
 msgstr ""
 
-#: oc-includes/osclass/installer/gui/install.php:148
+#: oc-includes/osclass/installer/gui/install.php
 msgid "Your server meets every requirement."
 msgstr ""
 
-#: oc-includes/osclass/installer/gui/install.php:238
+#: oc-includes/osclass/installer/gui/install.php
 msgid ""
 "Your session expired before setup finished. Please restart the installer to "
 "complete it."
 msgstr ""
 
-#: oc-includes/osclass/install.php:192
+#: oc-includes/osclass/install.php
 msgid "Your session expired — please submit the form again."
 msgstr ""
 
-#: oc-includes/osclass/install-location.php:57
+#: oc-includes/osclass/install-location.php
 msgid "Your session expired. Reload the page and start again."
 msgstr ""
 
-#: oc-includes/osclass/install.php:121
+#: oc-includes/osclass/install.php
 msgid "Your session expired. Reload the page and try again."
 msgstr ""
 
-#: oc-includes/osclass/installer/gui/install.php:36
+#: oc-includes/osclass/installer/gui/install.php
 msgid "Your site"
 msgstr ""
 
-#: oc-admin/themes/modern/upgrade/index.php:54
+#: oc-admin/themes/modern/upgrade/index.php
 msgid "Your site has not been changed. Nothing was left half-done."
 msgstr ""
 
-#: oc-includes/osclass/installer/gui/install-finish.php:28
+#: oc-includes/osclass/installer/gui/install-finish.php
 msgid "Your site is ready."
 msgstr ""
 
-#: oc-admin/themes/modern/appearance/widgets.php:95
+#: oc-admin/themes/modern/appearance/widgets.php
 msgid ""
 "Your theme no longer has this section — these widgets are not shown on the "
 "site. Move them somewhere else, or delete them."
 msgstr ""
 
-#: oc-admin/themes/modern/categories/iframe.php:39
+#: oc-admin/themes/modern/categories/iframe.php
 msgid "Zero means listings in this category never expire."
 msgstr ""
 
-#: oc-admin/themes/modern/items/frm.php:277
-#: oc-admin/themes/modern/users/frm.php:316
+#: oc-admin/themes/modern/items/frm.php
+#: oc-admin/themes/modern/users/frm.php
 msgid "Zip code"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:616
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "allow_url_fopen"
 msgstr ""
 
-#: oc-includes/osclass/helpers/hUtils.php:348
+#: oc-includes/osclass/helpers/hUtils.php
 msgid "am"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/index.php:301
+#: oc-admin/themes/modern/settings/index.php
 msgid "at most"
 msgstr ""
 
-#: oc-admin/themes/modern/parts/market.php:405
-#: oc-admin/themes/modern/parts/market.php:611
+#: oc-admin/themes/modern/parts/market.php
 msgid "by %s"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:367
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "cURL"
 msgstr ""
 
-#: oc-includes/osclass/install-functions.php:140
+#: oc-includes/osclass/install-functions.php
 msgid "cURL extension for PHP"
 msgstr ""
 
-#: oc-includes/osclass/install-functions.php:142
+#: oc-includes/osclass/install-functions.php
 msgid "cURL extension is required. How to "
 msgstr ""
 
-#: oc-includes/osclass/classes/EmailVariables.php:67
+#: oc-includes/osclass/classes/EmailVariables.php
 msgid "change user password url"
 msgstr ""
 
-#: oc-includes/osclass/install-functions.php:595
+#: oc-includes/osclass/install-functions.php
 msgid "config-sample.php doesn't exist. Check if everything is "
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:599
+#: oc-admin/themes/modern/tools/system-info.php
 msgid ""
 "config.php is writable by the web server. It holds your database "
 "credentials and does not need to be writable after install — make it "
 "read-only."
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:597
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "config.php permissions"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:578
+#: oc-admin/themes/modern/tools/system-info.php
 msgid ""
 "config.php sets %1$s, but that driver is not available — so the cache "
 "silently falls back to per-request and every page recomputes its data. "
 "Install the matching extension, or remove the setting."
 msgstr ""
 
-#: oc-admin/themes/modern/billing/order.php:71
-#: oc-admin/themes/modern/billing/wallet.php:120
+#: oc-admin/themes/modern/billing/order.php
+#: oc-admin/themes/modern/billing/wallet.php
 msgid "credits"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:373
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "ctype"
 msgstr ""
 
-#: oc-admin/themes/modern/items/settings.php:208
-#: oc-admin/themes/modern/tools/cleanup.php:136
-#: oc-admin/themes/modern/tools/cleanup.php:77
-#: oc-admin/themes/modern/tools/logs.php:61
+#: oc-admin/themes/modern/items/settings.php
+#: oc-admin/themes/modern/tools/cleanup.php
+#: oc-admin/themes/modern/tools/logs.php
 msgid "days"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/spamNbots.php:271
+#: oc-admin/themes/modern/settings/spamNbots.php
 msgid "days, pruned by the daily cron. Only the window above "
 msgstr ""
 
-#: oc-admin/themes/modern/tools/logs.php:93
+#: oc-admin/themes/modern/tools/logs.php
 msgid "details, action or IP"
 msgstr ""
 
-#: oc-includes/osclass/classes/upgrade/Upgrade.php:146
+#: oc-includes/osclass/classes/upgrade/Upgrade.php
 msgid ""
 "doesn't exists, unknown error occurred while downloading and extracting "
 "package."
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:428
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "enabled"
 msgstr ""
 
-#: oc-includes/vendor/gettext/gettext/src/Extractors/VueJs.php:379
+#: oc-includes/vendor/gettext/gettext/src/Extractors/VueJs.php
 msgid "extract element content"
 msgstr ""
 
-#: oc-includes/vendor/gettext/gettext/src/Extractors/VueJs.php:290
+#: oc-includes/vendor/gettext/gettext/src/Extractors/VueJs.php
 msgid "extract this"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:369
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "fileinfo"
 msgstr ""
 
-#: oc-includes/osclass/classes/form/FieldForm.php:473
-#: oc-includes/osclass/classes/form/FieldForm.php:502
+#: oc-includes/osclass/classes/form/FieldForm.php
 msgid "from"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:382
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "installed"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/iframe.php:186
+#: oc-admin/themes/modern/fields/iframe.php
 msgid "is"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/iframe.php:186
+#: oc-admin/themes/modern/fields/iframe.php
 msgid "is filled"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/iframe.php:186
+#: oc-admin/themes/modern/fields/iframe.php
 msgid "is greater than"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/iframe.php:186
+#: oc-admin/themes/modern/fields/iframe.php
 msgid "is less than"
 msgstr ""
 
-#: oc-admin/themes/modern/fields/iframe.php:186
+#: oc-admin/themes/modern/fields/iframe.php
 msgid "is not"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:86
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "just now"
 msgstr ""
 
-#: oc-includes/osclass/classes/datatables/ItemsDataTable.php:820
+#: oc-includes/osclass/classes/datatables/ItemsDataTable.php
 msgid "keyword"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/index.php:293
-#: oc-admin/themes/modern/settings/index.php:309
+#: oc-admin/themes/modern/settings/index.php
 msgid "listings at most"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:368
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "mbstring"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/spamNbots.php:242
+#: oc-admin/themes/modern/settings/spamNbots.php
 msgid "minutes. How far back failures are counted, and so how "
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:382
-#: oc-admin/themes/modern/tools/system-info.php:419
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "missing"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:366
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "mysqli"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/index.php:440
+#: oc-admin/themes/modern/settings/index.php
 msgid "never"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:540
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "never run"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/permalinks.php:695
+#: oc-admin/themes/modern/settings/permalinks.php
 msgid "nginx does not read .htaccess files. Add the "
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebAjax.php:414
-#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php:1097
+#: oc-includes/osclass/classes/controller/CWebAjax.php
+#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php
 msgid "no action defined"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:203
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "not set"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:201
-#: oc-admin/themes/modern/tools/system-info.php:428
-#: oc-admin/themes/modern/tools/system-info.php:589
-#: oc-admin/themes/modern/tools/system-info.php:618
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "off"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:201
-#: oc-admin/themes/modern/tools/system-info.php:589
-#: oc-admin/themes/modern/tools/system-info.php:609
-#: oc-admin/themes/modern/tools/system-info.php:618
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "on"
 msgstr ""
 
-#: oc-admin/themes/modern/items/frm.php:207
+#: oc-admin/themes/modern/items/frm.php
 msgid "optional"
 msgstr ""
 
-#: oc-includes/osclass/installer/basic_data.php:106
+#: oc-includes/osclass/installer/basic_data.php
 msgid "osclass@example.com"
 msgstr ""
 
-#: oc-includes/osclass/install-functions.php:1097
+#: oc-includes/osclass/install-functions.php
 msgid "password: %s"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:565
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "per-request"
 msgstr ""
 
-#: oc-admin/themes/modern/parts/market.php:286
+#: oc-admin/themes/modern/parts/market.php
 msgid "plugins"
 msgstr ""
 
-#: oc-includes/osclass/helpers/hUtils.php:348
+#: oc-includes/osclass/helpers/hUtils.php
 msgid "pm"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:455
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "post_max_size is smaller than upload_max_filesize"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/spamNbots.php:146
+#: oc-admin/themes/modern/settings/spamNbots.php
 msgid "reCAPTCHA secret key"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/spamNbots.php:138
+#: oc-admin/themes/modern/settings/spamNbots.php
 msgid "reCAPTCHA site key"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/spamNbots.php:125
+#: oc-admin/themes/modern/settings/spamNbots.php
 msgid "reCAPTCHA site key and reCAPTCHA secret key"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:446
-#: oc-admin/themes/modern/tools/system-info.php:601
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "read-only"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/sitemap.php:170
+#: oc-admin/themes/modern/settings/sitemap.php
 msgid "robots.txt"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/sitemap.php:181
+#: oc-admin/themes/modern/settings/sitemap.php
 msgid "robots.txt contents"
 msgstr ""
 
-#: oc-admin/themes/modern/settings/sitemap.php:173
+#: oc-admin/themes/modern/settings/sitemap.php
 msgid ""
 "robots.txt is not writable by the web server. Fix the file or folder "
 "permissions before saving changes here."
 msgstr ""
 
-#: oc-includes/osclass/classes/upgrade/UpgradePackage.php:131
+#: oc-includes/osclass/classes/upgrade/UpgradePackage.php
 msgid "s_source_file is not a valid url"
 msgstr ""
 
-#: oc-admin/themes/modern/parts/market.php:286
+#: oc-admin/themes/modern/parts/market.php
 msgid "themes"
 msgstr ""
 
-#: oc-admin/themes/modern/billing/order.php:211
+#: oc-admin/themes/modern/billing/order.php
 msgid "this user"
 msgstr ""
 
-#: oc-includes/osclass/classes/form/FieldForm.php:477
-#: oc-includes/osclass/classes/form/FieldForm.php:504
-#: oc-includes/osclass/helpers/hItems.php:1589
+#: oc-includes/osclass/classes/form/FieldForm.php
+#: oc-includes/osclass/helpers/hItems.php
 msgid "to"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:347
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "unavailable"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:349
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "unknown"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:523
-#: oc-admin/themes/modern/tools/system-info.php:62
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "unlimited"
 msgstr ""
 
-#: oc-includes/osclass/emails.php:147
-#: oc-includes/osclass/emails.php:245
-#: oc-includes/osclass/emails.php:343
+#: oc-includes/osclass/emails.php
 msgid "unsubscribe alert"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:579
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "unsupported"
 msgstr ""
 
-#: oc-includes/osclass/install-functions.php:1096
+#: oc-includes/osclass/install-functions.php
 msgid "username: %s"
 msgstr ""
 
-#: oc-admin/themes/modern/appearance/widgets.php:293
+#: oc-admin/themes/modern/appearance/widgets.php
 msgid "widgets"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:446
-#: oc-admin/themes/modern/tools/system-info.php:601
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "writable"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:370
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "zip"
 msgstr ""
 
-#: oc-includes/osclass/emails.php:1867
+#: oc-includes/osclass/emails.php
 msgid "{WEB_TITLE} - We failed trying to upgrade your site to Shopclass {VERSION}"
 msgstr ""
 
-#: oc-includes/osclass/emails.php:1860
+#: oc-includes/osclass/emails.php
 msgid "{WEB_TITLE} - Your site has upgraded to Shopclass {VERSION}"
 msgstr ""
 
-#: oc-includes/osclass/classes/form/ItemForm.php:1585
+#: oc-includes/osclass/classes/form/ItemForm.php
 msgid "{file} could not be uploaded."
 msgstr ""
 
-#: oc-includes/osclass/classes/form/ItemForm.php:1582
+#: oc-includes/osclass/classes/form/ItemForm.php
 msgid "{file} has an invalid extension. Valid extension(s): {extensions}."
 msgstr ""
 
-#: oc-includes/osclass/classes/form/ItemForm.php:1583
+#: oc-includes/osclass/classes/form/ItemForm.php
 msgid "{file} is too large."
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:233
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "— PHP limits"
 msgstr ""
 
-#: oc-includes/osclass/helpers/hForms.php:87
+#: oc-includes/osclass/helpers/hForms.php
 msgid "— Select a form —"
 msgstr ""
 
-#: oc-admin/themes/modern/tools/system-info.php:267
+#: oc-admin/themes/modern/tools/system-info.php
 msgid "— Shopclass"
 msgstr ""

--- a/oc-content/languages/messages.pot
+++ b/oc-content/languages/messages.pot
@@ -9,2506 +9,2386 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "x-generator: scripts/build-i18n.mjs\n"
 
-#: oc-includes/osclass/classes/controller/admin/CAdminItems.php:146
-#: oc-includes/osclass/classes/controller/admin/CAdminItems.php:179
+#: oc-includes/osclass/classes/controller/admin/CAdminItems.php
 msgid "%d change has been made"
 msgid_plural "%d changes have been made"
 msgstr[0] ""
 msgstr[1] ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminBilling.php:289
+#: oc-includes/osclass/classes/controller/admin/CAdminBilling.php
 msgid "%d credits added"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminBilling.php:303
+#: oc-includes/osclass/classes/controller/admin/CAdminBilling.php
 msgid "%d credits removed"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsKeywordBlock.php:169
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsKeywordBlock.php
 msgid "%d keyword has been imported"
 msgid_plural "%d keywords have been imported"
 msgstr[0] ""
 msgstr[1] ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminItems.php:98
+#: oc-includes/osclass/classes/controller/admin/CAdminItems.php
 msgid "%d listing has been activated"
 msgid_plural "%d listings have been activated"
 msgstr[0] ""
 msgstr[1] ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminItems.php:114
+#: oc-includes/osclass/classes/controller/admin/CAdminItems.php
 msgid "%d listing has been deactivated"
 msgid_plural "%d listings have been deactivated"
 msgstr[0] ""
 msgstr[1] ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminItems.php:201
+#: oc-includes/osclass/classes/controller/admin/CAdminItems.php
 msgid "%d listing has been deleted"
 msgid_plural "%d listings have been deleted"
 msgstr[0] ""
 msgstr[1] ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminItems.php:82
+#: oc-includes/osclass/classes/controller/admin/CAdminItems.php
 msgid "%d listing has been disabled"
 msgid_plural "%d listings have been disabled"
 msgstr[0] ""
 msgstr[1] ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminItems.php:66
+#: oc-includes/osclass/classes/controller/admin/CAdminItems.php
 msgid "%d listing has been enabled"
 msgid_plural "%d listings have been enabled"
 msgstr[0] ""
 msgstr[1] ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminItems.php:130
+#: oc-includes/osclass/classes/controller/admin/CAdminItems.php
 msgid "%d listing has been marked as premium"
 msgid_plural "%d listings have been marked as premium"
 msgstr[0] ""
 msgstr[1] ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminItems.php:162
+#: oc-includes/osclass/classes/controller/admin/CAdminItems.php
 msgid "%d listing has been marked as spam"
 msgid_plural "%d listings have been marked as spam"
 msgstr[0] ""
 msgstr[1] ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminItems.php:330
+#: oc-includes/osclass/classes/controller/admin/CAdminItems.php
 msgid "%d listing has been unmarked"
 msgid_plural "%d listings have been unmarked"
 msgstr[0] ""
 msgstr[1] ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminItems.php:267
+#: oc-includes/osclass/classes/controller/admin/CAdminItems.php
 msgid "%d listing has been unmarked as duplicated"
 msgid_plural "%d listings have been unmarked as duplicated"
 msgstr[0] ""
 msgstr[1] ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminItems.php:288
+#: oc-includes/osclass/classes/controller/admin/CAdminItems.php
 msgid "%d listing has been unmarked as expired"
 msgid_plural "%d listings have been unmarked as expired"
 msgstr[0] ""
 msgstr[1] ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminItems.php:244
+#: oc-includes/osclass/classes/controller/admin/CAdminItems.php
 msgid "%d listing has been unmarked as missclassified"
 msgid_plural "%d listings have been unmarked as missclassified"
 msgstr[0] ""
 msgstr[1] ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminItems.php:309
+#: oc-includes/osclass/classes/controller/admin/CAdminItems.php
 msgid "%d listing has been unmarked as offensive"
 msgid_plural "%d listings have been unmarked as offensive"
 msgstr[0] ""
 msgstr[1] ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminItems.php:222
+#: oc-includes/osclass/classes/controller/admin/CAdminItems.php
 msgid "%d listing has been unmarked as spam"
 msgid_plural "%d listings have been unmarked as spam"
 msgstr[0] ""
 msgstr[1] ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminItems.php:352
+#: oc-includes/osclass/classes/controller/admin/CAdminItems.php
 msgid "%d listing has had its reports cleared"
 msgid_plural "%d listings have had their reports cleared"
 msgstr[0] ""
 msgstr[1] ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminTools.php:431
+#: oc-includes/osclass/classes/controller/admin/CAdminTools.php
 msgid "%d log entry has been removed"
 msgid_plural "%d log entries have been removed"
 msgstr[0] ""
 msgstr[1] ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsLocations.php:208
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsLocations.php:283
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsLocations.php:380
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsLocations.php:454
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsLocations.php:56
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsLocations.php
 msgid "%s already was in the database"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebBilling.php:269
+#: oc-includes/osclass/classes/controller/CWebBilling.php
 msgid "%s applied to this listing"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php:321
-#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php:380
+#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php
 msgid "%s can't be disabled because it's the default language"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsCurrencies.php:157
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsCurrencies.php
 msgid "%s couldn't be deleted because it has listings associated to it"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsCurrencies.php:160
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsCurrencies.php
 msgid "%s couldn't be deleted because it's the default currency"
 msgstr ""
 
-#: oc-includes/osclass/gui/billing/buy-content.php:113
+#: oc-includes/osclass/gui/billing/buy-content.php
 msgid "%s credits"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsCurrencies.php:176
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsCurrencies.php
 msgid "%s currencies have been deleted"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebBilling.php:268
+#: oc-includes/osclass/classes/controller/CWebBilling.php
 msgid "%s extended on this listing"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsLocations.php:375
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsLocations.php
 msgid "%s has been added as a new city"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsLocations.php:65
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsLocations.php
 msgid "%s has been added as a new country"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsLocations.php:203
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsLocations.php
 msgid "%s has been added as a new region"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsLocations.php:277
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsLocations.php:449
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsLocations.php
 msgid "%s has been edited"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php:276
+#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php
 msgid "%s has been updated"
 msgstr ""
 
-#: oc-includes/osclass/classes/actions/ItemActions.php:719
-#: oc-includes/osclass/classes/actions/ItemActions.php:733
-#: oc-includes/osclass/classes/actions/ItemActions.php:757
-#: oc-includes/osclass/classes/actions/ItemActions.php:761
-#: oc-includes/osclass/classes/actions/ItemActions.php:771
-#: oc-includes/osclass/classes/actions/ItemActions.php:773
+#: oc-includes/osclass/classes/actions/ItemActions.php
 msgid "%s is invalid."
 msgstr ""
 
-#: oc-includes/osclass/classes/actions/ItemActions.php:722
-#: oc-includes/osclass/classes/actions/ItemActions.php:725
-#: oc-includes/osclass/classes/actions/ItemActions.php:736
-#: oc-includes/osclass/classes/actions/ItemActions.php:764
-#: oc-includes/osclass/classes/actions/ItemActions.php:776
-#: oc-includes/osclass/classes/actions/ItemActions.php:783
+#: oc-includes/osclass/classes/actions/ItemActions.php
 msgid "%s is required."
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminPages.php:238
+#: oc-includes/osclass/classes/controller/admin/CAdminPages.php
 msgid "%s pages couldn't be deleted"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminPages.php:228
+#: oc-includes/osclass/classes/controller/admin/CAdminPages.php
 msgid "%s pages couldn't be deleted because they are indelible"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminPages.php:248
+#: oc-includes/osclass/classes/controller/admin/CAdminPages.php
 msgid "%s pages have been deleted correctly"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebItem.php:595
+#: oc-includes/osclass/classes/controller/CWebItem.php
 msgid "<a href=\"%s\">Click here to sign-in</a>"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminItems.php:746
+#: oc-includes/osclass/classes/controller/admin/CAdminItems.php
 msgid "A new listing has been added"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminLogin.php:205
+#: oc-includes/osclass/classes/controller/admin/CAdminLogin.php
 msgid "A new password has been sent to your e-mail"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebItem.php:161
+#: oc-includes/osclass/classes/controller/CWebItem.php
 msgid "A user with that email address already exists, if it is you, please log in"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebRegister.php:114
+#: oc-includes/osclass/classes/controller/CWebRegister.php
 msgid "Account validation failed"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php:183
+#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php
 msgid "Activation email sent to one user"
 msgid_plural "Activation email sent to %s users"
 msgstr[0] ""
 msgstr[1] ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminTools.php:420
+#: oc-includes/osclass/classes/controller/admin/CAdminTools.php
 msgid "Activity log settings saved"
 msgstr ""
 
-#: oc-includes/osclass/gui/billing/wallet-content.php:51
+#: oc-includes/osclass/gui/billing/wallet-content.php
 msgid "Added by admin"
 msgstr ""
 
-#: oc-includes/osclass/classes/actions/ItemActions.php:592
+#: oc-includes/osclass/classes/actions/ItemActions.php
 msgid "Address too long."
 msgstr ""
 
-#: oc-includes/osclass/classes/actions/ItemActions.php:590
+#: oc-includes/osclass/classes/actions/ItemActions.php
 msgid "Address too short."
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsAdvanced.php:53
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsAdvanced.php
 msgid "Advanced settings have been updated"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebUser.php:285
-#: oc-includes/osclass/classes/controller/CWebUserNonSecure.php:118
+#: oc-includes/osclass/classes/controller/CWebUser.php
+#: oc-includes/osclass/classes/controller/CWebUserNonSecure.php
 msgid "Alert activated"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php:328
-#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php:364
+#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php
 msgid "Alert id isn't in the correct format"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsPermalinks.php:359
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsPermalinks.php
 msgid "All fields are required."
 msgstr ""
 
-#: oc-includes/osclass/gui/billing/orders-content.php:99
+#: oc-includes/osclass/gui/billing/orders-content.php
 msgid "Amount"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminItems.php:416
-#: oc-includes/osclass/classes/controller/admin/CAdminItems.php:430
-#: oc-includes/osclass/classes/controller/admin/CAdminItems.php:439
-#: oc-includes/osclass/classes/controller/admin/CAdminItems.php:448
-#: oc-includes/osclass/classes/controller/admin/CAdminItems.php:480
-#: oc-includes/osclass/classes/controller/admin/CAdminItems.php:509
-#: oc-includes/osclass/classes/controller/admin/CAdminItems.php:695
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsKeywordBlock.php:265
+#: oc-includes/osclass/classes/controller/admin/CAdminItems.php
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsKeywordBlock.php
 msgid "An error has occurred"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminTools.php:220
-#: oc-includes/osclass/classes/controller/admin/CAdminTools.php:258
+#: oc-includes/osclass/classes/controller/admin/CAdminTools.php
 msgid "Archived successfully!"
 msgstr ""
 
-#: oc-includes/osclass/gui/billing/orders-content.php:144
+#: oc-includes/osclass/gui/billing/orders-content.php
 msgid "Back to your wallet"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminTools.php:150
-#: oc-includes/osclass/classes/controller/admin/CAdminTools.php:194
+#: oc-includes/osclass/classes/controller/admin/CAdminTools.php
 msgid "Backup completed successfully"
 msgstr ""
 
-#: oc-includes/osclass/gui/billing/wallet-content.php:105
+#: oc-includes/osclass/gui/billing/wallet-content.php
 msgid "Balance after"
 msgstr ""
 
-#: oc-includes/osclass/classes/billing/gateway/OfflineGateway.php:35
+#: oc-includes/osclass/classes/billing/gateway/OfflineGateway.php
 msgid "Bank transfer"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsBilling.php:159
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsBilling.php
 msgid "Bank transfer settings have been updated"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsStorage.php:215
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsStorage.php
 msgid "Better S3 is not configured; nothing to adopt."
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsStorage.php:239
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsStorage.php
 msgid ""
 "Better S3 settings imported. Existing images are adopted in the background "
 "as the storage worker runs."
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebBilling.php:76
+#: oc-includes/osclass/classes/controller/CWebBilling.php
 msgid "Billing is not available on this site"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminBilling.php:57
+#: oc-includes/osclass/classes/controller/admin/CAdminBilling.php
 msgid "Billing is switched off. Turn it on to use orders and credits."
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsBilling.php:102
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsBilling.php
 msgid "Billing settings have been updated"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php:579
-#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php:598
+#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php
 msgid "Both rules can not be empty"
 msgstr ""
 
-#: oc-includes/osclass/gui/billing/buy-content.php:76
-#: oc-includes/osclass/gui/billing/buy.php:32
-#: oc-includes/osclass/helpers/hBilling.php:825
+#: oc-includes/osclass/gui/billing/buy-content.php
+#: oc-includes/osclass/gui/billing/buy.php
+#: oc-includes/osclass/helpers/hBilling.php
 msgid "Buy credits"
 msgstr ""
 
-#: oc-includes/osclass/gui/billing/wallet-content.php:90
+#: oc-includes/osclass/gui/billing/wallet-content.php
 msgid "Buy more credits"
 msgstr ""
 
-#: oc-includes/osclass/gui/billing/buy-content.php:35
+#: oc-includes/osclass/gui/billing/buy-content.php
 msgid "Buying credits is not available on this site."
 msgstr ""
 
-#: oc-includes/osclass/gui/billing/orders-content.php:54
+#: oc-includes/osclass/gui/billing/orders-content.php
 msgid "Cancelled"
 msgstr ""
 
-#: oc-includes/osclass/classes/actions/ItemActions.php:565
+#: oc-includes/osclass/classes/actions/ItemActions.php
 msgid "Category invalid."
 msgstr ""
 
-#: oc-includes/osclass/gui/billing/wallet-content.php:104
+#: oc-includes/osclass/gui/billing/wallet-content.php
 msgid "Change"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminItems.php:478
-#: oc-includes/osclass/classes/controller/admin/CAdminItems.php:507
+#: oc-includes/osclass/classes/controller/admin/CAdminItems.php
 msgid "Changes have been applied"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminItems.php:659
+#: oc-includes/osclass/classes/controller/admin/CAdminItems.php
 msgid "Changes saved correctly"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebItem.php:192
+#: oc-includes/osclass/classes/controller/CWebItem.php
 msgid "Check your inbox to validate your listing"
 msgstr ""
 
-#: oc-includes/osclass/gui/billing/buy-content.php:105
+#: oc-includes/osclass/gui/billing/buy-content.php
 msgid "Choose a package"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsLocations.php:405
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsLocations.php
 msgid "City name cannot be blank"
 msgstr ""
 
-#: oc-includes/osclass/classes/actions/ItemActions.php:584
+#: oc-includes/osclass/classes/actions/ItemActions.php
 msgid "City too long."
 msgstr ""
 
-#: oc-includes/osclass/classes/actions/ItemActions.php:583
+#: oc-includes/osclass/classes/actions/ItemActions.php
 msgid "City too short."
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminTools.php:352
+#: oc-includes/osclass/classes/controller/admin/CAdminTools.php
 msgid "Cleanup ran, but nothing matched the enabled rules."
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminTools.php:350
+#: oc-includes/osclass/classes/controller/admin/CAdminTools.php
 msgid "Cleanup removed %d item(s). Run again to clear any remaining backlog."
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminTools.php:339
+#: oc-includes/osclass/classes/controller/admin/CAdminTools.php
 msgid "Cleanup settings saved"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminItemComments.php:184
+#: oc-includes/osclass/classes/controller/admin/CAdminItemComments.php
 msgid "Comment is required"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsComments.php:83
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsComments.php
 msgid "Comment settings have been updated"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsComments.php:62
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsComments.php
 msgid "Comments per page must only contain numeric characters"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminPlugins.php:247
+#: oc-includes/osclass/classes/controller/admin/CAdminPlugins.php
 msgid "Configuration was saved"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsStorage.php:185
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsStorage.php:198
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsStorage.php
 msgid "Configure and activate a remote backend first."
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsStorage.php:160
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsStorage.php:163
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsStorage.php
 msgid "Connection test failed. Check your credentials and settings."
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsStorage.php:158
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsStorage.php
 msgid "Connection test succeeded"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsMain.php:80
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsMain.php
 msgid "Contact email field is required"
 msgstr ""
 
-#: oc-includes/osclass/gui/billing/buy-content.php:138
+#: oc-includes/osclass/gui/billing/buy-content.php
 msgid "Continue"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminTools.php:138
+#: oc-includes/osclass/classes/controller/admin/CAdminTools.php
 msgid "Could not connect with the database"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminTools.php:173
+#: oc-includes/osclass/classes/controller/admin/CAdminTools.php
 msgid "Could not connect with the database. Error: %s"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminTools.php:180
+#: oc-includes/osclass/classes/controller/admin/CAdminTools.php
 msgid "Could not select the database. Error: %s"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsLocations.php:123
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsLocations.php
 msgid "Country has been edited"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsLocations.php:84
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsLocations.php
 msgid "Country name cannot be blank"
 msgstr ""
 
-#: oc-includes/osclass/classes/actions/ItemActions.php:577
+#: oc-includes/osclass/classes/actions/ItemActions.php
 msgid "Country too long."
 msgstr ""
 
-#: oc-includes/osclass/classes/actions/ItemActions.php:575
+#: oc-includes/osclass/classes/actions/ItemActions.php
 msgid "Country too short."
 msgstr ""
 
-#: oc-includes/osclass/gui/billing/orders-content.php:100
-#: oc-includes/osclass/gui/billing/wallet-content.php:76
-#: oc-includes/osclass/gui/billing/wallet.php:33
-#: oc-includes/osclass/helpers/hBilling.php:824
+#: oc-includes/osclass/gui/billing/orders-content.php
+#: oc-includes/osclass/gui/billing/wallet-content.php
+#: oc-includes/osclass/gui/billing/wallet.php
+#: oc-includes/osclass/helpers/hBilling.php
 msgid "Credits"
 msgstr ""
 
-#: oc-includes/osclass/gui/billing/wallet-content.php:33
+#: oc-includes/osclass/gui/billing/wallet-content.php
 msgid "Credits are not available on this site."
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminBilling.php:363
+#: oc-includes/osclass/classes/controller/admin/CAdminBilling.php
 msgid "Credits must be at least 1"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsCurrencies.php:72
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsCurrencies.php
 msgid "Currency added"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsCurrencies.php:74
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsCurrencies.php
 msgid "Currency couldn't be added"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php:249
+#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php
 msgid "Currency format field is required"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminBilling.php:368
+#: oc-includes/osclass/classes/controller/admin/CAdminBilling.php
 msgid "Currency must be a 3-letter code, e.g. USD"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsBilling.php:110
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsBilling.php
 msgid "Currency must be a 3-letter code, e.g. USD."
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsCurrencies.php:132
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsCurrencies.php
 msgid "Currency updated"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebUser.php:219
+#: oc-includes/osclass/classes/controller/CWebUser.php
 msgid "Current password doesn't match"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminAppearance.php:94
+#: oc-includes/osclass/classes/controller/admin/CAdminAppearance.php
 msgid "Current theme can not be deleted"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsSitemap.php:107
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsSitemap.php
 msgid "Custom URL added to the sitemap"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsSitemap.php:120
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsSitemap.php
 msgid "Custom URL removed from the sitemap"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsLatestSearches.php:48
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsLatestSearches.php
 msgid "Custom number could not be left empty"
 msgstr ""
 
-#: oc-includes/osclass/gui/billing/orders-content.php:97
-#: oc-includes/osclass/gui/billing/wallet-content.php:106
+#: oc-includes/osclass/gui/billing/orders-content.php
+#: oc-includes/osclass/gui/billing/wallet-content.php
 msgid "Date"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminItems.php:820
+#: oc-includes/osclass/classes/controller/admin/CAdminItems.php
 msgid "Description Length has to be a numeric value"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminAppearance.php:135
-#: oc-includes/osclass/classes/controller/admin/CAdminAppearance.php:174
+#: oc-includes/osclass/classes/controller/admin/CAdminAppearance.php
 msgid "Description field is required"
 msgstr ""
 
-#: oc-includes/osclass/classes/actions/ItemActions.php:561
+#: oc-includes/osclass/classes/actions/ItemActions.php
 msgid "Description too long (%s)."
 msgstr ""
 
-#: oc-includes/osclass/classes/actions/ItemActions.php:558
+#: oc-includes/osclass/classes/actions/ItemActions.php
 msgid "Description too short (%s)."
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php:431
+#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php
 msgid "Directory \"%s\" has been successfully removed"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php:141
+#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php
 msgid "Directory \"%s\" was not created"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php:426
+#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php
 msgid "Directory '%s' couldn't be removed"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php:414
+#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php
 msgid ""
 "Directory '%s' couldn't be removed because it's the default language. <a "
 "href=\"%s\">Set another language</a> as default first and try again"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php:437
+#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php
 msgid "Directory '%s' couldn't be removed;)"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminAdmins.php:101
+#: oc-includes/osclass/classes/controller/admin/CAdminAdmins.php
 msgid "Email already in use"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminAdmins.php:192
-#: oc-includes/osclass/classes/controller/admin/CAdminAdmins.php:84
+#: oc-includes/osclass/classes/controller/admin/CAdminAdmins.php
 msgid "Email invalid"
 msgstr ""
 
-#: oc-includes/osclass/classes/actions/ItemActions.php:191
+#: oc-includes/osclass/classes/actions/ItemActions.php
 msgid "Email invalid."
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminItemComments.php:181
+#: oc-includes/osclass/classes/controller/admin/CAdminItemComments.php
 msgid "Email is not correct"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebLogin.php:51
+#: oc-includes/osclass/classes/controller/CWebLogin.php
 msgid "Empty passwords are not allowed. Please provide a password"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminBilling.php:353
+#: oc-includes/osclass/classes/controller/admin/CAdminBilling.php
 msgid "Enter a name for this package"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsSitemap.php:101
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsSitemap.php
 msgid "Enter a valid URL, including the scheme (e.g. https://example.com/page)"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminBilling.php:358
+#: oc-includes/osclass/classes/controller/admin/CAdminBilling.php
 msgid "Enter a valid amount, 0 or more"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminBilling.php:282
+#: oc-includes/osclass/classes/controller/admin/CAdminBilling.php
 msgid "Enter how many credits to add or remove"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminMain.php:92
+#: oc-includes/osclass/classes/controller/admin/CAdminMain.php
 msgid "Entered an invalid email"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminMain.php:101
+#: oc-includes/osclass/classes/controller/admin/CAdminMain.php
 msgid "Error subscribing"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebLogin.php:330
+#: oc-includes/osclass/classes/controller/CWebLogin.php
 msgid "Error, the password don't match"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminLogin.php:249
+#: oc-includes/osclass/classes/controller/admin/CAdminLogin.php
 msgid "Error, the passwords don't match"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminTools.php:235
-#: oc-includes/osclass/classes/controller/admin/CAdminTools.php:261
+#: oc-includes/osclass/classes/controller/admin/CAdminTools.php
 msgid "Error, the zip file was not created in the specified directory"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsCurrencies.php:119
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsCurrencies.php
 msgid "Error: the currency code is not in the correct format"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminAdmins.php:212
+#: oc-includes/osclass/classes/controller/admin/CAdminAdmins.php
 msgid "Existing email"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminAdmins.php:217
+#: oc-includes/osclass/classes/controller/admin/CAdminAdmins.php
 msgid "Existing username"
 msgstr ""
 
-#: oc-includes/osclass/gui/billing/orders-content.php:52
+#: oc-includes/osclass/gui/billing/orders-content.php
 msgid "Failed"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsPermalinks.php:408
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsPermalinks.php
 msgid "File <b>.htaccess</b> already exists and was not modified."
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsPermalinks.php:384
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsPermalinks.php:394
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsPermalinks.php
 msgid "File <b>.htaccess</b> couldn't be filled out with the right content."
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php:73
+#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php
 msgid "File uploaded but unable to activate the language"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsPermalinks.php:447
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsPermalinks.php
 msgid ""
 "Friendly URLs deactivated, but .htaccess file could not be deleted. Please, "
 "remove it manually"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsPermalinks.php:452
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsPermalinks.php
 msgid ""
 "Friendly URLs deactivated, but .htaccess file was modified outside "
 "Shopclass and was not deleted"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsPermalinks.php:444
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsPermalinks.php
 msgid "Friendly URLs successfully deactivated"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsMain.php:140
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsMain.php:142
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsMain.php
 msgid "General settings have been updated"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminItemComments.php:209
+#: oc-includes/osclass/classes/controller/admin/CAdminItemComments.php
 msgid "Great! We just updated your comment"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebItem.php:306
+#: oc-includes/osclass/classes/controller/CWebItem.php
 msgid "Great! We've just updated your listing"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsPermalinks.php:396
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsPermalinks.php
 msgid ""
 "Here's the content you have to add to the <b>.htaccess</b> file. If you "
 "can't create the file or experience some problems with the URLs, please "
 "deactivate the <em>Friendly URLs</em> option."
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsPermalinks.php:386
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsPermalinks.php
 msgid ""
 "Here's the content you have to add to the <b>.htaccess</b> file. If you "
 "can't create the file, please deactivate the <em>Friendly URLs</em> option."
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsPermalinks.php:410
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsPermalinks.php
 msgid ""
 "Here's the content you have to add to the <b>.htaccess</b> file. If you "
 "can't modify the file or experience some problems with the URLs, please "
 "deactivate the <em>Friendly URLs</em> option."
 msgstr ""
 
-#: oc-includes/osclass/gui/billing/wallet-content.php:96
+#: oc-includes/osclass/gui/billing/wallet-content.php
 msgid "History"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsPermalinks.php:377
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsPermalinks.php
 msgid ""
 "However, we can't check if Apache module <b>mod_rewrite</b> is loaded. If "
 "you experience some problems with the URLs, you should deactivate "
 "<em>Friendly URLs</em>"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebLogin.php:278
+#: oc-includes/osclass/classes/controller/CWebLogin.php
 msgid ""
 "If that email address belongs to an account, we have sent it instructions "
 "to reset the password"
 msgstr ""
 
-#: oc-includes/osclass/classes/actions/ItemActions.php:536
+#: oc-includes/osclass/classes/actions/ItemActions.php
 msgid "Image is too big. Max. size"
 msgstr ""
 
-#: oc-includes/osclass/classes/actions/ItemActions.php:533
+#: oc-includes/osclass/classes/actions/ItemActions.php
 msgid "Image with an incorrect extension."
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminItems.php:811
+#: oc-includes/osclass/classes/controller/admin/CAdminItems.php
 msgid "Images per listing must only contain numeric characters"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminTools.php:54
+#: oc-includes/osclass/classes/controller/admin/CAdminTools.php
 msgid "Import complete"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebLogin.php:206
+#: oc-includes/osclass/classes/controller/CWebLogin.php
 msgid "Incorrect link"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminAdmins.php:114
-#: oc-includes/osclass/classes/controller/admin/CAdminAdmins.php:240
+#: oc-includes/osclass/classes/controller/admin/CAdminAdmins.php
 msgid "Incorrent current password"
 msgstr ""
 
-#: oc-includes/osclass/classes/Csrf.php:196
+#: oc-includes/osclass/classes/Csrf.php
 msgid "Invalid CSRF token."
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebLogin.php:242
+#: oc-includes/osclass/classes/controller/CWebLogin.php
 msgid "Invalid email address"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebLogin.php:89
+#: oc-includes/osclass/classes/controller/CWebLogin.php
 msgid "Invalid email/username or password"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminPlugins.php:279
+#: oc-includes/osclass/classes/controller/admin/CAdminPlugins.php
 msgid "Invalid plugin file"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsKeywordBlock.php:134
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsKeywordBlock.php
 msgid "Keyword id isn't in the correct format"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsKeywordBlock.php:255
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsKeywordBlock.php
 msgid "Keyword saved correctly"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsKeywordBlock.php:252
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsKeywordBlock.php
 msgid "Keyword updated correctly"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php:246
+#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php
 msgid "Language description field is required"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php:240
+#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php
 msgid "Language direction field is required"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php:188
+#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php
 msgid "Language id doesn't exist"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php:181
-#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php:214
+#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php
 msgid "Language id isn't in the correct format"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php:170
+#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php
 msgid "Language imported successfully"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php:237
+#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php
 msgid "Language name field is required"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php:243
+#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php
 msgid "Language short name field is required"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsMain.php:34
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsMain.php
 msgid "Last check"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsLatestSearches.php:53
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsLatestSearches.php
 msgid "Last search settings have been updated"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminItems.php:855
+#: oc-includes/osclass/classes/controller/admin/CAdminItems.php
 msgid "Listings' settings have been updated"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsLocations.php:525
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsLocations.php
 msgid "Location imported successfully"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php:650
+#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php
 msgid "Logged in as %s successfully"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsMailserver.php:77
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsMailserver.php
 msgid "Mail server configuration has changed"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsMailserver.php:61
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsMailserver.php
 msgid "Mail server type is incorrect"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminTools.php:291
+#: oc-includes/osclass/classes/controller/admin/CAdminTools.php
 msgid "Maintenance mode is OFF"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminTools.php:278
+#: oc-includes/osclass/classes/controller/admin/CAdminTools.php
 msgid "Maintenance mode is ON"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsMain.php:86
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsMain.php
 msgid "Max latest listings has to be a numeric value"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsMedia.php:186
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsMedia.php
 msgid "Media config has been updated"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsKeywordBlock.php:208
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsKeywordBlock.php
 msgid "Moderation settings have been updated"
 msgstr ""
 
-#: oc-includes/osclass/classes/actions/ItemActions.php:588
+#: oc-includes/osclass/classes/actions/ItemActions.php
 msgid "Municipality too long."
 msgstr ""
 
-#: oc-includes/osclass/classes/actions/ItemActions.php:586
+#: oc-includes/osclass/classes/actions/ItemActions.php
 msgid "Municipality too short."
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminAdmins.php:200
-#: oc-includes/osclass/classes/controller/admin/CAdminAdmins.php:92
+#: oc-includes/osclass/classes/controller/admin/CAdminAdmins.php
 msgid "Name invalid"
 msgstr ""
 
-#: oc-includes/osclass/classes/actions/ItemActions.php:190
+#: oc-includes/osclass/classes/actions/ItemActions.php
 msgid "Name too long."
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsLocations.php:361
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsLocations.php
 msgid "New city name cannot be blank"
 msgstr ""
 
-#: oc-includes/osclass/gui/billing/orders-content.php:127
-#: oc-includes/osclass/gui/billing/wallet-content.php:129
+#: oc-includes/osclass/gui/billing/orders-content.php
+#: oc-includes/osclass/gui/billing/wallet-content.php
 msgid "Newer"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php:384
+#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php
 msgid "No alerts have been activated"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php:392
+#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php
 msgid "No alerts have been deactivated"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php:344
+#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php
 msgid "No alerts have been deleted"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsCurrencies.php:134
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsCurrencies.php
 msgid "No changes were made"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsLocations.php:505
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsLocations.php
 msgid "No city was selected"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsLocations.php:171
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsLocations.php
 msgid "No country was selected"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsCurrencies.php:168
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsCurrencies.php
 msgid "No currencies have been deleted"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminAppearance.php:62
-#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php:82
-#: oc-includes/osclass/classes/controller/admin/CAdminPlugins.php:72
-#: oc-includes/osclass/classes/controller/admin/CAdminTools.php:59
+#: oc-includes/osclass/classes/controller/admin/CAdminAppearance.php
+#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php
+#: oc-includes/osclass/classes/controller/admin/CAdminPlugins.php
+#: oc-includes/osclass/classes/controller/admin/CAdminTools.php
 msgid "No file was uploaded"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsKeywordBlock.php:147
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsKeywordBlock.php
 msgid "No keywords have been deleted"
 msgstr ""
 
-#: oc-includes/osclass/gui/billing/buy-content.php:96
+#: oc-includes/osclass/gui/billing/buy-content.php
 msgid "No payment method is set up yet."
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminPlugins.php:251
-#: oc-includes/osclass/classes/controller/admin/CAdminPlugins.php:272
+#: oc-includes/osclass/classes/controller/admin/CAdminPlugins.php
 msgid "No plugin selected"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsLocations.php:337
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsLocations.php
 msgid "No region was selected"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php:628
+#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php
 msgid "No rules have been deleted"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminAppearance.php:97
+#: oc-includes/osclass/classes/controller/admin/CAdminAppearance.php
 msgid "No theme selected"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php:207
+#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php
 msgid "No users have been activated"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php:234
+#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php
 msgid "No users have been deactivated"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php:315
+#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php
 msgid "No users have been deleted"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php:286
+#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php
 msgid "No users have been disabled"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php:260
+#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php
 msgid "No users have been enabled"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php:181
+#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php
 msgid "No users have been selected"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebBilling.php:273
+#: oc-includes/osclass/classes/controller/CWebBilling.php
 msgid "Not enough credits for this upgrade. <a href=\"%s\">Buy more credits</a>"
 msgstr ""
 
-#: oc-includes/osclass/gui/billing/wallet-content.php:98
+#: oc-includes/osclass/gui/billing/wallet-content.php
 msgid "Nothing has moved yet."
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php:252
+#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php
 msgid "Number of decimals must only contain numeric characters"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminItems.php:814
+#: oc-includes/osclass/classes/controller/admin/CAdminItems.php
 msgid "Number of expiration days has to be a numeric value"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsMain.php:83
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsMain.php
 msgid "Number of listings in the RSS has to be a numeric value"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsMain.php:115
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsMain.php
 msgid "Number of listings in the RSS must be an integer"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsMain.php:89
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsMain.php
 msgid "Number of listings on search has to be a numeric value"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsComments.php:59
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsComments.php
 msgid "Number of moderate comments must only contain numeric characters"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminItems.php:808
+#: oc-includes/osclass/classes/controller/admin/CAdminItems.php
 msgid "Number of moderated listings must only contain numeric characters"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsMain.php:124
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsMain.php
 msgid "Number of recent listings displayed at home must be an integer"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsStorage.php:191
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsStorage.php
 msgid ""
 "Offload queued. Images move to remote storage in the background as the "
 "storage worker runs."
 msgstr ""
 
-#: oc-includes/osclass/gui/billing/orders-content.php:134
-#: oc-includes/osclass/gui/billing/wallet-content.php:136
+#: oc-includes/osclass/gui/billing/orders-content.php
+#: oc-includes/osclass/gui/billing/wallet-content.php
 msgid "Older"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php:387
+#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php
 msgid "One alert has been activated"
 msgid_plural "%s alerts have been activated"
 msgstr[0] ""
 msgstr[1] ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php:396
+#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php
 msgid "One alert has been deactivated"
 msgid_plural "%s alerts have been deactivated"
 msgstr[0] ""
 msgstr[1] ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php:347
+#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php
 msgid "One alert has been deleted"
 msgid_plural "%s alerts have been deleted"
 msgstr[0] ""
 msgstr[1] ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php:631
+#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php
 msgid "One ban rule has been deleted"
 msgid_plural "%s ban rules have been deleted"
 msgstr[0] ""
 msgstr[1] ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsCurrencies.php:172
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsCurrencies.php
 msgid "One currency has been deleted"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsPermalinks.php:359
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsPermalinks.php
 msgid "One field was not updated"
 msgid_plural "%s fields were not updated"
 msgstr[0] ""
 msgstr[1] ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsKeywordBlock.php:150
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsKeywordBlock.php
 msgid "One keyword has been deleted"
 msgid_plural "%s keywords have been deleted"
 msgstr[0] ""
 msgstr[1] ""
 
-#: oc-includes/osclass/classes/actions/ItemActions.php:472
+#: oc-includes/osclass/classes/actions/ItemActions.php
 msgid "One of the files you tried to upload exceeds the maximum size"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminPages.php:225
+#: oc-includes/osclass/classes/controller/admin/CAdminPages.php
 msgid "One page can't be deleted because it is indelible"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminPages.php:235
+#: oc-includes/osclass/classes/controller/admin/CAdminPages.php
 msgid "One page couldn't be deleted"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminPages.php:245
+#: oc-includes/osclass/classes/controller/admin/CAdminPages.php
 msgid "One page has been deleted correctly"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php:210
+#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php
 msgid "One user has been activated"
 msgid_plural "%s users have been activated"
 msgstr[0] ""
 msgstr[1] ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php:289
+#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php
 msgid "One user has been blocked"
 msgid_plural "%s users have been blocked"
 msgstr[0] ""
 msgstr[1] ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php:237
+#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php
 msgid "One user has been deactivated"
 msgid_plural "%s users have been deactivated"
 msgstr[0] ""
 msgstr[1] ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php:318
+#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php
 msgid "One user has been deleted"
 msgid_plural "%s users have been deleted"
 msgstr[0] ""
 msgstr[1] ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php:263
+#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php
 msgid "One user has been unblocked"
 msgid_plural "%s users have been unblocked"
 msgstr[0] ""
 msgstr[1] ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminBilling.php:209
+#: oc-includes/osclass/classes/controller/admin/CAdminBilling.php
 msgid "Only a paid order can be refunded"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebItem.php:141
-#: oc-includes/osclass/classes/controller/CWebItem.php:65
+#: oc-includes/osclass/classes/controller/CWebItem.php
 msgid "Only registered users are allowed to post listings"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebItem.php:508
-#: oc-includes/osclass/classes/controller/CWebItem.php:523
+#: oc-includes/osclass/classes/controller/CWebItem.php
 msgid "Only registered users can share listings"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminPages.php:184
+#: oc-includes/osclass/classes/controller/admin/CAdminPages.php
 msgid "Oops! That internal name is already in use. We can't make the changes"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebUser.php:287
-#: oc-includes/osclass/classes/controller/CWebUserNonSecure.php:120
+#: oc-includes/osclass/classes/controller/CWebUser.php
+#: oc-includes/osclass/classes/controller/CWebUserNonSecure.php
 msgid ""
 "Oops! There was a problem trying to activate your alert. Please contact an "
 "administrator"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebUser.php:308
-#: oc-includes/osclass/classes/controller/CWebUserNonSecure.php:141
+#: oc-includes/osclass/classes/controller/CWebUser.php
+#: oc-includes/osclass/classes/controller/CWebUserNonSecure.php
 msgid ""
 "Oops! There was a problem trying to unsubscribe you. Please contact an "
 "administrator"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebUser.php:381
-#: oc-includes/osclass/classes/controller/CWebUser.php:385
+#: oc-includes/osclass/classes/controller/CWebUser.php
 msgid "Oops! you can not do that"
 msgstr ""
 
-#: oc-includes/osclass/gui/billing/buy-content.php:85
+#: oc-includes/osclass/gui/billing/buy-content.php
 msgid "Order #%d"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminBilling.php:178
+#: oc-includes/osclass/classes/controller/admin/CAdminBilling.php
 msgid "Order #%d is marked paid and the credits have been added"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminBilling.php:205
+#: oc-includes/osclass/classes/controller/admin/CAdminBilling.php
 msgid "Order #%d is recorded as refunded and the credits have been taken back"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminBilling.php:177
+#: oc-includes/osclass/classes/controller/admin/CAdminBilling.php
 msgid ""
 "Order #%d was marked failed and is now marked paid; the credits have been "
 "added"
 msgstr ""
 
-#: oc-includes/osclass/gui/billing/orders-content.php:35
+#: oc-includes/osclass/gui/billing/orders-content.php
 msgid "Orders are not available on this site."
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminBilling.php:393
+#: oc-includes/osclass/classes/controller/admin/CAdminBilling.php
 msgid "Package created"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminBilling.php:413
+#: oc-includes/osclass/classes/controller/admin/CAdminBilling.php
 msgid "Package deleted"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminBilling.php:390
+#: oc-includes/osclass/classes/controller/admin/CAdminBilling.php
 msgid "Package updated"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsMain.php:77
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsMain.php
 msgid "Page title field is required"
 msgstr ""
 
-#: oc-includes/osclass/gui/billing/orders-content.php:51
+#: oc-includes/osclass/gui/billing/orders-content.php
 msgid "Paid"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebLogin.php:298
-#: oc-includes/osclass/classes/controller/CWebUser.php:210
+#: oc-includes/osclass/classes/controller/CWebLogin.php
+#: oc-includes/osclass/classes/controller/CWebUser.php
 msgid "Password cannot be blank"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebUser.php:246
+#: oc-includes/osclass/classes/controller/CWebUser.php
 msgid "Password has been changed"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminAdmins.php:96
+#: oc-includes/osclass/classes/controller/admin/CAdminAdmins.php
 msgid "Password invalid"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebUser.php:224
+#: oc-includes/osclass/classes/controller/CWebUser.php
 msgid "Passwords can't be empty"
 msgstr ""
 
-#: oc-includes/osclass/classes/actions/UserActions.php:312
-#: oc-includes/osclass/classes/actions/UserActions.php:60
-#: oc-includes/osclass/classes/controller/CWebUser.php:231
+#: oc-includes/osclass/classes/actions/UserActions.php
+#: oc-includes/osclass/classes/controller/CWebUser.php
 msgid "Passwords don't match"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminTools.php:134
-#: oc-includes/osclass/classes/controller/admin/CAdminTools.php:168
+#: oc-includes/osclass/classes/controller/admin/CAdminTools.php
 msgid "Path is empty"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebBilling.php:188
+#: oc-includes/osclass/classes/controller/CWebBilling.php
 msgid "Payment is unavailable right now. Please try again later."
 msgstr ""
 
-#: oc-includes/osclass/gui/billing/buy-content.php:124
-#: oc-includes/osclass/gui/billing/orders-content.php:98
+#: oc-includes/osclass/gui/billing/buy-content.php
+#: oc-includes/osclass/gui/billing/orders-content.php
 msgid "Payment method"
 msgstr ""
 
-#: oc-includes/osclass/gui/billing/orders-content.php:50
+#: oc-includes/osclass/gui/billing/orders-content.php
 msgid "Pending"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsPermalinks.php:366
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsPermalinks.php:415
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsPermalinks.php
 msgid "Permalinks structure updated"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsPermalinks.php:375
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsPermalinks.php
 msgid "Permalinks structure updated."
 msgstr ""
 
-#: oc-includes/osclass/classes/actions/ItemActions.php:594
+#: oc-includes/osclass/classes/actions/ItemActions.php
 msgid "Phone invalid."
 msgstr ""
 
-#: oc-includes/osclass/classes/actions/UserActions.php:50
-#: oc-includes/osclass/classes/controller/CWebContact.php:42
-#: oc-includes/osclass/classes/controller/CWebItem.php:148
-#: oc-includes/osclass/classes/controller/CWebItem.php:285
-#: oc-includes/osclass/classes/controller/CWebItem.php:476
-#: oc-includes/osclass/classes/controller/CWebItem.php:536
-#: oc-includes/osclass/classes/controller/CWebItem.php:612
-#: oc-includes/osclass/classes/controller/CWebItem.php:681
-#: oc-includes/osclass/classes/controller/CWebLogin.php:252
-#: oc-includes/osclass/classes/controller/CWebLogin.php:59
-#: oc-includes/osclass/classes/controller/CWebUserNonSecure.php:219
-#: oc-includes/osclass/classes/controller/admin/CAdminLogin.php:166
-#: oc-includes/osclass/classes/controller/admin/CAdminLogin.php:63
+#: oc-includes/osclass/classes/actions/UserActions.php
+#: oc-includes/osclass/classes/controller/CWebContact.php
+#: oc-includes/osclass/classes/controller/CWebItem.php
+#: oc-includes/osclass/classes/controller/CWebLogin.php
+#: oc-includes/osclass/classes/controller/CWebUserNonSecure.php
+#: oc-includes/osclass/classes/controller/admin/CAdminLogin.php
 msgid "Please complete the security check."
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebContact.php:71
+#: oc-includes/osclass/classes/controller/CWebContact.php
 msgid "Please enter a correct email"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebItem.php:706
+#: oc-includes/osclass/classes/controller/CWebItem.php
 msgid "Please fill the required field (email)"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebLogin.php:47
+#: oc-includes/osclass/classes/controller/CWebLogin.php
 msgid "Please provide an email address"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebUser.php:322
+#: oc-includes/osclass/classes/controller/CWebUser.php
 msgid "Please sign in to download your data"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebItem.php:710
+#: oc-includes/osclass/classes/controller/CWebItem.php
 msgid "Please type a comment"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminPlugins.php:122
+#: oc-includes/osclass/classes/controller/admin/CAdminPlugins.php
 msgid "Plugin couldn't be installed"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminPlugins.php:117
+#: oc-includes/osclass/classes/controller/admin/CAdminPlugins.php
 msgid "Plugin couldn't be installed because of: %s"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminPlugins.php:111
+#: oc-includes/osclass/classes/controller/admin/CAdminPlugins.php
 msgid "Plugin couldn't be installed because their files are missing"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminPlugins.php:141
+#: oc-includes/osclass/classes/controller/admin/CAdminPlugins.php
 msgid "Plugin couldn't be uninstalled"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminPlugins.php:169
+#: oc-includes/osclass/classes/controller/admin/CAdminPlugins.php
 msgid "Plugin disabled"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminPlugins.php:154
+#: oc-includes/osclass/classes/controller/admin/CAdminPlugins.php
 msgid "Plugin enabled"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminPlugins.php:126
+#: oc-includes/osclass/classes/controller/admin/CAdminPlugins.php
 msgid "Plugin installed"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminPlugins.php:171
+#: oc-includes/osclass/classes/controller/admin/CAdminPlugins.php
 msgid "Plugin is already disabled"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminPlugins.php:156
+#: oc-includes/osclass/classes/controller/admin/CAdminPlugins.php
 msgid "Plugin is already enabled"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminPlugins.php:107
+#: oc-includes/osclass/classes/controller/admin/CAdminPlugins.php
 msgid "Plugin is already installed"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminPlugins.php:139
+#: oc-includes/osclass/classes/controller/admin/CAdminPlugins.php
 msgid "Plugin uninstalled"
 msgstr ""
 
-#: oc-includes/osclass/classes/actions/ItemActions.php:566
+#: oc-includes/osclass/classes/actions/ItemActions.php
 msgid "Price must be a number."
 msgstr ""
 
-#: oc-includes/osclass/classes/actions/ItemActions.php:573
+#: oc-includes/osclass/classes/actions/ItemActions.php
 msgid "Price must be positive number."
 msgstr ""
 
-#: oc-includes/osclass/classes/actions/ItemActions.php:569
+#: oc-includes/osclass/classes/actions/ItemActions.php
 msgid "Price too long."
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsBilling.php:139
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsBilling.php
 msgid "Pricing settings have been updated"
 msgstr ""
 
-#: oc-includes/osclass/classes/Csrf.php:192
+#: oc-includes/osclass/classes/Csrf.php
 msgid "Probable invalid request."
 msgstr ""
 
-#: oc-includes/osclass/gui/billing/wallet-content.php:48
+#: oc-includes/osclass/gui/billing/wallet-content.php
 msgid "Purchase"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsMedia.php:230
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsMedia.php
 msgid ""
 "Queued %d images for background regeneration. They will process "
 "automatically via cron."
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsMedia.php:205
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsMedia.php
 msgid "Re-generation complete"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsSpamnBots.php:133
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsSpamnBots.php
 msgid "Recorded sign-in attempts have been cleared"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminTools.php:73
+#: oc-includes/osclass/classes/controller/admin/CAdminTools.php
 msgid "Recount category stats has been successful"
 msgstr ""
 
-#: oc-includes/osclass/classes/billing/gateway/OfflineGateway.php:61
+#: oc-includes/osclass/classes/billing/gateway/OfflineGateway.php
 msgid "Reference: #%d"
 msgstr ""
 
-#: oc-includes/osclass/gui/billing/wallet-content.php:50
+#: oc-includes/osclass/gui/billing/wallet-content.php
 msgid "Refund"
 msgstr ""
 
-#: oc-includes/osclass/gui/billing/orders-content.php:53
+#: oc-includes/osclass/gui/billing/orders-content.php
 msgid "Refunded"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsLocations.php:190
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsLocations.php:233
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsLocations.php
 msgid "Region name cannot be blank"
 msgstr ""
 
-#: oc-includes/osclass/classes/actions/ItemActions.php:581
+#: oc-includes/osclass/classes/actions/ItemActions.php
 msgid "Region too long."
 msgstr ""
 
-#: oc-includes/osclass/classes/actions/ItemActions.php:579
+#: oc-includes/osclass/classes/actions/ItemActions.php
 msgid "Region too short."
 msgstr ""
 
-#: oc-includes/osclass/gui/billing/wallet-content.php:52
+#: oc-includes/osclass/gui/billing/wallet-content.php
 msgid "Removed by admin"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminItems.php:529
+#: oc-includes/osclass/classes/controller/admin/CAdminItems.php
 msgid "Reports have been cleared for this listing"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminItems.php:697
-#: oc-includes/osclass/classes/controller/admin/CAdminMedia.php:48
+#: oc-includes/osclass/classes/controller/admin/CAdminItems.php
+#: oc-includes/osclass/classes/controller/admin/CAdminMedia.php
 msgid "Resource deleted"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsStorage.php:204
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsStorage.php
 msgid ""
 "Restore queued. Images download back to local storage in the background as "
 "the storage worker runs."
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php:607
+#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php
 msgid "Rule saved correctly"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php:588
+#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php
 msgid "Rule updated correctly"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsSpamnBots.php:103
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsSpamnBots.php
 msgid "Search alert settings have been updated"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php:365
+#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php
 msgid "Selected languages have been disabled for the backoffice (oc-admin)"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php:306
+#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php
 msgid "Selected languages have been disabled for the website"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php:341
+#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php
 msgid "Selected languages have been enabled for the backoffice (oc-admin)"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php:282
+#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php
 msgid "Selected languages have been enabled for the website"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsBilling.php:213
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsBilling.php
 msgid "Seller limit settings have been updated"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebItem.php:500
-#: oc-includes/osclass/classes/controller/CWebItem.php:518
+#: oc-includes/osclass/classes/controller/CWebItem.php
 msgid "Sharing listings by email has been disabled by the administrator"
 msgstr ""
 
-#: oc-includes/osclass/gui/billing/buy-content.php:33
+#: oc-includes/osclass/gui/billing/buy-content.php
 msgid "Sign in to buy credits."
 msgstr ""
 
-#: oc-includes/osclass/gui/billing/wallet-content.php:31
+#: oc-includes/osclass/gui/billing/wallet-content.php
 msgid "Sign in to see your credits."
 msgstr ""
 
-#: oc-includes/osclass/gui/billing/orders-content.php:33
+#: oc-includes/osclass/gui/billing/orders-content.php
 msgid "Sign in to see your orders."
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsSpamnBots.php:125
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsSpamnBots.php
 msgid "Sign-in protection settings have been updated"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsSitemap.php:153
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsSitemap.php
 msgid "Sitemap cache cleared and regenerated"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsSitemap.php:76
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsSitemap.php
 msgid "Sitemap settings have been updated"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebItem.php:722
+#: oc-includes/osclass/classes/controller/CWebItem.php
 msgid "Sorry, comments are disabled"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminLogin.php:90
+#: oc-includes/osclass/classes/controller/admin/CAdminLogin.php
 msgid ""
 "Sorry, incorrect username or password. <a href=\"%s\">Have you lost your "
 "password?</a>"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebLogin.php:289
-#: oc-includes/osclass/classes/controller/CWebLogin.php:337
-#: oc-includes/osclass/classes/controller/CWebUserNonSecure.php:89
-#: oc-includes/osclass/classes/controller/CWebUserNonSecure.php:93
-#: oc-includes/osclass/classes/controller/admin/CAdminLogin.php:214
-#: oc-includes/osclass/classes/controller/admin/CAdminLogin.php:228
+#: oc-includes/osclass/classes/controller/CWebLogin.php
+#: oc-includes/osclass/classes/controller/CWebUserNonSecure.php
+#: oc-includes/osclass/classes/controller/admin/CAdminLogin.php
 msgid "Sorry, the link is not valid"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebItem.php:694
+#: oc-includes/osclass/classes/controller/CWebItem.php
 msgid "Sorry, we could not save your comment. Try again later"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebItem.php:241
+#: oc-includes/osclass/classes/controller/CWebItem.php
 msgid "Sorry, we don't have any listings with that ID"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebForm.php:119
+#: oc-includes/osclass/classes/controller/CWebForm.php
 msgid "Sorry, your submission could not be saved. Please try again."
 msgstr ""
 
-#: oc-includes/osclass/gui/billing/wallet-content.php:49
+#: oc-includes/osclass/gui/billing/wallet-content.php
 msgid "Spent"
 msgstr ""
 
-#: oc-includes/osclass/gui/billing/orders-content.php:101
+#: oc-includes/osclass/gui/billing/orders-content.php
 msgid "Status"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsStorage.php:173
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsStorage.php
 msgid "Storage queue processed"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsStorage.php:136
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsStorage.php
 msgid "Storage settings updated"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminMain.php:98
+#: oc-includes/osclass/classes/controller/admin/CAdminMain.php
 msgid "Subscribed correctly"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/base/AdminSecBaseModel.php:60
+#: oc-includes/osclass/classes/controller/base/AdminSecBaseModel.php
 msgid "Thank you very much for your donation"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebForm.php:127
-#: oc-includes/osclass/classes/controller/CWebForm.php:63
+#: oc-includes/osclass/classes/controller/CWebForm.php
 msgid "Thank you! Your submission has been received."
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebItem.php:488
+#: oc-includes/osclass/classes/controller/CWebItem.php
 msgid "Thanks! That's very helpful"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsSitemap.php:122
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsSitemap.php
 msgid "That custom URL no longer exists"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebForm.php:81
+#: oc-includes/osclass/classes/controller/CWebForm.php
 msgid "That form has no fields."
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebForm.php:53
+#: oc-includes/osclass/classes/controller/CWebForm.php
 msgid "That form is no longer available."
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminBilling.php:297
+#: oc-includes/osclass/classes/controller/admin/CAdminBilling.php
 msgid ""
 "That is more than the balance holds. Remove no more than the current "
 "balance."
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsKeywordBlock.php:119
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsKeywordBlock.php
 msgid "That keyword no longer exists"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebUser.php:329
+#: oc-includes/osclass/classes/controller/CWebUser.php
 msgid "That link is not valid"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebBilling.php:233
+#: oc-includes/osclass/classes/controller/CWebBilling.php
 msgid "That listing does not belong to you"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminBilling.php:184
+#: oc-includes/osclass/classes/controller/admin/CAdminBilling.php
 msgid "That order had already been settled"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminBilling.php:134
-#: oc-includes/osclass/classes/controller/admin/CAdminBilling.php:168
-#: oc-includes/osclass/classes/controller/admin/CAdminBilling.php:199
+#: oc-includes/osclass/classes/controller/admin/CAdminBilling.php
 msgid "That order no longer exists"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminBilling.php:396
+#: oc-includes/osclass/classes/controller/admin/CAdminBilling.php
 msgid "That package could not be saved"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebBilling.php:168
+#: oc-includes/osclass/classes/controller/CWebBilling.php
 msgid "That package is no longer available"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminBilling.php:324
-#: oc-includes/osclass/classes/controller/admin/CAdminBilling.php:386
-#: oc-includes/osclass/classes/controller/admin/CAdminBilling.php:415
+#: oc-includes/osclass/classes/controller/admin/CAdminBilling.php
 msgid "That package no longer exists"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebBilling.php:174
+#: oc-includes/osclass/classes/controller/CWebBilling.php
 msgid "That payment method is not available"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebBilling.php:227
+#: oc-includes/osclass/classes/controller/CWebBilling.php
 msgid "That upgrade is not available"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminBilling.php:241
-#: oc-includes/osclass/classes/controller/admin/CAdminBilling.php:273
+#: oc-includes/osclass/classes/controller/admin/CAdminBilling.php
 msgid "That user no longer exists"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminAdmins.php:294
+#: oc-includes/osclass/classes/controller/admin/CAdminAdmins.php
 msgid "The admin couldn't be deleted"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminAdmins.php:136
+#: oc-includes/osclass/classes/controller/admin/CAdminAdmins.php
 msgid "The admin has been added"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminAdmins.php:292
+#: oc-includes/osclass/classes/controller/admin/CAdminAdmins.php
 msgid "The admin has been deleted correctly"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminAdmins.php:256
+#: oc-includes/osclass/classes/controller/admin/CAdminAdmins.php
 msgid "The admin has been updated"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminAdmins.php:276
+#: oc-includes/osclass/classes/controller/admin/CAdminAdmins.php
 msgid "The admin id isn't in the correct format"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebUser.php:432
-#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php:817
+#: oc-includes/osclass/classes/controller/CWebUser.php
+#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php
 msgid "The avatar you tried to upload exceeds the maximum size"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebUser.php:440
-#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php:825
+#: oc-includes/osclass/classes/controller/CWebUser.php
+#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php
 msgid "The avatar you tried to upload is not a valid image"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminTools.php:107
+#: oc-includes/osclass/classes/controller/admin/CAdminTools.php
 msgid "The cache could not be cleared"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminTools.php:105
+#: oc-includes/osclass/classes/controller/admin/CAdminTools.php
 msgid "The cache has been cleared"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebItem.php:759
+#: oc-includes/osclass/classes/controller/CWebItem.php
 msgid "The comment doesn't exist"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminItemComments.php:144
+#: oc-includes/osclass/classes/controller/admin/CAdminItemComments.php
 msgid "The comment has been approved"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebItem.php:774
-#: oc-includes/osclass/classes/controller/admin/CAdminItemComments.php:215
+#: oc-includes/osclass/classes/controller/CWebItem.php
+#: oc-includes/osclass/classes/controller/admin/CAdminItemComments.php
 msgid "The comment has been deleted"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminItemComments.php:165
+#: oc-includes/osclass/classes/controller/admin/CAdminItemComments.php
 msgid "The comment has been disabled"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminItemComments.php:151
+#: oc-includes/osclass/classes/controller/admin/CAdminItemComments.php
 msgid "The comment has been disapproved"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminItemComments.php:158
+#: oc-includes/osclass/classes/controller/admin/CAdminItemComments.php
 msgid "The comment has been enabled"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebItem.php:764
+#: oc-includes/osclass/classes/controller/CWebItem.php
 msgid "The comment is not active, you cannot delete it"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebItem.php:769
+#: oc-includes/osclass/classes/controller/CWebItem.php
 msgid "The comment was not added by you, you cannot delete it"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminItemComments.php:75
+#: oc-includes/osclass/classes/controller/admin/CAdminItemComments.php
 msgid "The comments have been approved"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminItemComments.php:108
+#: oc-includes/osclass/classes/controller/admin/CAdminItemComments.php
 msgid "The comments have been blocked"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminItemComments.php:62
+#: oc-includes/osclass/classes/controller/admin/CAdminItemComments.php
 msgid "The comments have been deleted"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminItemComments.php:85
+#: oc-includes/osclass/classes/controller/admin/CAdminItemComments.php
 msgid "The comments have been disapproved"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminItemComments.php:98
+#: oc-includes/osclass/classes/controller/admin/CAdminItemComments.php
 msgid "The comments have been unblocked"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsCurrencies.php:85
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsCurrencies.php:95
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsCurrencies.php
 msgid "The currency code '%s' doesn't exist"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsCurrencies.php:59
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsCurrencies.php
 msgid "The currency code is not in the correct format"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php:408
+#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php
 msgid ""
 "The current language can't be deleted. Please logout and login again with "
 "another language."
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminEmails.php:93
+#: oc-includes/osclass/classes/controller/admin/CAdminEmails.php
 msgid "The email couldn't be updated, at least one title should not be empty"
 msgstr ""
 
-#: oc-includes/osclass/classes/actions/UserActions.php:76
+#: oc-includes/osclass/classes/actions/UserActions.php
 msgid "The email is not valid"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminEmails.php:87
+#: oc-includes/osclass/classes/controller/admin/CAdminEmails.php
 msgid "The email/alert has been updated"
 msgstr ""
 
-#: oc-includes/osclass/classes/actions/UserActions.php:85
+#: oc-includes/osclass/classes/actions/UserActions.php
 msgid "The field %s is too long"
 msgstr ""
 
-#: oc-includes/osclass/classes/actions/ItemActions.php:444
-#: oc-includes/osclass/classes/controller/CWebContact.php:152
+#: oc-includes/osclass/classes/actions/ItemActions.php
+#: oc-includes/osclass/classes/controller/CWebContact.php
 msgid "The file you tried to upload does not have a valid extension"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminPlugins.php:262
+#: oc-includes/osclass/classes/controller/admin/CAdminPlugins.php
 msgid "The files were deleted"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminTools.php:146
-#: oc-includes/osclass/classes/controller/admin/CAdminTools.php:190
+#: oc-includes/osclass/classes/controller/admin/CAdminTools.php
 msgid "The folder is not writable"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsKeywordBlock.php:235
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsKeywordBlock.php
 msgid "The keyword must be at least %d characters long"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php:70
+#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php
 msgid "The language has been installed correctly"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php:289
-#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php:314
-#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php:348
-#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php:373
+#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php
 msgid "The language ids aren't in the correct format"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebRegister.php:88
+#: oc-includes/osclass/classes/controller/CWebRegister.php
 msgid "The link is not valid anymore. Sorry for the inconvenience!"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminItems.php:419
+#: oc-includes/osclass/classes/controller/admin/CAdminItems.php
 msgid "The listing can't be activated because it's blocked"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebItem.php:346
+#: oc-includes/osclass/classes/controller/CWebItem.php
 msgid "The listing can't be validated"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminItems.php:383
+#: oc-includes/osclass/classes/controller/admin/CAdminItems.php
 msgid "The listing couldn't be deleted"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebAjax.php:137
-#: oc-includes/osclass/classes/controller/CWebAjax.php:148
-#: oc-includes/osclass/classes/controller/CWebItem.php:411
-#: oc-includes/osclass/classes/controller/CWebItem.php:418
+#: oc-includes/osclass/classes/controller/CWebAjax.php
+#: oc-includes/osclass/classes/controller/CWebItem.php
 msgid "The listing doesn't belong to you"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebAjax.php:127
-#: oc-includes/osclass/classes/controller/CWebItem.php:405
+#: oc-includes/osclass/classes/controller/CWebAjax.php
+#: oc-includes/osclass/classes/controller/CWebItem.php
 msgid "The listing doesn't exist"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebItem.php:349
+#: oc-includes/osclass/classes/controller/CWebItem.php
 msgid "The listing has already been validated"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminItems.php:414
+#: oc-includes/osclass/classes/controller/admin/CAdminItems.php
 msgid "The listing has been activated"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebItem.php:821
+#: oc-includes/osclass/classes/controller/CWebItem.php
 msgid "The listing has been blocked or is awaiting moderation from the admin"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminItems.php:428
+#: oc-includes/osclass/classes/controller/admin/CAdminItems.php
 msgid "The listing has been deactivated"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminItems.php:381
+#: oc-includes/osclass/classes/controller/admin/CAdminItems.php
 msgid "The listing has been deleted"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminItems.php:446
+#: oc-includes/osclass/classes/controller/admin/CAdminItems.php
 msgid "The listing has been disabled"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminItems.php:437
+#: oc-includes/osclass/classes/controller/admin/CAdminItems.php
 msgid "The listing has been enabled"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminItems.php:554
+#: oc-includes/osclass/classes/controller/admin/CAdminItems.php
 msgid "The listing has been unmarked as"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebItem.php:344
+#: oc-includes/osclass/classes/controller/CWebItem.php
 msgid "The listing has been validated"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebItem.php:815
+#: oc-includes/osclass/classes/controller/CWebItem.php
 msgid "The listing hasn't been enabled. Please enable it in order to make it public"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminItems.php:556
+#: oc-includes/osclass/classes/controller/admin/CAdminItems.php
 msgid "The listing hasn't been unmarked as"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebItem.php:805
+#: oc-includes/osclass/classes/controller/CWebItem.php
 msgid ""
 "The listing hasn't been validated. Please validate it in order to make it "
 "public"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsPermalinks.php:99
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsPermalinks.php
 msgid ""
 "The listing permalink structure must include {ITEM_ID}; it was left "
 "unchanged."
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebItem.php:370
-#: oc-includes/osclass/classes/controller/CWebItem.php:378
+#: oc-includes/osclass/classes/controller/CWebItem.php
 msgid "The listing you are trying to delete couldn't be deleted"
 msgstr ""
 
-#: oc-includes/osclass/classes/actions/UserActions.php:305
-#: oc-includes/osclass/classes/actions/UserActions.php:71
+#: oc-includes/osclass/classes/actions/UserActions.php
 msgid "The name cannot be empty"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminAdmins.php:283
+#: oc-includes/osclass/classes/controller/admin/CAdminAdmins.php
 msgid "The operation hasn't been completed. You're trying to remove yourself!"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminPages.php:178
+#: oc-includes/osclass/classes/controller/admin/CAdminPages.php
 msgid "The page couldn't be added, at least one title should not be empty"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminPages.php:112
+#: oc-includes/osclass/classes/controller/admin/CAdminPages.php
 msgid "The page couldn't be updated, at least one title should not be empty"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminPages.php:174
+#: oc-includes/osclass/classes/controller/admin/CAdminPages.php
 msgid "The page has been added"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminPages.php:106
+#: oc-includes/osclass/classes/controller/admin/CAdminPages.php
 msgid "The page has been updated"
 msgstr ""
 
-#: oc-includes/osclass/classes/actions/UserActions.php:55
+#: oc-includes/osclass/classes/actions/UserActions.php
 msgid "The password cannot be empty"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminAdmins.php:229
+#: oc-includes/osclass/classes/controller/admin/CAdminAdmins.php
 msgid "The password couldn't be updated. Passwords don't match"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminLogin.php:58
+#: oc-includes/osclass/classes/controller/admin/CAdminLogin.php
 msgid "The password field is empty"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebLogin.php:327
-#: oc-includes/osclass/classes/controller/admin/CAdminLogin.php:246
+#: oc-includes/osclass/classes/controller/CWebLogin.php
+#: oc-includes/osclass/classes/controller/admin/CAdminLogin.php
 msgid "The password has been changed"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminPlugins.php:60
+#: oc-includes/osclass/classes/controller/admin/CAdminPlugins.php
 msgid "The plugin folder is not writable"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminPlugins.php:101
+#: oc-includes/osclass/classes/controller/admin/CAdminPlugins.php
 msgid ""
 "The plugin generated %d characters of <strong>unexpected output</strong> "
 "during the installation. Output: \"%s\""
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminPlugins.php:64
+#: oc-includes/osclass/classes/controller/admin/CAdminPlugins.php
 msgid "The plugin has been uploaded correctly"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebAjax.php:197
-#: oc-includes/osclass/classes/controller/CWebItem.php:448
+#: oc-includes/osclass/classes/controller/CWebAjax.php
+#: oc-includes/osclass/classes/controller/CWebItem.php
 msgid "The selected photo couldn't be deleted"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebAjax.php:116
-#: oc-includes/osclass/classes/controller/CWebItem.php:399
+#: oc-includes/osclass/classes/controller/CWebAjax.php
+#: oc-includes/osclass/classes/controller/CWebItem.php
 msgid "The selected photo couldn't be deleted, the url doesn't exist"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebAjax.php:193
-#: oc-includes/osclass/classes/controller/CWebItem.php:445
+#: oc-includes/osclass/classes/controller/CWebAjax.php
+#: oc-includes/osclass/classes/controller/CWebItem.php
 msgid "The selected photo does not belong to you"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebAjax.php:190
-#: oc-includes/osclass/classes/controller/CWebItem.php:443
+#: oc-includes/osclass/classes/controller/CWebAjax.php
+#: oc-includes/osclass/classes/controller/CWebItem.php
 msgid "The selected photo has been successfully deleted"
 msgstr ""
 
-#: oc-includes/osclass/classes/actions/UserActions.php:94
-#: oc-includes/osclass/classes/controller/CWebUser.php:127
+#: oc-includes/osclass/classes/actions/UserActions.php
+#: oc-includes/osclass/classes/controller/CWebUser.php
 msgid "The specified e-mail is already in use"
 msgstr ""
 
-#: oc-includes/osclass/classes/actions/UserActions.php:294
+#: oc-includes/osclass/classes/actions/UserActions.php
 msgid "The specified e-mail is already used by %s"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebUser.php:159
+#: oc-includes/osclass/classes/controller/CWebUser.php
 msgid "The specified e-mail is not valid"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebUser.php:194
+#: oc-includes/osclass/classes/controller/CWebUser.php
 msgid "The specified username could not be empty"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebUser.php:177
+#: oc-includes/osclass/classes/controller/CWebUser.php
 msgid "The specified username is already in use"
 msgstr ""
 
-#: oc-includes/osclass/classes/actions/UserActions.php:105
-#: oc-includes/osclass/classes/controller/CWebUser.php:179
+#: oc-includes/osclass/classes/actions/UserActions.php
+#: oc-includes/osclass/classes/controller/CWebUser.php
 msgid "The specified username is not valid, it contains some invalid words"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminAppearance.php:50
+#: oc-includes/osclass/classes/controller/admin/CAdminAppearance.php
 msgid "The theme folder is not writable"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminAppearance.php:54
+#: oc-includes/osclass/classes/controller/admin/CAdminAppearance.php
 msgid "The theme has been installed correctly"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php:65
+#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php
 msgid "The translation folder is not writable"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebLogin.php:160
-#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php:643
+#: oc-includes/osclass/classes/controller/CWebLogin.php
+#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php
 msgid "The user doesn't exist"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php:78
+#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php
 msgid "The user has been created successfully"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebRegister.php:67
+#: oc-includes/osclass/classes/controller/CWebRegister.php
 msgid "The user has been created. An activation email has been sent"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php:73
+#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php
 msgid "The user has been created. We've sent an activation e-mail"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebLogin.php:171
+#: oc-includes/osclass/classes/controller/CWebLogin.php
 msgid "The user has been suspended"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php:155
+#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php
 msgid "The user has been updated"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php:157
+#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php
 msgid "The user has been updated and activated"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebLogin.php:168
+#: oc-includes/osclass/classes/controller/CWebLogin.php
 msgid "The user has not been validated yet"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebLogin.php:164
+#: oc-includes/osclass/classes/controller/CWebLogin.php
 msgid ""
 "The user has not been validated yet. Would you like to re-send your <a "
 "href=\"%s\">activation?</a>"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminLogin.php:53
+#: oc-includes/osclass/classes/controller/admin/CAdminLogin.php
 msgid "The username field is empty"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebUser.php:185
+#: oc-includes/osclass/classes/controller/CWebUser.php
 msgid "The username was updated"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsMedia.php:102
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsMedia.php
 msgid "The watermark image has to be a .PNG file"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminAppearance.php:58
-#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php:78
-#: oc-includes/osclass/classes/controller/admin/CAdminPlugins.php:68
+#: oc-includes/osclass/classes/controller/admin/CAdminAppearance.php
+#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php
+#: oc-includes/osclass/classes/controller/admin/CAdminPlugins.php
 msgid "The zip file is not valid"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminAppearance.php:325
+#: oc-includes/osclass/classes/controller/admin/CAdminAppearance.php
 msgid "Theme activated correctly"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminAppearance.php:89
+#: oc-includes/osclass/classes/controller/admin/CAdminAppearance.php
 msgid "Theme removed successfully"
 msgstr ""
 
-#: oc-includes/osclass/gui/billing/buy-content.php:92
+#: oc-includes/osclass/gui/billing/buy-content.php
 msgid "There are no credit packages for sale right now."
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminTools.php:142
-#: oc-includes/osclass/classes/controller/admin/CAdminTools.php:186
+#: oc-includes/osclass/classes/controller/admin/CAdminTools.php
 msgid "There are no tables to back up"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminAdmins.php:138
+#: oc-includes/osclass/classes/controller/admin/CAdminAdmins.php
 msgid "There has been an error adding a new admin"
 msgstr ""
 
-#: oc-includes/osclass/emails.php:994
+#: oc-includes/osclass/emails.php
 msgid "There has been some errors sending the message"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminAdmins.php:153
+#: oc-includes/osclass/classes/controller/admin/CAdminAdmins.php
 msgid "There is no admin with this id"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php:88
+#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php
 msgid "There was a problem adding the language"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminPlugins.php:78
+#: oc-includes/osclass/classes/controller/admin/CAdminPlugins.php
 msgid "There was a problem adding the plugin"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminAppearance.php:68
+#: oc-includes/osclass/classes/controller/admin/CAdminAppearance.php
 msgid "There was a problem adding the theme"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsLocations.php:166
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsLocations.php:332
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsLocations.php:500
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsLocations.php
 msgid "There was a problem deleting locations"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminTools.php:56
+#: oc-includes/osclass/classes/controller/admin/CAdminTools.php
 msgid "There was a problem importing data to the database"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php:624
+#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php
 msgid "There was a problem importing email templates"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsLocations.php:534
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsLocations.php
 msgid "There was a problem importing the selected location"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminAppearance.php:91
+#: oc-includes/osclass/classes/controller/admin/CAdminAppearance.php
 msgid "There was a problem removing the theme"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsMedia.php:106
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsMedia.php:98
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsMedia.php
 msgid "There was a problem uploading the watermark image"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminTools.php:281
+#: oc-includes/osclass/classes/controller/admin/CAdminTools.php
 msgid ""
 "There was an error creating the .maintenance file, please create it "
 "manually at the root folder"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminTools.php:294
+#: oc-includes/osclass/classes/controller/admin/CAdminTools.php
 msgid ""
 "There was an error removing the .maintenance file, please remove it "
 "manually from the root folder"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminPlugins.php:265
+#: oc-includes/osclass/classes/controller/admin/CAdminPlugins.php
 msgid ""
 "There were an error deleting the files, please check the permissions of the "
 "files in %s"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsLocations.php:126
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsLocations.php
 msgid "There were some problems editing the country"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminAdmins.php:162
-#: oc-includes/osclass/classes/controller/admin/CAdminAdmins.php:267
-#: oc-includes/osclass/classes/controller/admin/CAdminAdmins.php:58
-#: oc-includes/osclass/classes/controller/admin/CAdminAppearance.php:35
-#: oc-includes/osclass/classes/controller/admin/CAdminAppearance.php:77
-#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php:49
-#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php:99
-#: oc-includes/osclass/classes/controller/admin/CAdminLogin.php:155
-#: oc-includes/osclass/classes/controller/admin/CAdminPlugins.php:133
-#: oc-includes/osclass/classes/controller/admin/CAdminPlugins.php:148
-#: oc-includes/osclass/classes/controller/admin/CAdminPlugins.php:163
-#: oc-includes/osclass/classes/controller/admin/CAdminPlugins.php:45
-#: oc-includes/osclass/classes/controller/admin/CAdminPlugins.php:87
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsAdvanced.php:41
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsLocations.php:136
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsLocations.php:178
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsLocations.php:222
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsLocations.php:295
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsLocations.php:346
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsLocations.php:393
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsLocations.php:45
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsLocations.php:466
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsLocations.php:514
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsLocations.php:77
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsMailserver.php:40
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsMedia.php:193
+#: oc-includes/osclass/classes/controller/admin/CAdminAdmins.php
+#: oc-includes/osclass/classes/controller/admin/CAdminAppearance.php
+#: oc-includes/osclass/classes/controller/admin/CAdminLanguages.php
+#: oc-includes/osclass/classes/controller/admin/CAdminLogin.php
+#: oc-includes/osclass/classes/controller/admin/CAdminPlugins.php
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsAdvanced.php
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsLocations.php
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsMailserver.php
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsMedia.php
 msgid "This action can't be done because it's a demo site"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminTools.php:117
-#: oc-includes/osclass/classes/controller/admin/CAdminTools.php:158
-#: oc-includes/osclass/classes/controller/admin/CAdminTools.php:213
-#: oc-includes/osclass/classes/controller/admin/CAdminTools.php:241
-#: oc-includes/osclass/classes/controller/admin/CAdminTools.php:268
-#: oc-includes/osclass/classes/controller/admin/CAdminTools.php:307
-#: oc-includes/osclass/classes/controller/admin/CAdminTools.php:344
-#: oc-includes/osclass/classes/controller/admin/CAdminTools.php:41
-#: oc-includes/osclass/classes/controller/admin/CAdminTools.php:425
-#: oc-includes/osclass/classes/controller/admin/CAdminTools.php:69
-#: oc-includes/osclass/classes/controller/admin/CAdminTools.php:81
-#: oc-includes/osclass/classes/controller/admin/CAdminTools.php:91
-#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php:1051
+#: oc-includes/osclass/classes/controller/admin/CAdminTools.php
+#: oc-includes/osclass/classes/controller/admin/ajax/CAdminAjax.php
 msgid "This action cannot be done because it is a demo site"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminAdmins.php:207
+#: oc-includes/osclass/classes/controller/admin/CAdminAdmins.php
 msgid "This admin doesn't exist"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebBilling.php:254
+#: oc-includes/osclass/classes/controller/CWebBilling.php
 msgid "This listing already has that upgrade"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebBilling.php:249
+#: oc-includes/osclass/classes/controller/CWebBilling.php
 msgid ""
 "This listing already has that upgrade, permanently -- there is nothing to "
 "extend"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebItem.php:466
-#: oc-includes/osclass/classes/controller/CWebItem.php:576
-#: oc-includes/osclass/classes/controller/CWebItem.php:744
+#: oc-includes/osclass/classes/controller/CWebItem.php
 msgid "This listing doesn't exist"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebLogin.php:190
+#: oc-includes/osclass/classes/controller/CWebLogin.php
 msgid "This should never happen"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebBilling.php:242
+#: oc-includes/osclass/classes/controller/CWebBilling.php
 msgid "This upgrade is not available right now"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminItems.php:817
+#: oc-includes/osclass/classes/controller/admin/CAdminItems.php
 msgid "Title Length has to be a numeric value"
 msgstr ""
 
-#: oc-includes/osclass/classes/actions/ItemActions.php:548
+#: oc-includes/osclass/classes/actions/ItemActions.php
 msgid "Title too long (%s)."
 msgstr ""
 
-#: oc-includes/osclass/classes/actions/ItemActions.php:546
+#: oc-includes/osclass/classes/actions/ItemActions.php
 msgid "Title too short (%s)."
 msgstr ""
 
-#: oc-includes/osclass/classes/actions/ItemActions.php:207
+#: oc-includes/osclass/classes/actions/ItemActions.php
 msgid "Too fast. You should wait a little to publish your ad."
 msgstr ""
 
-#: oc-includes/osclass/helpers/hSecurity.php:266
+#: oc-includes/osclass/helpers/hSecurity.php
 msgid "Too many failed attempts. Please try again in %d minute."
 msgid_plural "Too many failed attempts. Please try again in %d minutes."
 msgstr[0] ""
 msgstr[1] ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminAppearance.php:525
+#: oc-includes/osclass/classes/controller/admin/CAdminAppearance.php
 msgid "Unknown widget type"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebUser.php:306
-#: oc-includes/osclass/classes/controller/CWebUserNonSecure.php:139
+#: oc-includes/osclass/classes/controller/CWebUser.php
+#: oc-includes/osclass/classes/controller/CWebUserNonSecure.php
 msgid "Unsubscribed correctly"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsBilling.php:186
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsBilling.php
 msgid "Upgrade settings have been updated"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php:171
-#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php:197
-#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php:224
-#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php:250
-#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php:276
-#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php:301
-#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php:616
+#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php
 msgid "User id isn't in the correct format"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebUserNonSecure.php:161
+#: oc-includes/osclass/classes/controller/CWebUserNonSecure.php
 msgid "User not activated"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebUserNonSecure.php:166
+#: oc-includes/osclass/classes/controller/CWebUserNonSecure.php
 msgid "User not enabled"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebRegister.php:30
+#: oc-includes/osclass/classes/controller/CWebRegister.php
 msgid "User registration is not enabled"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php:436
+#: oc-includes/osclass/classes/controller/admin/CAdminUsers.php
 msgid "User settings have been updated"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminAdmins.php:106
+#: oc-includes/osclass/classes/controller/admin/CAdminAdmins.php
 msgid "Username already in use"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminAdmins.php:196
-#: oc-includes/osclass/classes/controller/admin/CAdminAdmins.php:88
+#: oc-includes/osclass/classes/controller/admin/CAdminAdmins.php
 msgid "Username invalid"
 msgstr ""
 
-#: oc-includes/osclass/classes/actions/UserActions.php:101
+#: oc-includes/osclass/classes/actions/UserActions.php
 msgid "Username is already taken"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebLogin.php:36
-#: oc-includes/osclass/classes/controller/CWebRegister.php:49
+#: oc-includes/osclass/classes/controller/CWebLogin.php
+#: oc-includes/osclass/classes/controller/CWebRegister.php
 msgid "Users are not enabled"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebLogin.php:24
-#: oc-includes/osclass/classes/controller/CWebRegister.php:25
-#: oc-includes/osclass/classes/controller/CWebUser.php:24
-#: oc-includes/osclass/classes/controller/CWebUserNonSecure.php:27
+#: oc-includes/osclass/classes/controller/CWebLogin.php
+#: oc-includes/osclass/classes/controller/CWebRegister.php
+#: oc-includes/osclass/classes/controller/CWebUser.php
+#: oc-includes/osclass/classes/controller/CWebUserNonSecure.php
 msgid "Users not enabled"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebLogin.php:226
+#: oc-includes/osclass/classes/controller/CWebLogin.php
 msgid "Validation email re-sent"
 msgstr ""
 
-#: oc-includes/osclass/gui/billing/buy-content.php:144
+#: oc-includes/osclass/gui/billing/buy-content.php
 msgid "View your past orders"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminItems.php:803
+#: oc-includes/osclass/classes/controller/admin/CAdminItems.php
 msgid "Wait time must only contain numeric characters"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebLogin.php:228
+#: oc-includes/osclass/classes/controller/CWebLogin.php
 msgid ""
 "We have just sent you an email to validate your account, you will have to "
 "wait a few minutes to resend it again"
 msgstr ""
 
-#: oc-includes/osclass/classes/actions/ItemActions.php:1678
+#: oc-includes/osclass/classes/actions/ItemActions.php
 msgid "We just sent your message to %s"
 msgstr ""
 
-#: oc-includes/osclass/emails.php:739
+#: oc-includes/osclass/emails.php
 msgid ""
 "We tried to sent you an e-mail, but it failed. Please, contact an "
 "administrator"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebItem.php:583
-#: oc-includes/osclass/classes/controller/CWebItem.php:636
+#: oc-includes/osclass/classes/controller/CWebItem.php
 msgid "We're sorry, but the listing has expired. You can't contact the seller"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebItem.php:666
+#: oc-includes/osclass/classes/controller/CWebItem.php
 msgid "We've just sent an e-mail to the seller"
 msgstr ""
 
-#: oc-includes/osclass/emails.php:736
+#: oc-includes/osclass/emails.php
 msgid "We've sent you an e-mail. Follow its instructions to validate the changes"
 msgstr ""
 
-#: oc-includes/osclass/gui/billing/wallet-content.php:103
+#: oc-includes/osclass/gui/billing/wallet-content.php
 msgid "What happened"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminAppearance.php:204
+#: oc-includes/osclass/classes/controller/admin/CAdminAppearance.php
 msgid "Widget added correctly"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminAppearance.php:167
+#: oc-includes/osclass/classes/controller/admin/CAdminAppearance.php
 msgid "Widget cannot be updated correctly"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminAppearance.php:129
+#: oc-includes/osclass/classes/controller/admin/CAdminAppearance.php
 msgid "Widget removed correctly"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminAppearance.php:165
+#: oc-includes/osclass/classes/controller/admin/CAdminAppearance.php
 msgid "Widget updated correctly"
 msgstr ""
 
-#: oc-includes/osclass/classes/actions/ItemActions.php:232
+#: oc-includes/osclass/classes/actions/ItemActions.php
 msgid ""
 "You are at your listing limit. Free up a listing -- delete one or let one "
 "expire -- to post again."
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminAppearance.php:530
+#: oc-includes/osclass/classes/controller/admin/CAdminAppearance.php
 msgid "You are not allowed to add this widget type"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebItem.php:593
-#: oc-includes/osclass/classes/controller/CWebItem.php:605
+#: oc-includes/osclass/classes/controller/CWebItem.php
 msgid "You can't contact the seller, only registered users can"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminEmails.php:90
-#: oc-includes/osclass/classes/controller/admin/CAdminPages.php:109
+#: oc-includes/osclass/classes/controller/admin/CAdminEmails.php
+#: oc-includes/osclass/classes/controller/admin/CAdminPages.php
 msgid "You can't repeat internal name"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsMedia.php:154
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsMedia.php
 msgid ""
 "You cannot set a maximum file size higher than the one allowed in the PHP "
 "configuration: <b>%d KB</b>"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminAdmins.php:36
-#: oc-includes/osclass/classes/controller/admin/CAdminItems.php:47
-#: oc-includes/osclass/classes/controller/base/AdminSecBaseModel.php:39
+#: oc-includes/osclass/classes/controller/admin/CAdminAdmins.php
+#: oc-includes/osclass/classes/controller/admin/CAdminItems.php
+#: oc-includes/osclass/classes/controller/base/AdminSecBaseModel.php
 msgid "You don't have enough permissions"
 msgstr ""
 
-#: oc-includes/osclass/gui/billing/orders-content.php:92
+#: oc-includes/osclass/gui/billing/orders-content.php
 msgid "You have not bought any credits yet."
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminPages.php:158
-#: oc-includes/osclass/classes/controller/admin/CAdminPages.php:89
+#: oc-includes/osclass/classes/controller/admin/CAdminPages.php
 msgid "You have to set a different internal name"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminPages.php:153
-#: oc-includes/osclass/classes/controller/admin/CAdminPages.php:84
+#: oc-includes/osclass/classes/controller/admin/CAdminPages.php
 msgid "You have to set an internal name"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminMain.php:81
+#: oc-includes/osclass/classes/controller/admin/CAdminMain.php
 msgid "You have very few free space left, users will not be able to upload pictures"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebItem.php:751
+#: oc-includes/osclass/classes/controller/CWebItem.php
 msgid "You must be logged in to delete a comment"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebItem.php:718
+#: oc-includes/osclass/classes/controller/CWebItem.php
 msgid "You need to be logged to comment"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/CAdminMain.php:95
+#: oc-includes/osclass/classes/controller/admin/CAdminMain.php
 msgid "You're already subscribed"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebItem.php:650
+#: oc-includes/osclass/classes/controller/CWebItem.php
 msgid "You've sent too many messages recently. Please try again later."
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebItem.php:550
+#: oc-includes/osclass/classes/controller/CWebItem.php
 msgid "You've shared too many listings recently. Please try again later."
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsSpamnBots.php:60
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsSpamnBots.php
 msgid "Your Akismet key has been cleared"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsSpamnBots.php:62
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsSpamnBots.php
 msgid "Your Akismet key has been updated"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebRegister.php:93
+#: oc-includes/osclass/classes/controller/CWebRegister.php
 msgid "Your account has already been validated"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebRegister.php:70
+#: oc-includes/osclass/classes/controller/CWebRegister.php
 msgid "Your account has been created successfully"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebRegister.php:112
+#: oc-includes/osclass/classes/controller/CWebRegister.php
 msgid "Your account has been validated"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebUser.php:378
+#: oc-includes/osclass/classes/controller/CWebUser.php
 msgid "Your account have been deleted"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebItem.php:702
+#: oc-includes/osclass/classes/controller/CWebItem.php
 msgid "Your comment has been approved"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebItem.php:714
+#: oc-includes/osclass/classes/controller/CWebItem.php
 msgid "Your comment has been marked as spam"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebItem.php:698
+#: oc-includes/osclass/classes/controller/CWebItem.php
 msgid "Your comment is awaiting moderation"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebContact.php:57
-#: oc-includes/osclass/classes/controller/CWebForm.php:71
-#: oc-includes/osclass/classes/controller/CWebItem.php:171
-#: oc-includes/osclass/classes/controller/CWebItem.php:630
-#: oc-includes/osclass/classes/controller/CWebLogin.php:117
-#: oc-includes/osclass/classes/controller/CWebRegister.php:60
-#: oc-includes/osclass/classes/controller/CWebUserNonSecure.php:236
+#: oc-includes/osclass/classes/controller/CWebContact.php
+#: oc-includes/osclass/classes/controller/CWebForm.php
+#: oc-includes/osclass/classes/controller/CWebItem.php
+#: oc-includes/osclass/classes/controller/CWebLogin.php
+#: oc-includes/osclass/classes/controller/CWebRegister.php
+#: oc-includes/osclass/classes/controller/CWebUserNonSecure.php
 msgid "Your current IP is not allowed"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebContact.php:54
-#: oc-includes/osclass/classes/controller/CWebContact.php:66
-#: oc-includes/osclass/classes/controller/CWebItem.php:168
-#: oc-includes/osclass/classes/controller/CWebItem.php:627
-#: oc-includes/osclass/classes/controller/CWebLogin.php:114
-#: oc-includes/osclass/classes/controller/CWebRegister.php:57
-#: oc-includes/osclass/classes/controller/CWebUserNonSecure.php:233
+#: oc-includes/osclass/classes/controller/CWebContact.php
+#: oc-includes/osclass/classes/controller/CWebItem.php
+#: oc-includes/osclass/classes/controller/CWebLogin.php
+#: oc-includes/osclass/classes/controller/CWebRegister.php
+#: oc-includes/osclass/classes/controller/CWebUserNonSecure.php
 msgid "Your current email is not allowed"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebUser.php:336
+#: oc-includes/osclass/classes/controller/CWebUser.php
 msgid "Your data could not be prepared"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebUserNonSecure.php:86
+#: oc-includes/osclass/classes/controller/CWebUserNonSecure.php
 msgid "Your email has been changed successfully"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebUserNonSecure.php:248
+#: oc-includes/osclass/classes/controller/CWebUserNonSecure.php
 msgid "Your email has been sent properly."
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebContact.php:166
+#: oc-includes/osclass/classes/controller/CWebContact.php
 msgid "Your email has been sent properly. Thank you for contacting us!"
 msgstr ""
 
-#: oc-includes/osclass/classes/actions/ItemActions.php:283
+#: oc-includes/osclass/classes/actions/ItemActions.php
 msgid "Your listing could not be saved. Please try again."
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebItem.php:368
+#: oc-includes/osclass/classes/controller/CWebItem.php
 msgid "Your listing has been deleted"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebItem.php:196
+#: oc-includes/osclass/classes/controller/CWebItem.php
 msgid "Your listing has been published"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebItem.php:194
+#: oc-includes/osclass/classes/controller/CWebItem.php
 msgid "Your listing will be published after an admin approves it."
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebItem.php:304
+#: oc-includes/osclass/classes/controller/CWebItem.php
 msgid "Your listing will be published after an admin approves the changes."
 msgstr ""
 
-#: oc-includes/osclass/gui/billing/orders-content.php:83
-#: oc-includes/osclass/gui/billing/orders.php:33
+#: oc-includes/osclass/gui/billing/orders-content.php
+#: oc-includes/osclass/gui/billing/orders.php
 msgid "Your orders"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/CWebUser.php:92
+#: oc-includes/osclass/classes/controller/CWebUser.php
 msgid "Your profile has been updated successfully"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsSpamnBots.php:92
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsSpamnBots.php
 msgid "Your reCAPTCHA key has been cleared"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsSpamnBots.php:94
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsSpamnBots.php
 msgid "Your reCAPTCHA key has been updated"
 msgstr ""
 
-#: oc-includes/osclass/classes/Csrf.php:194
+#: oc-includes/osclass/classes/Csrf.php
 msgid "Your session has expired, please reload the page and try again."
 msgstr ""
 
-#: oc-includes/osclass/gui/billing/wallet-content.php:87
+#: oc-includes/osclass/gui/billing/wallet-content.php
 msgid "credits available"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsSitemap.php:140
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsSitemap.php
 msgid "robots.txt could not be saved"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsSitemap.php:142
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsSitemap.php
 msgid "robots.txt has been updated"
 msgstr ""
 
-#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsSitemap.php:134
+#: oc-includes/osclass/classes/controller/admin/settings/CAdminSettingsSitemap.php
 msgid "robots.txt is not writable. Fix the file or folder permissions and try again"
 msgstr ""

--- a/scripts/build-i18n.mjs
+++ b/scripts/build-i18n.mjs
@@ -58,15 +58,6 @@ function decode(single, double) {
     return null;
 }
 
-function lineOf(content, index) {
-    let line = 1;
-    for (let i = 0; i < index; i++) {
-        if (content.charCodeAt(i) === 10) {
-            line++;
-        }
-    }
-    return line;
-}
 
 async function walkPhp(dir, out = []) {
     for (const entry of await readdir(dir, { withFileTypes: true })) {
@@ -123,7 +114,7 @@ async function extract() {
             }
             const explicitDomain = decode(sDom, dDom);
             const domain = fn === '_m' ? 'messages' : (explicitDomain || DEFAULT_DOMAIN);
-            record(domain, msgid, null, `${file}:${lineOf(content, m.index)}`);
+            record(domain, msgid, null, file);
         }
 
         for (const m of content.matchAll(CONTEXT_RE)) {
@@ -135,7 +126,7 @@ async function extract() {
             }
             const explicitDomain = decode(sDom, dDom);
             const domain = fn === '_mx' ? 'messages' : (explicitDomain || DEFAULT_DOMAIN);
-            record(domain, msgid, null, `${file}:${lineOf(content, m.index)}`, msgctxt);
+            record(domain, msgid, null, file, msgctxt);
         }
 
         for (const m of content.matchAll(PLURAL_RE)) {
@@ -146,7 +137,7 @@ async function extract() {
                 continue;
             }
             const domain = fn === '_mn' ? 'messages' : DEFAULT_DOMAIN;
-            record(domain, single, plural, `${file}:${lineOf(content, m.index)}`);
+            record(domain, single, plural, file);
         }
     }
 }


### PR DESCRIPTION
The `.pot` templates carried `#: file:line` references, so any edit near a translatable string re-numbered them — and the `i18n-drift` check failed even when **no string changed** (e.g. #521, a refactor with zero new strings).

Emit **file-only** references (`build-i18n.mjs`). Now `i18n-drift` reports drift only when strings are actually **added, changed, or moved between files** — which is exactly when a human should regenerate and review the templates. This is better than auto-committing the `.pot` in CI (which can't push to fork PRs, adds unreviewed bot commits, and still churns on every line shift).

The large diff is the one-time removal of `:line` from every reference; future diffs stay small.